### PR TITLE
fix(session): set currentSession when loading from date folders

### DIFF
--- a/source/utils/session/sessionManager.ts
+++ b/source/utils/session/sessionManager.ts
@@ -157,6 +157,9 @@ class SessionManager {
 				if (hookResult.warningMessage) {
 					this.lastLoadHookWarning = hookResult.warningMessage;
 				}
+
+				// 设置currentSession
+				this.currentSession = session;
 				return session;
 			}
 		} catch (error) {


### PR DESCRIPTION
## 问题描述

修复 `loadSession` 方法在从日期文件夹加载会话时缺失 `this.currentSession` 赋值的 bug。

## Bug 根因

在 commit `e445864` 添加 `onSessionStart` hook 逻辑时，引入了此 bug:

- ✅ **第一条代码路径**(旧格式加载): 正确设置了 `this.currentSession`
- ❌ **第二条代码路径**(日期文件夹查找): 漏掉了 `this.currentSession = session;` 赋值

这导致从日期文件夹恢复会话时，`currentSession` 为空，造成会话恢复失败。

## 修复内容

在日期文件夹加载路径中，hook 执行成功后，添加缺失的赋值语句:

```typescript
// 设置currentSession
this.currentSession = session;
return session;
```

## 测试验证

- [x] 从旧格式加载会话正常
- [x] 从日期文件夹加载会话正常
- [x] 会话恢复后 `currentSession` 正确设置

## 影响范围

- 仅影响会话管理模块
- 修复了会话恢复功能的 critical bug
- 无 breaking changes
