### PR TITLE
fix(windows): resolve 'Access is denied' errors on Ctrl+C exit

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -30,6 +30,7 @@ import {onNavigate} from './hooks/integration/useGlobalNavigation.js';
 import {useTerminalSize} from './hooks/ui/useTerminalSize.js';
 import {I18nProvider} from './i18n/index.js';
 import {ThemeProvider} from './ui/contexts/ThemeContext.js';
+import {gracefulExit} from './utils/core/processManager.js';
 
 type Props = {
 	version?: string;
@@ -71,7 +72,7 @@ function ShowTaskListWrapper() {
 		return (
 			<Suspense fallback={loadingFallback}>
 				<TaskManagerScreen
-					onBack={() => process.exit(0)}
+					onBack={() => gracefulExit()}
 					onResumeTask={() => {
 						// Session is already set by convertTaskToSession
 						// Just navigate to chat view
@@ -175,7 +176,7 @@ function AppContent({
 			// Both 'chat' and 'resume-last' go to chat view
 			setCurrentView(value === 'resume-last' ? 'chat' : value);
 		} else if (value === 'exit') {
-			process.exit(0);
+			gracefulExit();
 		}
 	};
 
@@ -285,7 +286,7 @@ export default function App({
 					<Suspense fallback={loadingFallback}>
 						<HeadlessModeScreen
 							prompt={headlessPrompt}
-							onComplete={() => process.exit(0)}
+							onComplete={() => gracefulExit()}
 						/>
 					</Suspense>
 				</ThemeProvider>

--- a/source/hooks/integration/useGlobalExit.ts
+++ b/source/hooks/integration/useGlobalExit.ts
@@ -18,8 +18,9 @@ export function useGlobalExit(
 		if (key.ctrl && input === 'c') {
 			const now = Date.now();
 			if (now - lastCtrlCTime < ctrlCTimeout) {
-				// Second Ctrl+C within timeout - exit
-				process.exit(0);
+				// Second Ctrl+C within timeout - emit SIGINT to trigger cleanup
+				// This ensures proper async cleanup before exit
+				process.emit('SIGINT');
 			} else {
 				// First Ctrl+C - show notification
 				setLastCtrlCTime(now);

--- a/source/ui/pages/MCPConfigScreen.tsx
+++ b/source/ui/pages/MCPConfigScreen.tsx
@@ -5,6 +5,7 @@ import {writeFileSync, readFileSync, existsSync} from 'fs';
 import {join} from 'path';
 import {homedir, platform} from 'os';
 import {getMCPConfig, validateMCPConfig} from '../../utils/config/apiConfig.js';
+import {gracefulExit} from '../../utils/core/processManager.js';
 
 type Props = {
 	onBack: () => void;
@@ -73,7 +74,7 @@ export default function MCPConfigScreen({onBack}: Props) {
 				console.error('  Ubuntu/Debian: sudo apt-get install nano');
 				console.error('  CentOS/RHEL:   sudo yum install nano');
 				console.error('  macOS:         nano is usually pre-installed');
-				process.exit(1);
+				gracefulExit();
 				return;
 			}
 
@@ -106,12 +107,12 @@ export default function MCPConfigScreen({onBack}: Props) {
 					}
 				}
 
-				process.exit(0);
+				gracefulExit();
 			});
 
 			child.on('error', error => {
 				console.error('Failed to open editor:', error.message);
-				process.exit(1);
+				gracefulExit();
 			});
 		};
 

--- a/source/utils/core/processManager.ts
+++ b/source/utils/core/processManager.ts
@@ -1,12 +1,14 @@
-import {ChildProcess} from 'child_process';
+import {ChildProcess, exec} from 'child_process';
 
 /**
  * Process Manager
  * Tracks and manages all child processes to ensure proper cleanup
+ * Supports Windows process tree termination
  */
 class ProcessManager {
 	private processes: Set<ChildProcess> = new Set();
 	private isShuttingDown = false;
+	private readonly isWindows = process.platform === 'win32';
 
 	/**
 	 * Register a child process for tracking
@@ -31,27 +33,45 @@ class ProcessManager {
 
 	/**
 	 * Kill a specific process gracefully
+	 * On Windows, uses taskkill with /T flag to terminate process tree
 	 */
 	private killProcess(process: ChildProcess): void {
-		try {
-			if (process.pid && !process.killed) {
-				// Try graceful termination first
+		const pid = process.pid;
+		if (!pid || process.killed) {
+			return;
+		}
+
+		if (this.isWindows) {
+			// Windows: Use taskkill to kill entire process tree
+			// /T = terminate child processes, /F = force
+			// Redirect stderr to NUL to suppress "Access is denied" error spam
+			exec(`taskkill /PID ${pid} /T /F 2>NUL`, {windowsHide: true}, () => {
+				// Ignore errors - process may already be dead or inaccessible
+			});
+		} else {
+			// Unix: Use SIGTERM for graceful termination
+			try {
 				process.kill('SIGTERM');
 
 				// Force kill after 1 second if still alive
 				setTimeout(() => {
-					if (process.pid && !process.killed) {
-						process.kill('SIGKILL');
+					try {
+						if (!process.killed) {
+							process.kill('SIGKILL');
+						}
+					} catch {
+						// Process already dead
 					}
 				}, 1000);
+			} catch {
+				// Process already dead
 			}
-		} catch (error) {
-			// Process might already be dead, ignore errors
 		}
 	}
 
 	/**
 	 * Kill all tracked processes
+	 * On Windows, kills process trees to ensure no orphaned children
 	 */
 	killAll(): void {
 		this.isShuttingDown = true;
@@ -73,3 +93,13 @@ class ProcessManager {
 
 // Export singleton instance
 export const processManager = new ProcessManager();
+
+/**
+ * Graceful exit with async cleanup support
+ * Emits SIGINT to trigger cleanup handlers before exit
+ */
+export function gracefulExit(): void {
+	// Emit SIGINT to trigger async cleanup handlers in cli.tsx
+	// The SIGINT handler will call process.exit() after cleanup
+	process.emit('SIGINT');
+}


### PR DESCRIPTION
 Description: 修复 Windows 下 Ctrl+C 退出时的 "Access is denied" 错误

我不清楚其他系统,按理说应该有类似问题

原因: 我在Windows terminal里执行snow cli 双击Ctrl+C 退出时
会出现一片
ERROR: The process with PID 70480 (child process of PID 81792) could not be terminated.
Reason: Access is denied.
ERROR: The process with PID 85172 (child process of PID 81792) could not be terminated.
Reason: Access is denied.
ERROR: The process with PID 83332 (child process of PID 81792) could not be terminated.
Reason: Access is denied.
ERROR: The process with PID 84860 (child process of PID 81792) could not be terminated.
Reason: Access is denied.
ERROR: The process with PID 50492 (child process of PID 81792) could not be terminated.
Reason: Access is denied.
ERROR: The process with PID 75056 (child process of PID 81792) could not be terminated.
Reason: Access is denied.
ERROR: The process with PID 79560 (child process of PID 81792) could not be terminated.
Reason: Access is denied.
ERROR: The process with PID 3820 (child process of PID 81792) could not be terminated.
Reason: Access is denied.
ERROR: The process with PID 81792 (child process of PID 48412) could not be terminated.
Reason: Access is denied
这样的报错,我猜测是node程序的经典bug,有子进程子程序没有完成就退出了主程序,导致子进程在接收到主进程killed之后才知道慌乱自杀就会这样,反正是处理的不够优雅,于是我用opus进行了调查并修复,于是有了这个pr

- Use taskkill /T /F on Windows to terminate process trees
- Redirect taskkill stderr to NUL to suppress error spam
- Separate sync/async cleanup for proper exit handling
- Add gracefulExit() for unified exit with async cleanup
- Ensure MCP connections close before process termination