### PR TITLE
修复：移除 todo-create 工具的 parentId 参数以解决显示问题

### DIFF
--- a/source/mcp/todo.ts
+++ b/source/mcp/todo.ts
@@ -1,4 +1,4 @@
-import { Tool, type CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import {Tool, type CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import fs from 'fs/promises';
 import path from 'path';
 // Type definitions
@@ -8,7 +8,7 @@ import type {
 	GetCurrentSessionId,
 } from './types/todo.types.js';
 // Utility functions
-import { formatDateForFolder } from './utils/todo/date.utils.js';
+import {formatDateForFolder} from './utils/todo/date.utils.js';
 
 /**
  * TODO 管理服务 - 支持创建、查询、更新 TODO
@@ -23,7 +23,7 @@ export class TodoService {
 	}
 
 	async initialize(): Promise<void> {
-		await fs.mkdir(this.todoDir, { recursive: true });
+		await fs.mkdir(this.todoDir, {recursive: true});
 	}
 
 	private getTodoPath(sessionId: string, date?: Date): string {
@@ -35,12 +35,12 @@ export class TodoService {
 
 	private async ensureTodoDir(date?: Date): Promise<void> {
 		try {
-			await fs.mkdir(this.todoDir, { recursive: true });
+			await fs.mkdir(this.todoDir, {recursive: true});
 
 			if (date) {
 				const dateFolder = formatDateForFolder(date);
 				const todoDir = path.join(this.todoDir, dateFolder);
-				await fs.mkdir(todoDir, { recursive: true });
+				await fs.mkdir(todoDir, {recursive: true});
 			}
 		} catch (error) {
 			// Directory already exists or other error
@@ -254,18 +254,18 @@ export class TodoService {
 				name: 'todo-create',
 				description: ` RECOMMENDED: Create TODO list for structured task execution. Use this for ALL multi-step tasks!
 
- MANDATORY RULE - PARALLEL CALLS ONLY:
- NEVER call todo-create alone! MUST call with other tools in the SAME function call block.
- ALWAYS: todo-create + filesystem-read (or other action tool) in parallel
- FORBIDDEN: Call todo-create, wait for result, then call other tools
+MANDATORY RULE - PARALLEL CALLS ONLY:
+NEVER call todo-create alone! MUST call with other tools in the SAME function call block.
+ALWAYS: todo-create + filesystem-read (or other action tool) in parallel
+FORBIDDEN: Call todo-create, wait for result, then call other tools
 
 ##  DEFAULT USAGE - Use TODO by default for:
- ANY multi-file changes (always create TODO first)
- ANY feature implementation (plan with TODO)
- ANY refactoring work (track with TODO)
- Bug fixes involving 2+ files (use TODO)
- Tasks with 3+ distinct steps (create TODO)
- SKIP ONLY: Single-file trivial edits (1-2 lines)
+ANY multi-file changes (always create TODO first)
+ANY feature implementation (plan with TODO)
+ANY refactoring work (track with TODO)
+Bug fixes involving 2+ files (use TODO)
+Tasks with 3+ distinct steps (create TODO)
+SKIP ONLY: Single-file trivial edits (1-2 lines)
 
 ##  WHY CREATE TODO:
 - Ensures all requirements are addressed
@@ -284,6 +284,7 @@ export class TodoService {
 - Order by logical dependencies
 - Be specific (e.g., "Modify validateInput in form.ts" not "fix validation")
 - Include verification step if critical
+- Creates root tasks only - use todo-add to create subtasks
 
 ##  LIFECYCLE:
 This REPLACES the entire TODO list. For adding tasks to existing list, use "todo-add" instead.
@@ -301,11 +302,6 @@ This REPLACES the entire TODO list. For adding tasks to existing list, use "todo
 										type: 'string',
 										description:
 											'TODO item description - must be specific, actionable, and technically precise (e.g., "Modify handleSubmit function in ChatInput.tsx to validate user input before processing" NOT "fix input validation")',
-									},
-									parentId: {
-										type: 'string',
-										description:
-											'Parent TODO ID ,The parent task parameter is empty, and the value of the parameter in the child task uses the parent task `id` (optional, for creating subtasks in hierarchical structure)',
 									},
 								},
 								required: ['content'],
@@ -456,8 +452,8 @@ NOTE: Deleting a parent task will cascade delete all its children automatically.
 		try {
 			switch (toolName) {
 				case 'create': {
-					const { todos } = args as {
-						todos: Array<{ content: string; parentId?: string }>;
+					const {todos} = args as {
+						todos: Array<{content: string}>;
 					};
 
 					const todoItems: TodoItem[] = todos.map(t => {
@@ -470,7 +466,6 @@ NOTE: Deleting a parent task will cascade delete all its children automatically.
 							status: 'pending' as const,
 							createdAt: now,
 							updatedAt: now,
-							parentId: t.parentId,
 						};
 					});
 
@@ -505,7 +500,7 @@ NOTE: Deleting a parent task will cascade delete all its children automatically.
 				}
 
 				case 'update': {
-					const { todoId, status, content } = args as {
+					const {todoId, status, content} = args as {
 						todoId: string;
 						status?: 'pending' | 'completed';
 						content?: string;
@@ -529,7 +524,7 @@ NOTE: Deleting a parent task will cascade delete all its children automatically.
 				}
 
 				case 'add': {
-					const { content, parentId } = args as {
+					const {content, parentId} = args as {
 						content: string;
 						parentId?: string;
 					};
@@ -546,7 +541,7 @@ NOTE: Deleting a parent task will cascade delete all its children automatically.
 				}
 
 				case 'delete': {
-					const { todoId } = args as {
+					const {todoId} = args as {
 						todoId: string;
 					};
 
@@ -579,8 +574,9 @@ NOTE: Deleting a parent task will cascade delete all its children automatically.
 				content: [
 					{
 						type: 'text',
-						text: `Error executing ${toolName}: ${error instanceof Error ? error.message : String(error)
-							}`,
+						text: `Error executing ${toolName}: ${
+							error instanceof Error ? error.message : String(error)
+						}`,
 					},
 				],
 				isError: true,


### PR DESCRIPTION
## 🐛 修复：移除 todo-create 的 parentId 参数以解决显示问题

### 📋 问题分析

#### 根本原因

当 Agent 调用 `todo-create` 并传入 `parentId` 参数时，经常会传入**占位符值**（如 `"todo_1"`、`"1"` 或其他临时字符串），而不是真实的 TODO ID。这导致：

1. **无效的父级引用** - 前端尝试构建层级树结构时，无法找到具有占位符 ID 的父节点
2. **UI 显示错乱** - 缩进错误、展开/折叠功能失效、子任务变成孤儿节点
3. **数据完整性问题** - 占位符字符串被存储为实际的 parentId 值到 JSON 文件中

#### 为什么会出现占位符

- Agent 在创建初始 TODO 列表时没有真实的父任务 ID
- Agent 尝试在创建阶段就建立层级关系
- 没有验证机制阻止无效的 parentId 值被存储

### 🔧 解决方案

**完全移除 `todo-create` 的 `parentId` 参数：**

#### 设计原则澄清

- **`todo-create`**：创建/替换整个 TODO 列表，**仅创建根任务**
- **`todo-add`**：向现有列表添加新任务，**支持 parentId 创建子任务**

这强制执行了职责分离，防止无效数据产生。

#### 修改内容

1. ✅ 从 `todo-create` 的 input schema 中移除 `parentId`
2. ✅ 从 create 实现中移除 `parentId` 处理逻辑
3. ✅ 添加明确文档说明："Creates root tasks only - use todo-add to create subtasks"
4. ✅ 更新工具描述，强调仅创建根任务

### 📊 影响评估

#### ✅ 正确使用方式无破坏性变更

- 正确的工作流已经使用 `todo-add` 创建子任务
- `todo-create` 按设计本就应该只创建根任务
```
// ❌ 旧方式（不再支持）
todo-create({
  todos: [
    {content: "父任务"},
    {content: "子任务", parentId: "xxx"}  // ← 会被忽略
  ]
})

// ✅ 新方式（正确做法）
todo-create({
  todos: [{content: "父任务"}, {content: "子任务"}]
})
// 然后使用 todo-add 建立层级
todo-add({content: "子任务详情", parentId: "todo-xxx"})
````

### 🔍 审核请求

#### 关于工具提示词和系统提示词

**说明：** 本 PR 对工具描述和系统提示词的修改非常小。主要变更为：

- 添加了一行说明："Creates root tasks only - use todo-add to create subtasks"
- 澄清了生命周期和使用指南

**请审核这些提示词修改是否符合您的设计。** 如果您对以下方面有特定偏好：

- 工具描述的结构
- 提示词的措辞风格
- 使用指南的格式
- 文档编写方式

我很乐意根据您对项目的愿景进行调整。

### 📝 总结

| 方面         | 详情                                           |
| ------------ | ---------------------------------------------- |
| **问题**     | 占位符 parentId 值导致 UI 显示问题             |
| **解决方案** | 从 todo-create 移除 parentId，强制仅创建根任务 |
| **破坏性**   | 仅影响不正确的使用模式                         |
| **迁移**     | 使用 todo-add 创建子任务                       |
| **提示词**   | 最小化修改 - 请审核是否符合理念                |

---

**期待您的反馈，特别是关于提示词修改的部分！** 🙏
