### PR TITLE
fix: add Ctrl+Y as backup shortcut for YOLO mode toggle

### DIFF
--- a/source/hooks/useKeyboardInput.ts
+++ b/source/hooks/useKeyboardInput.ts
@@ -120,13 +120,13 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 		pasteFromClipboard,
 		onSubmit,
 		ensureFocus,
-	showAgentPicker,
-	setShowAgentPicker,
-	agentSelectedIndex,
-	setAgentSelectedIndex,
-	updateAgentPickerState,
-	getFilteredAgents,
-	handleAgentSelect,
+		showAgentPicker,
+		setShowAgentPicker,
+		agentSelectedIndex,
+		setAgentSelectedIndex,
+		updateAgentPickerState,
+		getFilteredAgents,
+		handleAgentSelect,
 		showTodoPicker,
 		setShowTodoPicker,
 		todoSelectedIndex,
@@ -195,6 +195,16 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 
 		// Shift+Tab - Toggle YOLO mode
 		if (key.shift && key.tab) {
+			executeCommand('yolo').then(result => {
+				if (onCommand) {
+					onCommand('yolo', result);
+				}
+			});
+			return;
+		}
+
+		// Ctrl+Y - Toggle YOLO mode
+		if (key.ctrl && input === 'y') {
 			executeCommand('yolo').then(result => {
 				if (onCommand) {
 					onCommand('yolo', result);
@@ -326,40 +336,43 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 			return;
 		}
 
-	// Handle agent picker navigation
-	if (showAgentPicker) {
-		const filteredAgents = getFilteredAgents();
+		// Handle agent picker navigation
+		if (showAgentPicker) {
+			const filteredAgents = getFilteredAgents();
 
-		// Up arrow in agent picker
-		if (key.upArrow) {
-			setAgentSelectedIndex(prev => Math.max(0, prev - 1));
-			return;
-		}
-
-		// Down arrow in agent picker
-		if (key.downArrow) {
-			const maxIndex = Math.max(0, filteredAgents.length - 1);
-			setAgentSelectedIndex(prev => Math.min(maxIndex, prev + 1));
-			return;
-		}
-
-		// Enter - select agent
-		if (key.return) {
-			if (filteredAgents.length > 0 && agentSelectedIndex < filteredAgents.length) {
-				const selectedAgent = filteredAgents[agentSelectedIndex];
-				if (selectedAgent) {
-					handleAgentSelect(selectedAgent);
-					setShowAgentPicker(false);
-					setAgentSelectedIndex(0);
-				}
+			// Up arrow in agent picker
+			if (key.upArrow) {
+				setAgentSelectedIndex(prev => Math.max(0, prev - 1));
+				return;
 			}
-			return;
-		}
 
-		// Allow typing to filter - don't block regular input
-		// The input will be processed below and updateAgentPickerState will be called
-		// which will update the filter automatically
-	}
+			// Down arrow in agent picker
+			if (key.downArrow) {
+				const maxIndex = Math.max(0, filteredAgents.length - 1);
+				setAgentSelectedIndex(prev => Math.min(maxIndex, prev + 1));
+				return;
+			}
+
+			// Enter - select agent
+			if (key.return) {
+				if (
+					filteredAgents.length > 0 &&
+					agentSelectedIndex < filteredAgents.length
+				) {
+					const selectedAgent = filteredAgents[agentSelectedIndex];
+					if (selectedAgent) {
+						handleAgentSelect(selectedAgent);
+						setShowAgentPicker(false);
+						setAgentSelectedIndex(0);
+					}
+				}
+				return;
+			}
+
+			// Allow typing to filter - don't block regular input
+			// The input will be processed below and updateAgentPickerState will be called
+			// which will update the filter automatically
+		}
 
 		// Handle history menu navigation
 		if (showHistoryMenu) {
@@ -596,12 +609,12 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 				inputStartCursorPos.current = buffer.getCursorPosition();
 			}
 
-		buffer.moveLeft();
-		const text = buffer.getFullText();
-		const cursorPos = buffer.getCursorPosition();
-		updateFilePickerState(text, cursorPos);
-		updateAgentPickerState(text, cursorPos);
-		triggerUpdate();
+			buffer.moveLeft();
+			const text = buffer.getFullText();
+			const cursorPos = buffer.getCursorPosition();
+			updateFilePickerState(text, cursorPos);
+			updateAgentPickerState(text, cursorPos);
+			triggerUpdate();
 			return;
 		}
 
@@ -625,12 +638,12 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 				inputStartCursorPos.current = buffer.getCursorPosition();
 			}
 
-		buffer.moveRight();
-		const text = buffer.getFullText();
-		const cursorPos = buffer.getCursorPosition();
-		updateFilePickerState(text, cursorPos);
-		updateAgentPickerState(text, cursorPos);
-		triggerUpdate();
+			buffer.moveRight();
+			const text = buffer.getFullText();
+			const cursorPos = buffer.getCursorPosition();
+			updateFilePickerState(text, cursorPos);
+			updateAgentPickerState(text, cursorPos);
+			triggerUpdate();
 			return;
 		}
 
@@ -665,26 +678,26 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 			// 2. Cursor at start of single line -> navigate history
 			// 3. Otherwise -> normal cursor movement
 			if (isEmpty || (!hasNewline && isAtStart)) {
-			const navigated = navigateHistoryUp();
-			if (navigated) {
-				updateFilePickerState(
-					buffer.getFullText(),
-					buffer.getCursorPosition(),
-				);
-				updateAgentPickerState(
-					buffer.getFullText(),
-					buffer.getCursorPosition(),
-				);
-				triggerUpdate();
-				return;
+				const navigated = navigateHistoryUp();
+				if (navigated) {
+					updateFilePickerState(
+						buffer.getFullText(),
+						buffer.getCursorPosition(),
+					);
+					updateAgentPickerState(
+						buffer.getFullText(),
+						buffer.getCursorPosition(),
+					);
+					triggerUpdate();
+					return;
+				}
 			}
-		}
 
-		// Normal cursor movement
-		buffer.moveUp();
-		updateFilePickerState(buffer.getFullText(), buffer.getCursorPosition());
-		updateAgentPickerState(buffer.getFullText(), buffer.getCursorPosition());
-		triggerUpdate();
+			// Normal cursor movement
+			buffer.moveUp();
+			updateFilePickerState(buffer.getFullText(), buffer.getCursorPosition());
+			updateAgentPickerState(buffer.getFullText(), buffer.getCursorPosition());
+			triggerUpdate();
 			return;
 		}
 
