### PR TITLE
feat(commands): add quit and exit commands to exit Snow CLI

### DIFF
--- a/source/hooks/useCommandHandler.ts
+++ b/source/hooks/useCommandHandler.ts
@@ -286,6 +286,18 @@ export function useCommandHandler(options: CommandHandlerOptions) {
 				// Reset terminal before navigating to welcome screen
 				resetTerminal(stdout);
 				navigateTo('welcome');
+			} else if (result.success && result.action === 'quit') {
+				const commandMessage: Message = {
+					role: 'command',
+					content: result.message ?? '',
+					commandName: commandName,
+				};
+				options.setMessages(prev => [...prev, commandMessage]);
+
+				// Use setTimeout to allow the message to be displayed
+				setTimeout(() => {
+					process.exit(0);
+				}, 500);
 			} else if (result.success && result.action === 'toggleYolo') {
 				// Toggle YOLO mode without adding command message
 				options.setYoloMode(prev => !prev);

--- a/source/hooks/useCommandPanel.ts
+++ b/source/hooks/useCommandPanel.ts
@@ -49,6 +49,14 @@ export function useCommandPanel(buffer: TextBuffer, isProcessing = false) {
 			name: 'todo-',
 			description: t.commandPanel.commands.todo,
 		},
+		{
+			name: 'quit',
+			description: t.commandPanel.commands.quit,
+		},
+		{
+			name: 'exit',
+			description: t.commandPanel.commands.exit,
+		},
 	];
 
 	const [showCommands, setShowCommands] = useState(false);

--- a/source/i18n/lang/en.ts
+++ b/source/i18n/lang/en.ts
@@ -391,6 +391,8 @@ export const en: TranslationKeys = {
 			export: 'Export chat conversation to text file with save dialog',
 			agent: 'Select and use a sub-agent to handle specific tasks',
 			todo: 'Search and select TODO comments from project files',
+			quit: 'Exit Snow AI application',
+			exit: 'Exit Snow AI application',
 		},
 	},
 	hooks: {

--- a/source/i18n/lang/es.ts
+++ b/source/i18n/lang/es.ts
@@ -414,6 +414,8 @@ export const es: TranslationKeys = {
 				'Exportar conversación de chat a archivo de texto con diálogo de guardado',
 			agent: 'Seleccionar y usar sub-agente para manejar tareas específicas',
 			todo: 'Buscar y seleccionar comentarios TODO de archivos del proyecto',
+			quit: 'Salir de la aplicación Snow AI',
+			exit: 'Salir de la aplicación Snow AI',
 		},
 	},
 	hooks: {

--- a/source/i18n/lang/ja.ts
+++ b/source/i18n/lang/ja.ts
@@ -380,6 +380,8 @@ export const ja: TranslationKeys = {
 				'チャット会話を保存ダイアログ付きのテキストファイルにエクスポート',
 			agent: 'サブエージェントを選択して特定のタスクを処理',
 			todo: 'プロジェクトファイルからTODOコメントを検索して選択',
+			quit: 'Snow AI アプリケーションを終了',
+			exit: 'Snow AI アプリケーションを終了',
 		},
 	},
 	hooks: {

--- a/source/i18n/lang/ko.ts
+++ b/source/i18n/lang/ko.ts
@@ -371,6 +371,8 @@ export const ko: TranslationKeys = {
 			export: '채팅 대화를 저장 대화상자가 있는 텍스트 파일로 내보내기',
 			agent: '하위 에이전트를 선택하고 특정 작업 처리',
 			todo: '프로젝트 파일에서 TODO 주석 검색 및 선택',
+			quit: 'Snow AI 애플리케이션 종료',
+			exit: 'Snow AI 애플리케이션 종료',
 		},
 	},
 	hooks: {

--- a/source/i18n/lang/zh-TW.ts
+++ b/source/i18n/lang/zh-TW.ts
@@ -365,6 +365,8 @@ export const zhTW: TranslationKeys = {
 			export: '將聊天對話匯出到帶儲存對話方塊的文字檔案',
 			agent: '選擇並使用子代理處理特定任務',
 			todo: '從專案檔案搜尋並選擇 TODO 註解',
+			quit: '退出 Snow AI 應用程式',
+			exit: '退出 Snow AI 應用程式',
 		},
 	},
 	hooks: {

--- a/source/i18n/lang/zh.ts
+++ b/source/i18n/lang/zh.ts
@@ -365,6 +365,8 @@ export const zh: TranslationKeys = {
 			export: '将聊天对话导出到带保存对话框的文本文件',
 			agent: '选择并使用子代理处理特定任务',
 			todo: '从项目文件搜索并选择 TODO 注释',
+			quit: '退出 Snow AI 应用',
+			exit: '退出 Snow AI 应用',
 		},
 	},
 	hooks: {

--- a/source/i18n/types.ts
+++ b/source/i18n/types.ts
@@ -369,6 +369,8 @@ export type TranslationKeys = {
 			export: string;
 			agent: string;
 			todo: string;
+			quit: string;
+			exit: string;
 		};
 	};
 	// Hooks

--- a/source/ui/pages/ChatScreen.tsx
+++ b/source/ui/pages/ChatScreen.tsx
@@ -157,6 +157,7 @@ export default function ChatScreen({skipWelcome}: Props) {
 			import('../../utils/commands/agent.js'),
 			import('../../utils/commands/todoPicker.js'),
 			import('../../utils/commands/help.js'),
+			import('../../utils/commands/quit.js'),
 		])
 			.then(() => {
 				setCommandsLoaded(true);

--- a/source/utils/commandExecutor.ts
+++ b/source/utils/commandExecutor.ts
@@ -17,7 +17,8 @@ export interface CommandResult {
 		| 'exportChat'
 		| 'showAgentPicker'
 		| 'showTodoPicker'
-		| 'showHelpPanel';
+		| 'showHelpPanel'
+		| 'quit';
 	prompt?: string;
 	alreadyConnected?: boolean; // For /ide command to indicate if VSCode is already connected
 }

--- a/source/utils/commands/quit.ts
+++ b/source/utils/commands/quit.ts
@@ -1,0 +1,25 @@
+import { registerCommand, type CommandResult } from '../commandExecutor.js';
+
+// Quit command handler
+registerCommand('quit', {
+	execute: (): CommandResult => {
+		return {
+			success: true,
+			action: 'quit',
+			message: 'Exiting Snow AI...',
+		};
+	},
+});
+
+// Also register 'exit' as an alias
+registerCommand('exit', {
+	execute: (): CommandResult => {
+		return {
+			success: true,
+			action: 'quit',
+			message: 'Exiting Snow AI...',
+		};
+	},
+});
+
+export default {};


### PR DESCRIPTION
snow退出需要使用连续2次ctrl+c命令,可能造成误触，希望提供显式的 /quit 和 /exit 命令，让用户在聊天输入框中直接输入命令即可退出。
---
主要改动

  - 新增退出命令
      - 新增 source/utils/commands/quit.ts
  - 命令处理逻辑
  - 命令面板集成
  - 对应文案修改