### PR TITLE
Fix: Preserve indentation in filesystem-edit_search for indentation-sensitive languages

### DIFF
--- a/source/mcp/filesystem.ts
+++ b/source/mcp/filesystem.ts
@@ -1123,7 +1123,25 @@ export class FilesystemMCPService {
 				.replace(/\r/g, '\n');
 			const beforeLines = lines.slice(0, startLine - 1);
 			const afterLines = lines.slice(endLine);
-			const replaceLines = normalizedReplace.split('\n');
+			let replaceLines = normalizedReplace.split('\n');
+
+			// Fix indentation for Python/YAML files: preserve first line's original indentation
+			// but keep relative indentation for subsequent lines
+			if (replaceLines.length > 0) {
+				const originalFirstLine = lines[startLine - 1];
+				const originalIndent = originalFirstLine?.match(/^(\s*)/)?.[1] || '';
+				const replaceFirstLine = replaceLines[0];
+				const replaceIndent = replaceFirstLine?.match(/^(\s*)/)?.[1] || '';
+
+				// Only adjust if the first line indentation is different
+				if (originalIndent !== replaceIndent && replaceFirstLine) {
+					// Adjust only the first line to match original indentation
+					const adjustedFirstLine = originalIndent + replaceFirstLine.trim();
+					replaceLines[0] = adjustedFirstLine;
+					// Subsequent lines keep their relative indentation
+				}
+			}
+
 			const modifiedLines = [...beforeLines, ...replaceLines, ...afterLines];
 			const modifiedContent = modifiedLines.join('\n');
 


### PR DESCRIPTION
## 问题描述
`filesystem-edit_search` 工具在编辑 Python、YAML 等缩进敏感语言时，会导致替换内容的第一行缩进丢失，造成语法错误。
## 现状举例
`filesystem-edit_search` 工具修改前
```
def rename_file(file_path):
    # 获取文件名
    file_name = os.path.basename(file_path)
    if '切图' == os.path.basename(
            os.path.dirname(file_path)):
        # 获取文件所在文件夹的父文件夹名
        parent_folder_name = os.path.basename(
            os.path.dirname(os.path.dirname(os.path.dirname(file_path))))
    else:
        # 获取文件所在文件夹的父文件夹名
        parent_folder_name = os.path.basename(
            os.path.dirname(file_path))
    # 构建新文件名
    new_file_name = parent_folder_name + "_" + file_name
    return new_file_name
```
让Agent修改 else块中的内筒
```
def rename_file(file_path):
    # 获取文件名
    file_name = os.path.basename(file_path)
    if '切图' == os.path.basename(
            os.path.dirname(file_path)):
        # 获取文件所在文件夹的父文件夹名
        parent_folder_name = os.path.basename(
            os.path.dirname(os.path.dirname(os.path.dirname(file_path))))
else:
        parent_folder_name = os.path.basename(
            os.path.dirname(file_path)) -- 测试
    # 构建新文件名
    new_file_name = parent_folder_name + "_" + file_name
    return new_file_name
```
神奇的就丢了编辑中的第一行的缩进,
ts等依赖大括号的语言会自动格式化故此bug不明显
但pyhton一是不支持自动格式化,二是直接报错,也格式化不了,
然后Agent就又会用此工具反复错误的修改.
## 问题原因
工具直接使用 Agent 提供的替换内容，没有考虑被替换位置的上下文缩进。

## 解决方案
- 检测被替换内容第一行的原始缩进
- 自动调整替换内容第一行的缩进以匹配原始位置
- 保持后续行的相对缩进关系不变

## 影响范围
- 适用于所有缩进敏感的语言（Python、YAML、Makefile 等）
- 对其他语言无影响
- 向后兼容
