### PR TITLE
fix: 清理双击ESC回退时的IDE上下文信息污染

### DIFF
--- a/source/hooks/input/useHistoryNavigation.ts
+++ b/source/hooks/input/useHistoryNavigation.ts
@@ -1,5 +1,6 @@
 import {useState, useCallback, useRef, useEffect} from 'react';
 import {TextBuffer} from '../../utils/ui/textBuffer.js';
+import {cleanIDEContext} from '../../utils/core/fileUtils.js';
 import {
 	historyManager,
 	type HistoryEntry,
@@ -63,8 +64,10 @@ export function useHistoryNavigation(
 
 		// Keep original order (oldest first, newest last) and map with display numbers
 		return userMessages.map((msg, index) => {
+			// Clean IDE context info first, then clean for display
+			const cleanedContent = cleanIDEContext(msg.content);
 			// Remove all newlines, control characters and extra whitespace to ensure single line display
-			const cleanContent = msg.content
+			const cleanContent = cleanedContent
 				.replace(/[\r\n\t\v\f\u0000-\u001F\u007F-\u009F]+/g, ' ')
 				.replace(/\s+/g, ' ')
 				.trim();
@@ -73,11 +76,11 @@ export function useHistoryNavigation(
 					cleanContent.length > 50 ? '...' : ''
 				}`,
 				value: msg.originalIndex.toString(),
-				infoText: msg.content,
+				infoText: cleanedContent, // Use cleaned content for infoText as well
 			};
 		});
 	}, [chatHistory]);
-	// Handle history selection
+
 	const handleHistorySelect = useCallback(
 		(value: string) => {
 			const selectedIndex = parseInt(value, 10);
@@ -88,7 +91,7 @@ export function useHistoryNavigation(
 				setShowHistoryMenu(false);
 				onHistorySelect(
 					selectedIndex,
-					selectedMessage.content,
+					cleanIDEContext(selectedMessage.content), // Clean IDE context before passing
 					selectedMessage.images,
 				);
 			}

--- a/source/ui/pages/ChatScreen.tsx
+++ b/source/ui/pages/ChatScreen.tsx
@@ -45,6 +45,7 @@ import {useTerminalSize} from '../../hooks/ui/useTerminalSize.js';
 import {
 	parseAndValidateFileReferences,
 	createMessageWithFileInstructions,
+	cleanIDEContext,
 } from '../../utils/core/fileUtils.js';
 import {vscodeConnection} from '../../utils/ui/vscodeConnection.js';
 import {convertSessionMessagesToUI} from '../../utils/session/sessionConverter.js';
@@ -752,25 +753,23 @@ export default function ChatScreen({autoResume, enableYolo}: Props) {
 						selectedIndex,
 				  )
 				: [];
-
 			snapshotState.setPendingRollback({
 				messageIndex: selectedIndex,
 				fileCount: filePaths.length, // Use actual unique file count
 				filePaths,
-				message, // Save message for restore after rollback
+				message: cleanIDEContext(message), // Clean IDE context before saving
 				images, // Save images for restore after rollback
 			});
 		} else {
 			// No files to rollback, just rollback conversation
 			// Restore message to input buffer (with or without images)
 			setRestoreInputContent({
-				text: message,
+				text: cleanIDEContext(message), // Clean IDE context before restoring
 				images: images,
 			});
 			await performRollback(selectedIndex, false);
 		}
 	};
-
 	const performRollback = async (
 		selectedIndex: number,
 		rollbackFiles: boolean,


### PR DESCRIPTION
## 🎯 问题概述

用户发送消息时系统会自动添加IDE上下文信息（使用└─前缀显示当前文件、光标位置等），导致双击ESC回退时输入框显示包含IDE上下文信息的完整内容。如果直接发送会再次添加一遍ide上下文，故用户需要手动删除，从而造成用户体验不佳。
## 现状
双击esc回退,覆写到用户输入框中的消息
```
帮我重构这个函数
└─ VSCode Workspace: /project
└─ Active File: /src/utils.ts
└─ Cursor: Line 25, Column 10
```
实际只需要回退
```
帮我重构这个函数
```
## 🔧 解决方案

实现统一的IDE上下文清理机制，在历史消息回退的各个关键节点应用清理逻辑。

### 📝 主要修改

1. **新增 cleanIDEContext() 工具函数**
   - 位置：source/utils/core/fileUtils.ts
   - 功能：清理所有以"└─"开头的IDE上下文行

2. **修改历史消息导航逻辑**
   - 文件：source/hooks/input/useHistoryNavigation.ts
   - 在 getUserMessages() 和 handleHistorySelect() 中应用清理

3. **修改聊天屏幕回退逻辑**
   - 文件：source/ui/pages/ChatScreen.tsx
   - 确保回退到输入框的内容不包含IDE上下文


## 📊 影响范围

- ✅ 仅影响消息回退到输入框的显示
- ✅ 不影响消息保存逻辑
- ✅ 不影响IDE上下文信息的正常添加和显示
- ✅ 不影响/resume等会话恢复功能
- ✅ 向后兼容，不破坏现有功能