@@ -718,27 +731,27 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 			// 1. Empty input box -> navigate history (if in history mode)
 			// 2. Cursor at end of single line -> navigate history (if in history mode)
 			// 3. Otherwise -> normal cursor movement
-		if ((isEmpty || (!hasNewline && isAtEnd)) && currentHistoryIndex !== -1) {
-			const navigated = navigateHistoryDown();
-			if (navigated) {
-				updateFilePickerState(
-					buffer.getFullText(),
-					buffer.getCursorPosition(),
-				);
-				updateAgentPickerState(
-					buffer.getFullText(),
-					buffer.getCursorPosition(),
-				);
-				triggerUpdate();
-				return;
+			if ((isEmpty || (!hasNewline && isAtEnd)) && currentHistoryIndex !== -1) {
+				const navigated = navigateHistoryDown();
+				if (navigated) {
+					updateFilePickerState(
+						buffer.getFullText(),
+						buffer.getCursorPosition(),
+					);
+					updateAgentPickerState(
+						buffer.getFullText(),
+						buffer.getCursorPosition(),
+					);
+					triggerUpdate();
+					return;
+				}
 			}
-		}
 
-		// Normal cursor movement
-		buffer.moveDown();
-		updateFilePickerState(buffer.getFullText(), buffer.getCursorPosition());
-		updateAgentPickerState(buffer.getFullText(), buffer.getCursorPosition());
-		triggerUpdate();
+			// Normal cursor movement
+			buffer.moveDown();
+			updateFilePickerState(buffer.getFullText(), buffer.getCursorPosition());
+			updateAgentPickerState(buffer.getFullText(), buffer.getCursorPosition());
+			triggerUpdate();
 			return;
 		}
 
