### PR TITLE
fix: prevent 400 error when disableThinking is true

### DIFF
--- a/source/utils/core/retryUtils.ts
+++ b/source/utils/core/retryUtils.ts
@@ -70,11 +70,10 @@ function isRetriableError(error: Error): boolean {
 		return true;
 	}
 
-	// Server errors
+	// Server errors (5xx - temporary server issues, retryable)
+	// Note: 400, 403, 405 are client errors - typically not retryable
+	// as they indicate request format issues that won't change on retry
 	if (
-		errorMessage.includes('400') ||
-		errorMessage.includes('403') ||
-		errorMessage.includes('405') ||
 		errorMessage.includes('500') ||
 		errorMessage.includes('502') ||
 		errorMessage.includes('503') ||


### PR DESCRIPTION
## Summary

Fix potential 400 API error when sub-agents use `disableThinking: true` but message history contains thinking blocks.

## Problem

When Extended Thinking is enabled in the main flow, assistant messages may contain thinking blocks. If these messages are later processed with `disableThinking: true` (e.g., in sub-agents), the API could return a 400 error due to inconsistent message format.

Additionally, 400/403/405 client errors were being retried unnecessarily, which is incorrect behavior since these errors indicate request format issues that won't change on retry.

## Changes

### `source/api/anthropic.ts`
- Added `disableThinking` parameter to `convertToAnthropicMessages()` function
- When `disableThinking=true`, thinking blocks are stripped from messages
- Added debug logging for thinking parameter decisions

### `source/utils/core/retryUtils.ts`
- Removed 400, 403, 405 from retriable errors (client errors should not be retried)
- Only 5xx server errors are now retried

## Testing

- [x] TypeScript type check passes
- [x] Build succeeds
- [x] Backward compatible (default parameter value preserves existing behavior)
