### PR TITLE
fix: Fix skill-execute tool displaying character indices in preview

### DIFF
--- a/source/ui/components/tools/ToolResultPreview.tsx
+++ b/source/ui/components/tools/ToolResultPreview.tsx
@@ -42,6 +42,10 @@ export default function ToolResultPreview({
 			return renderACEPreview(toolName, data, maxLines);
 		} else if (toolName.startsWith('todo-')) {
 			return renderTodoPreview(toolName, data, maxLines);
+		} else if (toolName === 'skill-execute') {
+			// skill-execute returns a string message, no preview needed
+			// (the skill content is displayed elsewhere)
+			return null;
 		} else {
 			// Generic preview for unknown tools
 			return renderGenericPreview(data, maxLines);
@@ -444,6 +448,12 @@ function renderWebFetchPreview(data: any) {
 }
 
 function renderGenericPreview(data: any, maxLines: number) {
+	// Guard: if data is not an object (e.g., it's a string), skip preview
+	// This prevents Object.entries from treating strings as character arrays
+	if (typeof data !== 'object' || data === null) {
+		return null;
+	}
+
 	// For unknown tool types, show first few properties
 	const entries = Object.entries(data).slice(0, maxLines);
 	if (entries.length === 0) return null;


### PR DESCRIPTION
## Summary
Fix the bug where `skill-execute` tool preview displays character indices (0: <, 1: c, 2: o...) instead of proper output.

## Problem
When calling `skill-execute`, the tool result preview showed:
```
⚙ √ skill-execute
└ skill: "frontend-design"
  - 0: <
  - 1: c
  - 2: o
  - 3: m
  - 4: m
```

This happened because `skill-execute` returns a plain string (starting with `<command-message>...`), and `renderGenericPreview` was calling `Object.entries()` on it, which treats strings as character arrays.

## Solution
1. Add explicit handling for `skill-execute` tool - return `null` (no preview needed since skill content is displayed elsewhere)
2. Add type guard in `renderGenericPreview` to skip non-object data, preventing similar issues with other tools

## Testing
- Restarted Snow CLI after build
- Verified `skill-execute` no longer shows character indices
