### PR TITLE
fix(i18n): 子代理列表页面完整国际化支持

### DIFF
--- a/source/i18n/lang/en.ts
+++ b/source/i18n/lang/en.ts
@@ -275,6 +275,20 @@ export const en: TranslationKeys = {
 		ideTools: 'IDE Diagnostics Tools',
 		userInteractionTools: 'User Interaction Tools',
 	},
+	subAgentList: {
+		title: 'Sub-Agent Management',
+		noAgents: 'No sub-agents configured yet.',
+		noAgentsHint: 'Press "A" to add a new sub-agent.',
+		agentsCount: 'Sub-Agents ({count}):',
+		description: 'Description:',
+		noDescription: 'No description',
+		toolsCount: 'Tools: {count} selected',
+		updated: 'Updated:',
+		deleteConfirm: 'Delete "{name}"? (Y/N)',
+		deleteSuccess: 'Sub-agent deleted successfully!',
+		navigationHint:
+			'↑↓: Navigate | Enter: Edit | A: Add New | D: Delete | Esc: Back',
+	},
 	sensitiveCommandConfig: {
 		title: 'Sensitive Command Protection',
 		subtitle:

--- a/source/i18n/lang/es.ts
+++ b/source/i18n/lang/es.ts
@@ -293,6 +293,20 @@ export const es: TranslationKeys = {
 		ideTools: 'Herramientas de Diagnóstico IDE',
 		userInteractionTools: 'Herramientas de Interacción del Usuario',
 	},
+	subAgentList: {
+		title: 'Gestión de Sub-Agentes',
+		noAgents: 'No hay sub-agentes configurados.',
+		noAgentsHint: 'Presiona "A" para agregar un nuevo sub-agente.',
+		agentsCount: 'Sub-Agentes ({count}):',
+		description: 'Descripción:',
+		noDescription: 'Sin descripción',
+		toolsCount: 'Herramientas: {count} seleccionadas',
+		updated: 'Actualizado:',
+		deleteConfirm: '¿Eliminar "{name}"? (Y/N)',
+		deleteSuccess: '¡Sub-agente eliminado exitosamente!',
+		navigationHint:
+			'↑↓: Navegar | Enter: Editar | A: Agregar Nuevo | D: Eliminar | Esc: Volver',
+	},
 	sensitiveCommandConfig: {
 		title: 'Protección de Comandos Sensibles',
 		subtitle:

--- a/source/i18n/lang/ja.ts
+++ b/source/i18n/lang/ja.ts
@@ -265,6 +265,20 @@ export const ja: TranslationKeys = {
 		ideTools: 'IDE診断ツール',
 		userInteractionTools: 'ユーザー対話ツール',
 	},
+	subAgentList: {
+		title: 'サブエージェント管理',
+		noAgents: 'サブエージェントが設定されていません。',
+		noAgentsHint: '"A" を押して新しいサブエージェントを追加。',
+		agentsCount: 'サブエージェント ({count}):',
+		description: '説明:',
+		noDescription: '説明なし',
+		toolsCount: 'ツール: {count} 個選択済み',
+		updated: '更新日時:',
+		deleteConfirm: '"{name}" を削除しますか? (Y/N)',
+		deleteSuccess: 'サブエージェントを削除しました!',
+		navigationHint:
+			'↑↓: 移動 | Enter: 編集 | A: 新規追加 | D: 削除 | Esc: 戻る',
+	},
 	sensitiveCommandConfig: {
 		title: '機密コマンド保護',
 		subtitle: 'YOLO/自動承認モードでも確認が必要なコマンドを構成',

--- a/source/i18n/lang/ko.ts
+++ b/source/i18n/lang/ko.ts
@@ -258,6 +258,20 @@ export const ko: TranslationKeys = {
 		ideTools: 'IDE 진단 도구',
 		userInteractionTools: '사용자 상호작용 도구',
 	},
+	subAgentList: {
+		title: '하위 에이전트 관리',
+		noAgents: '하위 에이전트가 구성되지 않았습니다.',
+		noAgentsHint: '"A"를 눌러 새 하위 에이전트를 추가하세요.',
+		agentsCount: '하위 에이전트 ({count}):',
+		description: '설명:',
+		noDescription: '설명 없음',
+		toolsCount: '도구: {count}개 선택됨',
+		updated: '업데이트:',
+		deleteConfirm: '"{name}"을(를) 삭제하시겠습니까? (Y/N)',
+		deleteSuccess: '하위 에이전트가 삭제되었습니다!',
+		navigationHint:
+			'↑↓: 이동 | Enter: 편집 | A: 새 에이전트 추가 | D: 삭제 | Esc: 뒤로',
+	},
 	sensitiveCommandConfig: {
 		title: '민감한 명령 보호',
 		subtitle: 'YOLO/자동 승인 모드에서도 확인이 필요한 명령 구성',

--- a/source/i18n/lang/zh-TW.ts
+++ b/source/i18n/lang/zh-TW.ts
@@ -253,6 +253,20 @@ export const zhTW: TranslationKeys = {
 		ideTools: 'IDE 診斷工具',
 		userInteractionTools: '用戶交互工具',
 	},
+	subAgentList: {
+		title: '子代理管理',
+		noAgents: '尚未配置子代理。',
+		noAgentsHint: '按 "A" 新增新的子代理。',
+		agentsCount: '子代理 ({count}):',
+		description: '描述:',
+		noDescription: '無描述',
+		toolsCount: '工具: {count} 個已選擇',
+		updated: '更新時間:',
+		deleteConfirm: '刪除 "{name}"? (Y/N)',
+		deleteSuccess: '子代理刪除成功!',
+		navigationHint:
+			'↑↓: 導航 | Enter: 編輯 | A: 新增新代理 | D: 刪除 | Esc: 返回',
+	},
 	sensitiveCommandConfig: {
 		title: '敏感命令保護',
 		subtitle: '配置即使在 YOLO/自動批准模式下也需要確認的命令',

--- a/source/i18n/lang/zh.ts
+++ b/source/i18n/lang/zh.ts
@@ -253,6 +253,20 @@ export const zh: TranslationKeys = {
 		ideTools: 'IDE 诊断工具',
 		userInteractionTools: '用户交互工具',
 	},
+	subAgentList: {
+		title: '子代理管理',
+		noAgents: '尚未配置子代理。',
+		noAgentsHint: '按 "A" 添加新的子代理。',
+		agentsCount: '子代理 ({count}):',
+		description: '描述:',
+		noDescription: '无描述',
+		toolsCount: '工具: {count} 个已选择',
+		updated: '更新时间:',
+		deleteConfirm: '删除 "{name}"? (Y/N)',
+		deleteSuccess: '子代理删除成功!',
+		navigationHint:
+			'↑↓: 导航 | Enter: 编辑 | A: 添加新代理 | D: 删除 | Esc: 返回',
+	},
 	sensitiveCommandConfig: {
 		title: '敏感命令保护',
 		subtitle: '配置即使在 YOLO/自动批准模式下也需要确认的命令',

--- a/source/i18n/types.ts
+++ b/source/i18n/types.ts
@@ -256,6 +256,20 @@ export type TranslationKeys = {
 		ideTools: string;
 		userInteractionTools: string;
 	};
+	// Sub-Agent List Screen
+	subAgentList: {
+		title: string;
+		noAgents: string;
+		noAgentsHint: string;
+		agentsCount: string;
+		description: string;
+		noDescription: string;
+		toolsCount: string;
+		updated: string;
+		deleteConfirm: string;
+		deleteSuccess: string;
+		navigationHint: string;
+	};
 	// Sensitive Command Config Screen
 	sensitiveCommandConfig: {
 		title: string;

--- a/source/ui/pages/SubAgentListScreen.tsx
+++ b/source/ui/pages/SubAgentListScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../utils/subAgentConfig.js';
 import {useTerminalSize} from '../../hooks/useTerminalSize.js';
 import {useTheme} from '../contexts/ThemeContext.js';
+import {useI18n} from '../../i18n/index.js';
 
 type Props = {
 	onBack: () => void;
@@ -24,6 +25,7 @@ export default function SubAgentListScreen({
 }: Props) {
 	const {theme} = useTheme();
 	const {columns} = useTerminalSize();
+	const {t} = useI18n();
 	const [agents, setAgents] = useState<SubAgent[]>([]);
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -110,81 +112,99 @@ export default function SubAgentListScreen({
 
 	return (
 		<Box flexDirection="column" padding={1}>
-		{!inlineMode && (
-			<Box marginBottom={1}>
-				<Text bold color={theme.colors.menuInfo}>
-					❆ Sub-Agent Management
-				</Text>
-			</Box>
-		)}
+			{!inlineMode && (
+				<Box marginBottom={1}>
+					<Text bold color={theme.colors.menuInfo}>
+						❆ {t.subAgentList.title}
+					</Text>
+				</Box>
+			)}
 
 			{deleteSuccess && (
 				<Box marginBottom={1}>
-					<Alert variant="success">Sub-agent deleted successfully!</Alert>
+					<Alert variant="success">{t.subAgentList.deleteSuccess}</Alert>
 				</Box>
 			)}
 
 			{showDeleteConfirm && agents[selectedIndex] && (
 				<Box marginBottom={1}>
 					<Alert variant="warning">
-						Delete "{agents[selectedIndex].name}"? (Y/N)
+						{t.subAgentList.deleteConfirm.replace(
+							'{name}',
+							agents[selectedIndex].name,
+						)}
 					</Alert>
 				</Box>
 			)}
 
 			<Box flexDirection="column">
-			{agents.length === 0 ? (
-				<Box flexDirection="column">
-					<Text color={theme.colors.menuSecondary}>No sub-agents configured yet.</Text>
-					<Text color={theme.colors.menuSecondary}>Press 'A' to add a new sub-agent.</Text>
-				</Box>
-			) : (
-				<Box flexDirection="column">
-					<Text bold color={theme.colors.menuInfo}>
-						Sub-Agents ({agents.length}):
-					</Text>
+				{agents.length === 0 ? (
+					<Box flexDirection="column">
+						<Text color={theme.colors.menuSecondary}>
+							{t.subAgentList.noAgents}
+						</Text>
+						<Text color={theme.colors.menuSecondary}>
+							{t.subAgentList.noAgentsHint}
+						</Text>
+					</Box>
+				) : (
+					<Box flexDirection="column">
+						<Text bold color={theme.colors.menuInfo}>
+							{t.subAgentList.agentsCount.replace(
+								'{count}',
+								agents.length.toString(),
+							)}
+						</Text>
 
-					{agents.map((agent, index) => {
-						const isSelected = index === selectedIndex;
-						return (
-							<Box key={agent.id} flexDirection="column">
-								<Box>
-									<Text
-										color={isSelected ? theme.colors.menuSelected : theme.colors.menuNormal}
-										bold={isSelected}
-									>
-										{isSelected ? '❯ ' : '  '}
-										{agent.name}
-									</Text>
-								</Box>
-								{isSelected && (
-									<Box flexDirection="column" marginLeft={3}>
-										<Text color={theme.colors.menuSecondary}>
-											Description:{' '}
-											{truncateText(
-												agent.description || 'No description',
-												'Description: '.length,
-											)}
-										</Text>
-										<Text color={theme.colors.menuSecondary}>
-											Tools: {agent.tools.length} selected
-										</Text>
-										<Text color={theme.colors.menuSecondary} dimColor>
-											Updated: {new Date(agent.updatedAt).toLocaleString()}
+						{agents.map((agent, index) => {
+							const isSelected = index === selectedIndex;
+							return (
+								<Box key={agent.id} flexDirection="column">
+									<Box>
+										<Text
+											color={
+												isSelected
+													? theme.colors.menuSelected
+													: theme.colors.menuNormal
+											}
+											bold={isSelected}
+										>
+											{isSelected ? '❯ ' : '  '}
+											{agent.name}
 										</Text>
 									</Box>
-								)}
-							</Box>
-						);
-					})}
+									{isSelected && (
+										<Box flexDirection="column" marginLeft={3}>
+											<Text color={theme.colors.menuSecondary}>
+												{t.subAgentList.description}{' '}
+												{truncateText(
+													agent.description || t.subAgentList.noDescription,
+													t.subAgentList.description.length,
+												)}
+											</Text>
+											<Text color={theme.colors.menuSecondary}>
+												{t.subAgentList.toolsCount.replace(
+													'{count}',
+													agent.tools.length.toString(),
+												)}
+											</Text>
+											<Text color={theme.colors.menuSecondary} dimColor>
+												{t.subAgentList.updated}{' '}
+												{new Date(agent.updatedAt).toLocaleString()}
+											</Text>
+										</Box>
+									)}
+								</Box>
+							);
+						})}
 					</Box>
 				)}
 
-			<Box marginTop={1}>
-				<Text color={theme.colors.menuSecondary} dimColor>
-					↑↓: Navigate | Enter: Edit | A: Add New | D: Delete | Esc: Back
-				</Text>
-			</Box>
+				<Box marginTop={1}>
+					<Text color={theme.colors.menuSecondary} dimColor>
+						{t.subAgentList.navigationHint}
+					</Text>
+				</Box>
 			</Box>
 		</Box>
 	);


### PR DESCRIPTION
## 修改内容
### 修改前
<img width="619" height="228" alt="image" src="https://github.com/user-attachments/assets/894ef7ce-a5a1-4fb5-a0be-8bdb3af2256f" />

### 修改后
<img width="878" height="275" alt="image" src="https://github.com/user-attachments/assets/caf2eb00-c0e9-48bb-a04f-2332fd305466" />

### 新增国际化字段
- **子代理设置菜单**: `subAgentSettings`, `subAgentSettingsInfo`
- **子代理配置页面**: 完整的表单字段、工具分类、导航提示等
- **子代理列表页面**: 列表管理、操作提示、确认信息等

### 支持的语言
- 🇺🇸 English (en)
- 🇨🇳 中文简体 (zh) 
- 🇹🇼 中文繁体 (zh-TW)
- 🇯🇵 日本語 (ja)
- 🇰🇷 한국어 (ko)
- 🇪🇸 Español (es)

### 修改的文件
- `source/i18n/lang/*.ts` - 6 个语言文件
- `source/i18n/types.ts` - 类型定义
- `source/ui/pages/SubAgentListScreen.tsx` - 组件国际化

## 测试
- ✅ 所有语言显示正常
- ✅ 所有界面元素都有对应翻译
- ✅ 类型定义完整
- ✅ 功能无异常