@@ -758,15 +771,15 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 			const isSingleCharInput = input.length === 1;
 
 			if (isSingleCharInput) {
-			// For single character input (normal typing), insert immediately
-			// This prevents the "disappearing text" issue at line start
-			buffer.insert(input);
-			const text = buffer.getFullText();
-			const cursorPos = buffer.getCursorPosition();
-			updateCommandPanelState(text);
-			updateFilePickerState(text, cursorPos);
-			updateAgentPickerState(text, cursorPos);
-			triggerUpdate();
+				// For single character input (normal typing), insert immediately
+				// This prevents the "disappearing text" issue at line start
+				buffer.insert(input);
+				const text = buffer.getFullText();
+				const cursorPos = buffer.getCursorPosition();
+				updateCommandPanelState(text);
+				updateFilePickerState(text, cursorPos);
+				updateAgentPickerState(text, cursorPos);
+				triggerUpdate();
 			} else {
 				// For multi-character input (paste), use the buffering mechanism
 				// Save cursor position when starting new input accumulation
@@ -791,14 +804,14 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 				// Simple static message - no progress animation
 				if (currentLength > 300 && !isPasting.current) {
 					isPasting.current = true;
-				buffer.insertPastingIndicator();
-				// Trigger UI update to show the indicator
-				const text = buffer.getFullText();
-				const cursorPos = buffer.getCursorPosition();
-				updateCommandPanelState(text);
-				updateFilePickerState(text, cursorPos);
-				updateAgentPickerState(text, cursorPos);
-				triggerUpdate();
+					buffer.insertPastingIndicator();
+					// Trigger UI update to show the indicator
+					const text = buffer.getFullText();
+					const cursorPos = buffer.getCursorPosition();
+					updateCommandPanelState(text);
+					updateFilePickerState(text, cursorPos);
+					updateAgentPickerState(text, cursorPos);
+					triggerUpdate();
 				}
 
 				// Set timer to process accumulated input - fixed 100ms
@@ -836,13 +849,13 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 						// Reset inputStartCursorPos after processing to prevent stale position
 						inputStartCursorPos.current = buffer.getCursorPosition();
 
-				const text = buffer.getFullText();
-				const cursorPos = buffer.getCursorPosition();
-				updateCommandPanelState(text);
-				updateFilePickerState(text, cursorPos);
-				updateAgentPickerState(text, cursorPos);
-				triggerUpdate();
-			}
+						const text = buffer.getFullText();
+						const cursorPos = buffer.getCursorPosition();
+						updateCommandPanelState(text);
+						updateFilePickerState(text, cursorPos);
+						updateAgentPickerState(text, cursorPos);
+						triggerUpdate();
+					}
 				}, 100); // Fixed 100ms
 			}
 		}

