### PR TITLE
feat: 添加Profile快捷切换功能，支持Alt+P快速切换

### DIFF
--- a/source/i18n/lang/en.ts
+++ b/source/i18n/lang/en.ts
@@ -589,6 +589,9 @@ export const en: TranslationKeys = {
 		statusConnected: 'IDE Connected',
 		statusConnectionFailed:
 			'Connection Failed (this will not affect any usage) - Make sure Snow CLI plugin is installed and active in your IDE',
+		// Profile switch
+		profileCurrent: 'Profile',
+		profileSwitchHint: 'switch',
 		// Tool execution
 		toolCall: 'Tool call',
 		toolThinking: 'Thinking',

--- a/source/i18n/lang/es.ts
+++ b/source/i18n/lang/es.ts
@@ -616,6 +616,9 @@ export const es: TranslationKeys = {
 		statusConnected: 'IDE conectado',
 		statusConnectionFailed:
 			'Conexión fallida (esto no afectará ningún uso) - Por favor asegúrate de que el plugin Snow CLI esté instalado y activado en tu IDE',
+		// Profile switch
+		profileCurrent: 'Perfil',
+		profileSwitchHint: 'cambiar',
 		// Tool execution
 		toolCall: 'Llamada de Herramienta',
 		toolThinking: 'Pensamiento',

--- a/source/i18n/lang/ja.ts
+++ b/source/i18n/lang/ja.ts
@@ -577,6 +577,9 @@ export const ja: TranslationKeys = {
 		statusConnected: 'IDE接続済み',
 		statusConnectionFailed:
 			'接続に失敗（これは使用に影響しません） - IDEにSnow CLIプラグインがインストールされ有効になっていることを確認してください',
+		// Profile switch
+		profileCurrent: 'プロファイル',
+		profileSwitchHint: '切替',
 		// Tool execution
 		toolCall: 'ツール呼び出し',
 		toolThinking: '思考',

--- a/source/i18n/lang/ko.ts
+++ b/source/i18n/lang/ko.ts
@@ -566,6 +566,9 @@ export const ko: TranslationKeys = {
 		statusConnected: 'IDE 연결됨',
 		statusConnectionFailed:
 			'연결 실패 (이것은 사용에 영향을 미치지 않습니다) - IDE에 Snow CLI 플러그인이 설치 및 활성화되어 있는지 확인하세요',
+		// Profile switch
+		profileCurrent: '프로필',
+		profileSwitchHint: '전환',
 		// Tool execution
 		toolCall: '도구 호출',
 		toolThinking: '생각',

--- a/source/i18n/lang/zh-TW.ts
+++ b/source/i18n/lang/zh-TW.ts
@@ -559,6 +559,9 @@ export const zhTW: TranslationKeys = {
 		statusConnected: 'IDE 已連線',
 		statusConnectionFailed:
 			'連線失敗（這不會影響任何使用） - 請確保在你的 IDE 中安裝並啟用了 Snow CLI 外掛',
+		// Profile switch
+		profileCurrent: '目前設定檔',
+		profileSwitchHint: '切換',
 		// Tool execution
 		toolCall: '工具呼叫',
 		toolThinking: '思考',

--- a/source/i18n/lang/zh.ts
+++ b/source/i18n/lang/zh.ts
@@ -559,6 +559,9 @@ export const zh: TranslationKeys = {
 		statusConnected: 'IDE 已连接',
 		statusConnectionFailed:
 			'连接失败(这不会影响任何使用) - 请确保在你的 IDE 中安装并激活了 Snow CLI 插件',
+		// Profile switch
+		profileCurrent: '当前配置',
+		profileSwitchHint: '切换',
 		// Tool execution
 		toolCall: '工具调用',
 		toolThinking: '思考',

--- a/source/i18n/types.ts
+++ b/source/i18n/types.ts
@@ -563,6 +563,9 @@ export type TranslationKeys = {
 		statusConnecting: string;
 		statusConnected: string;
 		statusConnectionFailed: string;
+		// Profile switch
+		profileCurrent: string;
+		profileSwitchHint: string;
 		// Tool execution
 		toolCall: string;
 		toolThinking: string;

--- a/source/ui/components/common/StatusLine.tsx
+++ b/source/ui/components/common/StatusLine.tsx
@@ -5,6 +5,10 @@ import {useI18n} from '../../../i18n/index.js';
 import {useTheme} from '../../contexts/ThemeContext.js';
 import {getSimpleMode} from '../../../utils/config/themeConfig.js';
 
+// 根据平台返回快捷键显示文本: Mac 用 ⌥+P, 其他用 Alt+P
+const getProfileShortcut = () =>
+	process.platform === 'darwin' ? '⌥+P' : 'Alt+P';
+
 type VSCodeConnectionStatus =
 	| 'disconnected'
 	| 'connecting'
@@ -54,6 +58,9 @@ type Props = {
 		file: string;
 		timestamp: number;
 	} | null;
+
+	// Profile 信息
+	currentProfileName?: string;
 };
 
 function calculateContextPercentage(contextUsage: ContextUsage): number {
@@ -83,6 +90,7 @@ export default function StatusLine({
 	codebaseProgress,
 	watcherEnabled = false,
 	fileUpdateNotification,
+	currentProfileName,
 }: Props) {
 	const {t} = useI18n();
 	const {theme} = useTheme();
@@ -96,7 +104,8 @@ export default function StatusLine({
 		contextUsage ||
 		codebaseIndexing ||
 		watcherEnabled ||
-		fileUpdateNotification;
+		fileUpdateNotification ||
+		currentProfileName;
 
 	if (!hasAnyStatus) {
 		return null;
@@ -105,6 +114,16 @@ export default function StatusLine({
 	// 简易模式：横向单行显示状态，Token信息单独一行
 	if (simpleMode) {
 		const statusItems: Array<{text: string; color: string}> = [];
+
+		// Profile - 显示在最前面
+		if (currentProfileName) {
+			statusItems.push({
+				text: `⚙ ${currentProfileName} | ${getProfileShortcut()} ${
+					t.chatScreen.profileSwitchHint
+				}`,
+				color: theme.colors.menuInfo,
+			});
+		}
 
 		// YOLO模式
 		if (yoloMode) {
@@ -340,6 +359,16 @@ export default function StatusLine({
 								</>
 							);
 						})()}
+					</Text>
+				</Box>
+			)}
+
+			{/* Profile显示 */}
+			{currentProfileName && (
+				<Box>
+					<Text color={theme.colors.menuInfo} dimColor>
+						⚙ {t.chatScreen.profileCurrent}: {currentProfileName} |{' '}
+						{getProfileShortcut()} {t.chatScreen.profileSwitchHint}
 					</Text>
 				</Box>
 			)}

--- a/source/utils/config/configManager.ts
+++ b/source/utils/config/configManager.ts
@@ -267,6 +267,22 @@ export function switchProfile(profileName: string): void {
 }
 
 /**
+ * Get the next profile name for cycling through profiles
+ * Returns the next profile in alphabetical order, or wraps to the first one
+ */
+export function getNextProfileName(): string {
+	const profiles = getAllProfiles();
+	if (profiles.length <= 1) {
+		return getActiveProfileName();
+	}
+
+	const currentProfile = getActiveProfileName();
+	const currentIndex = profiles.findIndex(p => p.name === currentProfile);
+	const nextIndex = (currentIndex + 1) % profiles.length;
+	return profiles[nextIndex]?.name || profiles[0]?.name || 'default';
+}
+
+/**
  * Create a new profile
  */
 export function createProfile(profileName: string, config?: AppConfig): void {


### PR DESCRIPTION
## 功能描述

添加 Profile 快捷切换功能，用户可以通过 **Alt+P** (Mac: **⌥+P**) 快捷键在多个 Profile 之间快速循环切换。

## 主要改动

### 新增功能
- **快捷键切换**: Alt+P (Mac: ⌥+P) 循环切换 Profile
- **状态栏显示**: 显示当前 Profile 名称和快捷键提示
- **平台适配**: Mac 显示 ⌥+P，其他平台显示 Alt+P
- **多语言支持**: 支持简体中文、英语、西班牙语、日语、韩语、繁体中文

### 安全机制
在以下情况下阻止切换，避免意外操作：
- 面板打开时 (Session/MCP/Usage/Help/CustomCommand/Skills)
- 流式输出进行中
- 工具确认等待中
- 快照回滚确认中

## 修改文件

| 文件 | 说明 |
|------|------|
| `source/utils/config/configManager.ts` | 新增 `getNextProfileName()` 函数 |
| `source/i18n/types.ts` | 添加 i18n 类型定义 |
| `source/i18n/lang/*.ts` | 6种语言翻译 |
| `source/ui/components/common/StatusLine.tsx` | 状态栏显示 Profile 信息 |
| `source/ui/pages/ChatScreen.tsx` | 快捷键监听和状态管理 |

## 截图/演示

状态栏显示效果：
- 简易模式: `⚙ ProfileName | Alt+P switch`
- 标准模式: `⚙ Profile: ProfileName | Alt+P switch`

## 测试

- [x] TypeScript 编译通过
- [x] 构建成功
- [x] 单 Profile 时保持当前 Profile
- [x] 多 Profile 时循环切换正常
- [x] 面板打开时阻止切换
- [x] 流式输出时阻止切换
