### PR TITLE
feat: add xhigh reasoning effort level support

### DIFF
--- a/source/api/responses.ts
+++ b/source/api/responses.ts
@@ -23,7 +23,7 @@ export interface ResponseOptions {
 	tool_choice?: 'auto' | 'none' | 'required';
 	reasoning?: {
 		summary?: 'auto' | 'none';
-		effort?: 'low' | 'medium' | 'high';
+		effort?: 'low' | 'medium' | 'high' | 'xhigh';
 	} | null; // null means don't pass reasoning parameter (for small models)
 	prompt_cache_key?: string;
 	store?: boolean;
@@ -164,7 +164,7 @@ function getOpenAIConfig() {
 }
 
 function getResponsesReasoningConfig(): {
-	effort?: 'low' | 'medium' | 'high';
+	effort?: 'low' | 'medium' | 'high' | 'xhigh';
 	summary?: 'auto' | 'none';
 } | null {
 	const config = getOpenAiConfig();

--- a/source/utils/apiConfig.ts
+++ b/source/utils/apiConfig.ts
@@ -26,7 +26,7 @@ export interface GeminiThinkingConfig {
 
 export interface ResponsesReasoningConfig {
 	enabled: boolean;
-	effort: 'low' | 'medium' | 'high';
+	effort: 'low' | 'medium' | 'high' | 'xhigh';
 }
 
 export interface ApiConfig {


### PR DESCRIPTION
Currently, setting `Responses Reasoning Effort` to `XHIGH` in `API & Model Settings` cannot be saved successfully.