--- a/source/i18n/lang/en.ts
+++ b/source/i18n/lang/en.ts
@@ -360,7 +360,7 @@ export const en: TranslationKeys = {
 		navigateHistory: '↑/↓ - Navigate command/message history',
 		selectItem: 'Tab/Enter - Select item in pickers',
 		cancelClose: 'ESC - Cancel/close pickers or interrupt AI response',
-		toggleYolo: 'Shift+Tab - Toggle YOLO mode (auto-approve tools)',
+		toggleYolo: 'Shift+Tab/Ctrl+Y - Toggle YOLO mode (auto-approve tools)',
 		tipsTitle: '💡 Tips:',
 		tipUseHelp: 'Use /help anytime to see this information',
 		tipShowCommands: 'Type / to see all available commands',
@@ -402,7 +402,7 @@ export const en: TranslationKeys = {
 		headerSubtitle: '❆ SNOW AI CLI',
 		headerExplanations: 'Ask for code explanations and debugging help',
 		headerInterrupt: 'Press ESC during response to interrupt',
-		headerYolo: 'Press Shift+Tab: toggle YOLO',
+		headerYolo: 'Press Shift+Tab/Ctrl+Y: toggle YOLO',
 		headerShortcuts:
 			"Shortcuts: Ctrl+L (delete to start) • Ctrl+R (delete to end) • {pasteKey} (paste images) • '@' (files) • '@@' (search content) • '#' (sub-agents) • '/' (commands)",
 		headerWorkingDirectory: 'Working directory: {directory}',
@@ -515,7 +515,7 @@ export const en: TranslationKeys = {
 		shortcutDeleteToEnd: 'Delete to end',
 		shortcutCancel: 'Cancel (ESC)',
 		shortcutRegenerate: 'Regenerate (Ctrl+R)',
-		shortcutToggleYolo: 'Toggle YOLO (Shift+Tab)',
+		shortcutToggleYolo: 'Toggle YOLO (Shift+Tab/Ctrl+Y)',
 		// Rollback
 		rollbackConfirm: 'Confirm rollback',
 		rollbackFiles: 'Rollback files',

--- a/source/i18n/lang/zh-TW.ts
+++ b/source/i18n/lang/zh-TW.ts
@@ -336,7 +336,7 @@ export const zhTW: TranslationKeys = {
 		navigateHistory: '↑/↓ - 導航命令/訊息歷史',
 		selectItem: 'Tab/Enter - 在選擇器中選擇項目',
 		cancelClose: 'ESC - 取消/關閉選擇器或中斷 AI 回應',
-		toggleYolo: 'Shift+Tab - 切換 YOLO 模式(自動批准工具)',
+		toggleYolo: 'Shift+Tab/Ctrl+Y - 切換 YOLO 模式(自動批准工具)',
 		tipsTitle: '💡 提示:',
 		tipUseHelp: '隨時使用 /help 查看此資訊',
 		tipShowCommands: '輸入 / 查看所有可用命令',
@@ -376,7 +376,7 @@ export const zhTW: TranslationKeys = {
 		headerSubtitle: '❆ SNOW AI CLI',
 		headerExplanations: '詢問程式碼說明和偵錯協助',
 		headerInterrupt: '在回應期間按 ESC 中斷',
-		headerYolo: '按 Shift+Tab: 切換 YOLO',
+		headerYolo: '按 Shift+Tab/Ctrl+Y: 切換 YOLO',
 		headerShortcuts:
 			"快捷鍵: Ctrl+L (刪除至開頭) • Ctrl+R (刪除至末尾) • {pasteKey} (貼上圖片) • '@' (檔案) • '@@' (搜尋內容) • '#' (子代理) • '/' (命令)",
 		headerWorkingDirectory: '工作目錄: {directory}',
@@ -489,7 +489,7 @@ export const zhTW: TranslationKeys = {
 		shortcutDeleteToEnd: '刪除至末尾',
 		shortcutCancel: '取消 (ESC)',
 		shortcutRegenerate: '重新產生 (Ctrl+R)',
-		shortcutToggleYolo: '切換 YOLO (Shift+Tab)',
+		shortcutToggleYolo: '切換 YOLO (Shift+Tab/Ctrl+Y)',
 		// Rollback
 		rollbackConfirm: '確認回復',
 		rollbackFiles: '回復檔案',

--- a/source/i18n/lang/zh.ts
+++ b/source/i18n/lang/zh.ts
@@ -336,7 +336,7 @@ export const zh: TranslationKeys = {
 		navigateHistory: '↑/↓ - 导航命令/消息历史',
 		selectItem: 'Tab/Enter - 在选择器中选择项目',
 		cancelClose: 'ESC - 取消/关闭选择器或中断 AI 响应',
-		toggleYolo: 'Shift+Tab - 切换 YOLO 模式(自动批准工具)',
+		toggleYolo: 'Shift+Tab/Ctrl+Y - 切换 YOLO 模式(自动批准工具)',
 		tipsTitle: '💡 提示:',
 		tipUseHelp: '随时使用 /help 查看此信息',
 		tipShowCommands: '输入 / 查看所有可用命令',
@@ -376,7 +376,7 @@ export const zh: TranslationKeys = {
 		headerSubtitle: '❆ SNOW AI CLI',
 		headerExplanations: '询问代码说明和调试帮助',
 		headerInterrupt: '在响应期间按 ESC 中断',
-		headerYolo: '按 Shift+Tab: 切换 YOLO',
+		headerYolo: '按 Shift+Tab/Ctrl+Y: 切换 YOLO',
 		headerShortcuts:
 			"快捷键: Ctrl+L (删除至开头) • Ctrl+R (删除至末尾) • {pasteKey} (粘贴图片) • '@' (文件) • '@@' (搜索内容) • '#' (子代理) • '/' (命令)",
 		headerWorkingDirectory: '工作目录: {directory}',
@@ -472,7 +472,8 @@ export const zh: TranslationKeys = {
 		ideConnecting: '连接到 IDE...',
 		ideConnected: 'IDE 已连接',
 		ideDisconnected: 'IDE 已断开',
-		ideError: '连接失败(这不会影响任何使用) - 请确保在你的 IDE 中安装并激活了 Snow CLI 插件',
+		ideError:
+			'连接失败(这不会影响任何使用) - 请确保在你的 IDE 中安装并激活了 Snow CLI 插件',
 		ideActiveFile: '| {file}',
 		ideSelectedText: '| 已选择 {count} 个字符',
 		// Input
@@ -488,7 +489,7 @@ export const zh: TranslationKeys = {
 		shortcutDeleteToEnd: '删除至末尾',
 		shortcutCancel: '取消 (ESC)',
 		shortcutRegenerate: '重新生成 (Ctrl+R)',
-		shortcutToggleYolo: '切换 YOLO (Shift+Tab)',
+		shortcutToggleYolo: '切换 YOLO (Shift+Tab/Ctrl+Y)',
 		// Rollback
 		rollbackConfirm: '确认回滚',
 		rollbackFiles: '回滚文件',


### PR DESCRIPTION
## 问题描述

 在使用 Shift+Tab 切换 YOLO 模式时，发现某些情况下无法正确接收 Shift 键的状态。

 ### 调试信息
 在调试过程中发现以下问题：
 ```
 Input Debug: input = \"\" key = { shift: false, tab: true, ctrl: false, escape: 
 false }
 ```

 可以看到虽然按下了 Shift+Tab，但 `shift` 状态为 `false`，这导致快捷键无法正常触发。

 ## 解决方案

 为了解决这个问题，增加了一个备用快捷键 **Ctrl+Y** 来切换 YOLO 模式。

 ### 更改内容
 - ✅ 添加 Ctrl+Y 快捷键实现，与 Shift+Tab 功能完全相同
 - ✅ 更新所有语言版本的界面提示（中文、英文、繁体中文）
 - ✅ 保持 Shift+Tab 原有功能不变，确保向后兼容
 - ✅ 在帮助面板、主界面头部和快捷键提示中都显示两种快捷键选项

 ## 测试验证
 - ✅ 构建测试通过
 - ✅ 两种快捷键都能正常工作
 - ✅ 所有语言界面提示正确显示

 ## 好处
 1. **提高可用性**: 用户有两种快捷键选择，适应不同的使用习惯
 2. **解决兼容性问题**: 避免因 Shift 键状态检测问题导致功能不可用
 3. **用户体验**: 提供更灵活的操作方式"