### PR TITLE
feat(session): 实现按项目分类存储session、todo和历史记录

### DIFF
--- a/source/hooks/input/useHistoryNavigation.ts
+++ b/source/hooks/input/useHistoryNavigation.ts
@@ -41,7 +41,7 @@ export function useHistoryNavigation(
 
 	// Load persistent history on mount
 	useEffect(() => {
-		historyManager.loadHistory().then(entries => {
+		historyManager.getEntries().then(entries => {
 			setPersistentHistory(entries);
 		});
 	}, []);

--- a/source/hooks/input/useKeyboardInput.ts
+++ b/source/hooks/input/useKeyboardInput.ts
@@ -851,14 +851,17 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 			const text = buffer.getFullText();
 			const cursorPos = buffer.getCursorPosition();
 			const isEmpty = text.trim() === '';
-			const isAtStart = cursorPos === 0;
-			const hasNewline = text.includes('\n');
+
+			// Check if cursor is on the first line
+			const firstNewlineIndex = text.indexOf('\n');
+			const isOnFirstLine =
+				firstNewlineIndex === -1 || cursorPos <= firstNewlineIndex;
 
 			// Terminal-style history navigation:
 			// 1. Empty input box -> navigate history
-			// 2. Cursor at start of single line -> navigate history
-			// 3. Otherwise -> normal cursor movement
-			if (isEmpty || (!hasNewline && isAtStart)) {
+			// 2. Cursor on first line -> navigate history
+			// 3. Otherwise -> normal cursor movement (move up within multiline text)
+			if (isEmpty || isOnFirstLine) {
 				const navigated = navigateHistoryUp();
 				if (navigated) {
 					updateFilePickerState(
@@ -905,14 +908,17 @@ export function useKeyboardInput(options: KeyboardInputOptions) {
 			const text = buffer.getFullText();
 			const cursorPos = buffer.getCursorPosition();
 			const isEmpty = text.trim() === '';
-			const isAtEnd = cursorPos === text.length;
-			const hasNewline = text.includes('\n');
+
+			// Check if cursor is on the last line
+			const lastNewlineIndex = text.lastIndexOf('\n');
+			const isOnLastLine =
+				lastNewlineIndex === -1 || cursorPos > lastNewlineIndex;
 
 			// Terminal-style history navigation:
 			// 1. Empty input box -> navigate history (if in history mode)
-			// 2. Cursor at end of single line -> navigate history (if in history mode)
-			// 3. Otherwise -> normal cursor movement
-			if ((isEmpty || (!hasNewline && isAtEnd)) && currentHistoryIndex !== -1) {
+			// 2. Cursor on last line -> navigate history (if in history mode)
+			// 3. Otherwise -> normal cursor movement (move down within multiline text)
+			if ((isEmpty || isOnLastLine) && currentHistoryIndex !== -1) {
 				const navigated = navigateHistoryDown();
 				if (navigated) {
 					updateFilePickerState(

--- a/source/mcp/todo.ts
+++ b/source/mcp/todo.ts
@@ -12,13 +12,16 @@ import {formatDateForFolder} from './utils/todo/date.utils.js';
 
 /**
  * TODO 管理服务 - 支持创建、查询、更新 TODO
+ * 路径结构: ~/.snow/todos/项目名/YYYY-MM-DD/sessionId.json
  */
 export class TodoService {
 	private readonly todoDir: string;
 	private getCurrentSessionId: GetCurrentSessionId;
 
 	constructor(baseDir: string, getCurrentSessionId: GetCurrentSessionId) {
-		this.todoDir = path.join(baseDir, 'todos');
+		// baseDir 现在已经包含了项目ID，直接使用
+		// 路径结构: baseDir/YYYY-MM-DD/sessionId.json
+		this.todoDir = baseDir;
 		this.getCurrentSessionId = getCurrentSessionId;
 	}
 

--- a/source/utils/execution/mcpToolsManager.ts
+++ b/source/utils/execution/mcpToolsManager.ts
@@ -87,10 +87,15 @@ const CLIENT_IDLE_TIMEOUT = 10 * 60 * 1000; // 10 minutes idle timeout
 
 /**
  * Get the TODO service instance (lazy initialization)
+ * TODO 服务路径与 Session 保持一致，按项目分类存储
  */
 export function getTodoService(): TodoService {
 	if (!todoService) {
-		todoService = new TodoService(path.join(os.homedir(), '.snow'), () => {
+		// 获取当前项目ID，与 Session 路径结构保持一致
+		const projectId = sessionManager.getProjectId();
+		const basePath = path.join(os.homedir(), '.snow', 'todos', projectId);
+
+		todoService = new TodoService(basePath, () => {
 			const session = sessionManager.getCurrentSession();
 			return session ? session.id : null;
 		});

--- a/source/utils/session/historyManager.ts
+++ b/source/utils/session/historyManager.ts
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
 import {logger} from '../core/logger.js';
+import {getProjectId} from './projectUtils.js';
 
 export interface HistoryEntry {
 	content: string;
@@ -13,15 +14,27 @@ export interface HistoryData {
 	lastCleanup: number;
 }
 
+/**
+ * 历史记录管理器
+ * 按项目分类存储历史记录
+ * 路径结构: ~/.snow/history/项目名/history.json
+ */
 class HistoryManager {
+	private readonly historyDir: string;
 	private readonly historyFile: string;
 	private readonly maxAge = 24 * 60 * 60 * 1000; // 1 day in milliseconds
 	private readonly maxEntries = 1000; // Maximum number of entries to keep
 	private historyData: HistoryData | null = null;
+	private readonly currentProjectId: string;
+	// 旧格式的历史数据，只读备用，不会保存到新文件
+	private legacyEntries: HistoryEntry[] = [];
 
 	constructor() {
 		const snowDir = path.join(os.homedir(), '.snow');
-		this.historyFile = path.join(snowDir, 'history.json');
+		this.currentProjectId = getProjectId();
+		// 新路径: ~/.snow/history/项目名/history.json
+		this.historyDir = path.join(snowDir, 'history', this.currentProjectId);
+		this.historyFile = path.join(this.historyDir, 'history.json');
 	}
 
 	/**
@@ -38,21 +51,51 @@ class HistoryManager {
 
 	/**
 	 * Load history from file
+	 * 向后兼容：如果项目级历史不存在，尝试从旧的全局历史加载（只读备用）
+	 * 新数据只保存到项目级文件，不会污染旧文件
 	 */
 	async loadHistory(): Promise<HistoryEntry[]> {
 		try {
 			await this.ensureSnowDir();
 
-			// Try to read existing history file
-			const data = await fs.readFile(this.historyFile, 'utf-8');
-			this.historyData = JSON.parse(data) as HistoryData;
+			// 1. 首先尝试读取项目级历史文件（新格式）
+			try {
+				const data = await fs.readFile(this.historyFile, 'utf-8');
+				this.historyData = JSON.parse(data) as HistoryData;
 
-			// Clean up old entries if needed
-			await this.cleanupOldEntries();
+				// Clean up old entries if needed
+				await this.cleanupOldEntries();
 
-			return this.historyData.entries;
+				return this.historyData.entries;
+			} catch (error) {
+				// 项目级历史不存在，尝试旧格式作为只读备用
+			}
+
+			// 2. 尝试从旧的全局历史文件加载（只读备用，不迁移到新文件）
+			const snowDir = path.join(os.homedir(), '.snow');
+			const oldHistoryFile = path.join(snowDir, 'history.json');
+			try {
+				const data = await fs.readFile(oldHistoryFile, 'utf-8');
+				const oldData = JSON.parse(data) as HistoryData;
+
+				// 旧数据作为只读备用，不保存到新文件
+				this.legacyEntries = oldData.entries;
+
+				logger.debug(
+					`Loaded ${this.legacyEntries.length} legacy history entries as read-only backup`,
+				);
+			} catch (error) {
+				// 旧格式也不存在，legacyEntries 保持为空
+			}
+
+			// 3. 新文件从空开始，只保存当前项目的新数据
+			this.historyData = {
+				entries: [],
+				lastCleanup: Date.now(),
+			};
+			return this.legacyEntries;
 		} catch (error) {
-			// File doesn't exist or is corrupted, start fresh
+			// Unexpected error, start fresh
 			this.historyData = {
 				entries: [],
 				lastCleanup: Date.now(),
@@ -76,7 +119,8 @@ class HistoryManager {
 		}
 
 		// Don't add duplicate of the last entry
-		const lastEntry = this.historyData!.entries[this.historyData!.entries.length - 1];
+		const lastEntry =
+			this.historyData!.entries[this.historyData!.entries.length - 1];
 		if (lastEntry && lastEntry.content === content) {
 			return;
 		}
@@ -91,7 +135,9 @@ class HistoryManager {
 
 		// Limit the number of entries
 		if (this.historyData!.entries.length > this.maxEntries) {
-			this.historyData!.entries = this.historyData!.entries.slice(-this.maxEntries);
+			this.historyData!.entries = this.historyData!.entries.slice(
+				-this.maxEntries,
+			);
 		}
 
 		// Save to file
@@ -100,14 +146,20 @@ class HistoryManager {
 
 	/**
 	 * Get all history entries (newest first)
+	 * 当新格式文件存在时只返回新数据，否则返回旧数据作为备用
 	 */
 	async getEntries(): Promise<HistoryEntry[]> {
 		if (!this.historyData) {
 			await this.loadHistory();
 		}
 
-		// Return a copy in reverse order (newest first)
-		return [...this.historyData!.entries].reverse();
+		// 如果新格式有数据，只返回新数据（不合并旧数据）
+		if (this.historyData!.entries.length > 0) {
+			return [...this.historyData!.entries].reverse();
+		}
+
+		// 新格式为空时，返回旧数据作为只读备用
+		return [...this.legacyEntries].reverse();
 	}
 
 	/**
@@ -139,7 +191,9 @@ class HistoryManager {
 		if (this.historyData.entries.length < originalLength) {
 			await this.saveHistory();
 			logger.debug(
-				`Cleaned up ${originalLength - this.historyData.entries.length} old history entries`,
+				`Cleaned up ${
+					originalLength - this.historyData.entries.length
+				} old history entries`,
 			);
 		}
 	}

--- a/source/utils/session/projectUtils.ts
+++ b/source/utils/session/projectUtils.ts
@@ -1,0 +1,106 @@
+import path from 'path';
+import crypto from 'crypto';
+
+/**
+ * 项目工具函数 - 用于获取项目标识
+ * 
+ * 路径结构: ~/.snow/sessions/项目名/YYYYMMDD/UUID.json
+ * 参考 Claude Code 的设计
+ */
+
+/**
+ * 获取当前项目的唯一标识符
+ * 使用目录名作为主标识，附加短哈希确保唯一性
+ * 
+ * @param projectPath - 项目路径，默认为当前工作目录
+ * @returns 项目ID，格式为 "目录名-短哈希"
+ */
+export function getProjectId(projectPath?: string): string {
+	const cwd = projectPath || process.cwd();
+	const dirName = path.basename(cwd);
+	
+	// 生成路径的短哈希（6位）以区分同名目录
+	const pathHash = crypto
+		.createHash('sha256')
+		.update(cwd)
+		.digest('hex')
+		.slice(0, 6);
+	
+	// 清理目录名，移除不安全字符
+	const safeDirName = sanitizeProjectName(dirName);
+	
+	return `${safeDirName}-${pathHash}`;
+}
+
+/**
+ * 获取当前项目的简短名称（仅目录名）
+ * 用于显示目的
+ * 
+ * @param projectPath - 项目路径，默认为当前工作目录
+ * @returns 项目目录名
+ */
+export function getProjectName(projectPath?: string): string {
+	const cwd = projectPath || process.cwd();
+	return path.basename(cwd);
+}
+
+/**
+ * 获取当前项目的完整路径
+ * 
+ * @returns 项目完整路径
+ */
+export function getProjectPath(): string {
+	return process.cwd();
+}
+
+/**
+ * 清理项目名称，移除不安全的文件系统字符
+ * 
+ * @param name - 原始项目名
+ * @returns 安全的项目名
+ */
+export function sanitizeProjectName(name: string): string {
+	// 移除或替换不安全的文件系统字符
+	return name
+		.replace(/[<>:"/\\|?*\x00-\x1F]/g, '_') // 替换 Windows 不允许的字符
+		.replace(/\s+/g, '_') // 空格替换为下划线
+		.replace(/_+/g, '_') // 多个下划线合并
+		.replace(/^_|_$/g, '') // 移除首尾下划线
+		.slice(0, 100); // 限制长度
+}
+
+/**
+ * 格式化日期为文件夹名称 (YYYYMMDD)
+ * 注意：使用紧凑格式，不带连字符
+ * 
+ * @param date - 日期对象
+ * @returns 格式化的日期字符串 (YYYYMMDD)
+ */
+export function formatDateCompact(date: Date): string {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}${month}${day}`;
+}
+
+/**
+ * 检查路径是否为日期文件夹（旧格式 YYYY-MM-DD 或新格式 YYYYMMDD）
+ * 
+ * @param folderName - 文件夹名称
+ * @returns 是否为日期格式
+ */
+export function isDateFolder(folderName: string): boolean {
+	// 匹配 YYYY-MM-DD 或 YYYYMMDD 格式
+	return /^\d{4}-?\d{2}-?\d{2}$/.test(folderName);
+}
+
+/**
+ * 检查路径是否为项目文件夹（项目名-哈希 格式）
+ * 
+ * @param folderName - 文件夹名称
+ * @returns 是否为项目文件夹格式
+ */
+export function isProjectFolder(folderName: string): boolean {
+	// 匹配 项目名-6位哈希 格式
+	return /^.+-[a-f0-9]{6}$/.test(folderName);
+}


### PR DESCRIPTION
   ## 变更说明

   本PR实现了按项目分类存储数据的功能，参考Claude Code的设计。

   ### 核心改进

   - **新增 `projectUtils.ts`**: 项目标识工具函数，使用目录名+短哈希确保唯一性
   - **Session分类存储**: `~/.snow/sessions/项目名/YYYYMMDD/UUID.json`
   - **TODO分类存储**: `~/.snow/todos/项目名/YYYY-MM-DD/sessionId.json`
   - **历史记录分类存储**: `~/.snow/history/项目名/history.json`

   ### 键盘导航优化

   - 多行文本中，上下键只在光标位于首行/尾行时才触发历史导航
   - 其他情况正常在文本中移动光标

   ### 兼容性

   - 向后兼容旧格式历史数据（只读备用）
   - 新数据只保存到项目级文件