### PR TITLE
fix(ui): 修复MCP服务编辑時無法識別编辑器的问题

### DIFF
--- a/source/ui/pages/MCPConfigScreen.tsx
+++ b/source/ui/pages/MCPConfigScreen.tsx
@@ -15,16 +15,22 @@ const CONFIG_DIR = join(homedir(), '.snow');
 const MCP_CONFIG_FILE = join(CONFIG_DIR, 'mcp-config.json');
 
 function checkCommandExists(command: string): boolean {
-	try {
-		execSync(`command -v ${command}`, {
-			stdio: 'ignore',
-			shell: '/bin/zsh',
-			env: process.env,
-		});
-		return true;
-	} catch {
-		return false;
+	const shells = ['/bin/sh', '/bin/bash', '/bin/zsh'];
+
+	for (const shell of shells) {
+		try {
+			execSync(`command -v ${command}`, {
+				stdio: 'ignore',
+				shell,
+				env: process.env,
+			});
+			return true;
+		} catch {
+			// Try next shell
+		}
 	}
+
+	return false;
 }
 
 function getSystemEditor(): string | null {


### PR DESCRIPTION
### 問題描述
原代碼中用 /bin/zsh 和 $Editor 來識別编辑器, 對於沒有安裝zsh的環境會無法識別;

### 修复詳情
按順序用 /bin/sh > /bin/bash > /bin/zsh 來進行識別, 由於/bin/sh 和 /bin/bash 存在於幾乎所有的linux image build, 所以應該可以大大提升識別成功率

### 測試
npm run build > npm run start 
沒有error
在本身無法識別的環境下, 測試成功識別nano