### PR TITLE
fix:Correctly persist menu state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ out
 .snow
 AGENTS.md
 package.json
-PULL_REQUEST_TEMPLATE.md
-plan&change.md

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -122,6 +122,9 @@ function AppContent({
 	// This ensures configuration changes are picked up
 	const [chatScreenKey, setChatScreenKey] = useState(0);
 
+	// Track the welcome menu index to preserve selection when returning
+	const [welcomeMenuIndex, setWelcomeMenuIndex] = useState(0);
+
 	// Track whether to auto-resume last session (from resume-last menu option)
 	const [shouldAutoResume, setShouldAutoResume] = useState(false);
 
@@ -187,7 +190,12 @@ function AppContent({
 			case 'welcome':
 				return (
 					<Suspense fallback={loadingFallback}>
-						<WelcomeScreen version={version} onMenuSelect={handleMenuSelect} />
+						<WelcomeScreen
+							version={version}
+							onMenuSelect={handleMenuSelect}
+							defaultMenuIndex={welcomeMenuIndex}
+							onMenuSelectionPersist={setWelcomeMenuIndex}
+						/>
 					</Suspense>
 				);
 			case 'chat':
@@ -249,7 +257,12 @@ function AppContent({
 			default:
 				return (
 					<Suspense fallback={loadingFallback}>
-						<WelcomeScreen version={version} onMenuSelect={handleMenuSelect} />
+						<WelcomeScreen
+							version={version}
+							onMenuSelect={handleMenuSelect}
+							defaultMenuIndex={welcomeMenuIndex}
+							onMenuSelectionPersist={setWelcomeMenuIndex}
+						/>
 					</Suspense>
 				);
 		}

--- a/source/ui/pages/HooksConfigScreen.tsx
+++ b/source/ui/pages/HooksConfigScreen.tsx
@@ -20,6 +20,8 @@ import {
 
 type Props = {
 	onBack: () => void;
+	defaultScopeIndex?: number;
+	onScopeSelectionPersist?: (index: number) => void;
 };
 
 type Screen =
@@ -32,7 +34,7 @@ type Screen =
 type RuleField = 'description' | 'matcher';
 type ActionField = 'enabled' | 'type' | 'command' | 'prompt' | 'timeout';
 
-export default function HooksConfigScreen({onBack}: Props) {
+export default function HooksConfigScreen({onBack, defaultScopeIndex = 0, onScopeSelectionPersist}: Props) {
 	const {theme} = useTheme();
 	const {t} = useI18n();
 
@@ -44,6 +46,14 @@ export default function HooksConfigScreen({onBack}: Props) {
 	const [selectedRuleIndex, setSelectedRuleIndex] = useState<number>(-1);
 	const [editingRule, setEditingRule] = useState<HookRule | null>(null);
 	const [selectedHookInfo, setSelectedHookInfo] = useState('');
+
+	// Track the scope menu index for persistence
+	const [scopeMenuIndex, setScopeMenuIndex] = useState(defaultScopeIndex);
+
+	// Sync with parent's defaultScopeIndex when it changes
+	React.useEffect(() => {
+		setScopeMenuIndex(defaultScopeIndex);
+	}, [defaultScopeIndex]);
 
 	// 规则编辑状态
 	const [editingRuleField, setEditingRuleField] = useState<RuleField | null>(
@@ -133,6 +143,7 @@ export default function HooksConfigScreen({onBack}: Props) {
 			<>
 				<Menu
 					options={options}
+					defaultIndex={scopeMenuIndex}
 					onSelect={value => {
 						if (value === 'back') {
 							onBack();
@@ -141,8 +152,14 @@ export default function HooksConfigScreen({onBack}: Props) {
 							setScreen('hook-list');
 						}
 					}}
-					onSelectionChange={infoText => {
+					onSelectionChange={(infoText, value) => {
 						setSelectedHookInfo(infoText);
+						// Find index and persist
+						const index = options.findIndex(opt => opt.value === value);
+						if (index !== -1) {
+							setScopeMenuIndex(index);
+							onScopeSelectionPersist?.(index);
+						}
 					}}
 				/>
 				{selectedHookInfo && (


### PR DESCRIPTION
# fix(ui): 修复菜单返回不保持原选项的问题

## Summary

- 修复从二级菜单返回时，光标重置到第一个选项的问题
- 修复各级子菜单（如 Plan Agent）返回后不保持选中状态

## Changes

### `source/ui/components/Menu.tsx`
- 新增 `defaultIndex?: number` 属性支持受控初始索引
- 调整代码顺序，先计算 `visibleItemCount` 再初始化 state
- `selectedIndex` 和 `scrollOffset` 根据 `defaultIndex` 初始化并居中显示
- 添加 `useEffect` 同步父组件传入的 `defaultIndex` 变化
- 更新 `React.memo` 比较函数包含 `defaultIndex`

### `source/ui/pages/WelcomeScreen.tsx`
- 新增 `defaultMenuIndex?: number` 和 `onMenuSelectionPersist?: (index: number) => void` 属性
- 添加 `currentMenuIndex` 本地状态，与父组件同步
- 添加 `subAgentListIndex` 和 `hooksConfigIndex` 状态管理子菜单索引
- `handleSelectionChange` 和 `handleInlineMenuSelect` 在选择时持久化索引
- `Menu` 组件传入 `defaultIndex={currentMenuIndex}`

### `source/ui/pages/SubAgentListScreen.tsx`
- 新增 `defaultSelectedIndex?: number` 和 `onSelectionPersist?: (index: number) => void` 属性
- 初始化 `selectedIndex` 使用 `defaultSelectedIndex`
- 在上下键导航和进入编辑/添加时调用 `onSelectionPersist`

### `source/ui/pages/HooksConfigScreen.tsx`
- 新增 `defaultScopeIndex?: number` 和 `onScopeSelectionPersist?: (index: number) => void` 属性
- 添加 `scopeMenuIndex` 本地状态并同步
- scope-select 屏幕的 Menu 传入 `defaultIndex={scopeMenuIndex}`

### `source/app.tsx`
- 新增 `welcomeMenuIndex` 状态保存欢迎页菜单索引
- `WelcomeScreen` 传入 `defaultMenuIndex` 和 `onMenuSelectionPersist`

## Test Plan

- [x] 启动 CLI，进入欢迎页，进入二级菜单后返回停留原选项
- [x] 选择「API & Model Settings」，进入后按 Esc 返回，确认光标停留在原选项
- [x] 选择「Sub-Agent Settings」，选择 Plan Agent（第3个），进入后返回，确认停留在 Plan Agent
- [x] 选择「Hooks Settings」，选择 Project Hooks（第2个），进入后返回，确认停留在 Project Hook
