### PR TITLE
fix(build): 修复 Windows 本地开发时 sharp 模块加载失败问题

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -35,10 +35,18 @@ const require = _createRequire(import.meta.url);
 const __filename = _fileURLToPath(import.meta.url);
 const __dirname = _fileURLToPath(new URL('.', import.meta.url));`,
 	},
-	external: [
+external: [
 		// Only Node.js built-in modules should be external
 		...builtinModules,
 		...builtinModules.map(m => `node:${m}`),
+		// Sharp and its platform-specific native dependencies
+		'sharp',
+		'@img/sharp-win32-x64',
+		'@img/sharp-win32-arm64',
+		'@img/sharp-linux-x64',
+		'@img/sharp-linux-arm64',
+		'@img/sharp-darwin-x64',
+		'@img/sharp-darwin-arm64',
 	],
 	plugins: [stubPlugin],
 	minify: false,


### PR DESCRIPTION
## 问题描述

在 **Windows** 系统上进行本地开发，使用 `npm link` 时遇到以下错误：

```
Error: Could not load the "sharp" module using the win32-x64 runtime
```

### 根本原因

`sharp` 是一个原生 C++ 模块，在 commit `e445864` 中被引入用于 SVG 处理功能。但是 `build.mjs` 的构建配置没有相应更新，没有将 `sharp` 从打包中排除。

当 esbuild 尝试打包 `sharp` 时，它可以打包 JavaScript 代码，但**无法打包原生二进制文件**（`.node` 文件）。这导致运行时被打包的代码尝试加载原生依赖时出错。

### 为什么之前没有发现这个问题？

这个问题主要影响 **Windows 系统上本地开发**：

- CI/CD 直接发布到 npm，用户安装时会获得完整的 `sharp` 包及所有平台特定依赖
- 在 Linux/macOS 上可能不会遇到这个问题，因为依赖处理机制不同
- 如果只使用 CI 发布就不会发现这个问题

## 解决方案

在 `build.mjs` 的 `external` 配置中添加 `sharp` 及其平台特定的原生依赖：

```javascript
external: [
	...builtinModules,
	...builtinModules.map(m => `node:${m}`),
	// Sharp and its platform-specific native dependencies
	'sharp',
	'@img/sharp-win32-x64',
	'@img/sharp-win32-arm64',
	'@img/sharp-linux-x64',
	'@img/sharp-linux-arm64',
	'@img/sharp-darwin-x64',
	'@img/sharp-darwin-arm64',
];
```

这告诉 esbuild **不要打包**这些模块，让它们在运行时从 `node_modules` 加载。

## 测试环境

测试环境：**Windows 11 + Node.js v20.19.0**

```bash
# 构建成功
npm run build
✓ Bundle created successfully

# 直接运行成功
node bundle/cli.mjs --version
0.4.28

# npm link 成功
npm link
snow --version
0.4.28

# Sharp 功能正常（SVG 处理）
✓ SVG 转 PNG 功能工作正常
```

## 影响

- ✅ 修复了 Windows 上本地开发问题
- ✅ 不影响 CI/CD 或 npm 发布流程
- ✅ 对现有用户无破坏性更改
- ✅ Sharp 功能保持完全可用

## 相关信息

- Sharp 原始引入：commit `e445864`
- 影响范围：Windows 本地开发 + `npm link`
- 发现者：在 Windows 11 本地开发环境中遇到此问题
