### PR TITLE
fix(codebase): support Ollama /v1/embeddings and /api/embed

### DIFF
--- a/docs/usage/en/04.Codebase Setup.md
+++ b/docs/usage/en/04.Codebase Setup.md
@@ -8,11 +8,14 @@ Snow CLI supports enabling local codebase functionality.
 
 _The codebase is a vector search-based SQLite database used to store source code and comments from your codebase, with natural language query capabilities through vectorization._
 
-- The codebase supports two request schemes: Jina (OpenAI request scheme) and Ollama local request scheme.
+- The codebase supports two request schemes: Jina (OpenAI-compatible) and Ollama (local deployment, supports both OpenAI-compatible `/v1/embeddings` and native `/api/embed`).
 
-- Codebase BaseURL: For Jina configuration, refer to: `https://api.jina.ai/v1`. The application will automatically append `/embeddings` at the end. Similarly, the Ollama request type will automatically append `/embed` at the end.
+- Codebase BaseURL (multiple forms supported; Snow CLI will auto-normalize to the final endpoint):
 
-- Embedding Dimensions: Enter the correct dimensions supported by your embedding model.
+  - Jina (OpenAI-compatible) supports: `https://api.jina.ai`, `https://api.jina.ai/v1`, `https://api.jina.ai/v1/embeddings` (final request: `.../v1/embeddings`).
+  - Ollama supports: `http://localhost:11434`, `http://localhost:11434/v1`, `http://localhost:11434/v1/embeddings` (OpenAI-compatible); and `http://localhost:11434/api`, `http://localhost:11434/api/embed` (Ollama native).
+
+- Embedding Dimensions: Enter the dimensions supported by your embedding model. Some providers may ignore the `dimensions` parameter; Snow CLI will log a warning if the returned dimensions don’t match.
 
 **Note: Maximum batch lines refers to the number of `input` items in the request body, not the number of lines in code slices**
 

--- a/docs/usage/zh/04.代码库设置.md
+++ b/docs/usage/zh/04.代码库设置.md
@@ -8,11 +8,14 @@ Snow CLI 支持启用本地代码库功能。
 
 _代码库是一个基于向量搜索的 Sqlite 数据库，用于存储代码库的源代码和注释。并通过向量化自然语言查询。_
 
-- 代码库支持两种请求方案:Jina（即 OpenAI 请求方案）和 Ollama 本地请求方案。
+- 代码库支持两种请求方案：Jina（OpenAI 兼容）和 Ollama（本地部署，支持 OpenAI 兼容 `/v1/embeddings` 与原生 `/api/embed`）。
 
-- 代码库的 BaseURL: Jina 配置参考：`https://api.jina.ai/v1` 应用会自动补全末尾的`/embeddings`，同理 Ollama 请求类型会自动补全末尾的`/embed`。
+- 代码库的 BaseURL（支持多种写法，程序会自动补全/规范化到最终端点）：
 
-- 嵌入维度：嵌入模型支持的维度正确填写即可
+  - Jina（OpenAI 兼容）支持：`https://api.jina.ai`、`https://api.jina.ai/v1`、`https://api.jina.ai/v1/embeddings`（最终请求 `.../v1/embeddings`）。
+  - Ollama 支持：`http://localhost:11434`、`http://localhost:11434/v1`、`http://localhost:11434/v1/embeddings`（OpenAI 兼容）；以及 `http://localhost:11434/api`、`http://localhost:11434/api/embed`（Ollama 原生）。
+
+- 嵌入维度：填写嵌入模型支持的维度即可；部分服务可能忽略 `dimensions` 参数，若返回维度不一致会在日志中提示。
 
 **注意：批处理最大行数代表请求体中的 `input` 数，而非代码切片的行数**
 

--- a/source/api/embedding.ts
+++ b/source/api/embedding.ts
@@ -1,4 +1,5 @@
 import {loadCodebaseConfig} from '../utils/config/codebaseConfig.js';
+import {logger} from '../utils/core/logger.js';
 import {addProxyToFetchOptions} from '../utils/core/proxyUtils.js';
 import {getVersionHeader} from '../utils/core/version.js';
 
@@ -25,12 +26,183 @@ export interface EmbeddingResponse {
 	}>;
 }
 
+type OllamaEmbeddingsMode = 'openai' | 'ollama';
+
 interface OllamaEmbeddingResponse {
 	model: string;
 	embeddings: number[][];
 	total_duration?: number;
 	load_duration?: number;
 	prompt_eval_count?: number;
+}
+
+function isOpenAIEmbeddingsResponse(data: any): data is EmbeddingResponse {
+	return (
+		Boolean(data) &&
+		data.object === 'list' &&
+		Array.isArray(data.data) &&
+		data.data.every(
+			(item: any) =>
+				Boolean(item) &&
+				item.object === 'embedding' &&
+				typeof item.index === 'number' &&
+				Array.isArray(item.embedding),
+		)
+	);
+}
+
+function isOllamaEmbedResponse(data: any): data is OllamaEmbeddingResponse {
+	return (
+		Boolean(data) &&
+		typeof data.model === 'string' &&
+		Array.isArray(data.embeddings)
+	);
+}
+
+export function resolveOllamaEmbeddingsEndpoint(baseUrl: string): {
+	url: string;
+	mode: OllamaEmbeddingsMode;
+} {
+	const trimmed = baseUrl.trim().replace(/\/+$/, '');
+
+	if (trimmed.endsWith('/v1/embeddings')) {
+		return {url: trimmed, mode: 'openai'};
+	}
+
+	if (trimmed.endsWith('/api/embed')) {
+		return {url: trimmed, mode: 'ollama'};
+	}
+
+	if (trimmed.endsWith('/v1')) {
+		return {url: `${trimmed}/embeddings`, mode: 'openai'};
+	}
+
+	if (trimmed.endsWith('/api')) {
+		return {url: `${trimmed}/embed`, mode: 'ollama'};
+	}
+
+	// If the user passes a fully-qualified endpoint, try to infer mode.
+	if (trimmed.endsWith('/embeddings')) {
+		return {url: trimmed, mode: 'openai'};
+	}
+
+	if (trimmed.endsWith('/embed')) {
+		return {url: trimmed, mode: 'ollama'};
+	}
+
+	// Default to OpenAI-compatible endpoint for better interoperability.
+	return {url: `${trimmed}/v1/embeddings`, mode: 'openai'};
+}
+
+function resolveOpenAICompatibleEmbeddingsEndpoint(baseUrl: string): string {
+	const trimmed = baseUrl.trim().replace(/\/+$/, '');
+
+	if (trimmed.endsWith('/v1/embeddings')) {
+		return trimmed;
+	}
+
+	// Allow users to pass a fully-qualified endpoint.
+	if (trimmed.endsWith('/embeddings')) {
+		return trimmed;
+	}
+
+	if (trimmed.endsWith('/v1')) {
+		return `${trimmed}/embeddings`;
+	}
+
+	// Most OpenAI-compatible providers use /v1/embeddings.
+	return `${trimmed}/v1/embeddings`;
+}
+
+function warnOnDimensionMismatch(params: {
+	expectedDimensions?: number;
+	actualDimensions?: number;
+	model: string;
+	url: string;
+	mode: OllamaEmbeddingsMode;
+}): void {
+	const {expectedDimensions, actualDimensions, model, url, mode} = params;
+
+	if (!expectedDimensions || !actualDimensions) {
+		return;
+	}
+
+	if (expectedDimensions === actualDimensions) {
+		return;
+	}
+
+	logger.warn(
+		`Embedding dimension mismatch (expected ${expectedDimensions}, got ${actualDimensions}). Some providers ignore 'dimensions'.`,
+		{
+			model,
+			url,
+			mode,
+			expectedDimensions,
+			actualDimensions,
+		},
+	);
+}
+
+function normalizeOllamaResponse(params: {
+	data: unknown;
+	mode: OllamaEmbeddingsMode;
+	model: string;
+	expectedDimensions?: number;
+	url: string;
+}): EmbeddingResponse {
+	const {data, mode, model, expectedDimensions, url} = params;
+
+	// Some Ollama deployments return OpenAI-compatible format from /v1/embeddings.
+	if (isOpenAIEmbeddingsResponse(data)) {
+		const actualDimensions =
+			Array.isArray(data.data) && data.data.length > 0
+				? data.data[0]?.embedding?.length
+				: undefined;
+
+		warnOnDimensionMismatch({
+			expectedDimensions,
+			actualDimensions,
+			model,
+			url,
+			mode,
+		});
+
+		return data;
+	}
+
+	// Ollama native response format from /api/embed.
+	if (isOllamaEmbedResponse(data)) {
+		const actualDimensions =
+			Array.isArray(data.embeddings) && data.embeddings.length > 0
+				? data.embeddings[0]?.length
+				: undefined;
+
+		warnOnDimensionMismatch({
+			expectedDimensions,
+			actualDimensions,
+			model,
+			url,
+			mode,
+		});
+
+		return {
+			model: data.model,
+			object: 'list',
+			usage: {
+				total_tokens: data.prompt_eval_count || 0,
+				prompt_tokens: data.prompt_eval_count || 0,
+			},
+			data: data.embeddings.map((embedding, index) => ({
+				object: 'embedding',
+				index,
+				embedding,
+			})),
+		};
+	}
+
+	throw new Error(
+		`Unexpected Ollama embeddings response format from ${url}. Try setting baseUrl to http://localhost:11434 (or /v1 for OpenAI-compatible mode).`,
+	);
 }
 
 /**
@@ -86,17 +258,15 @@ export async function createEmbeddings(
 	// Determine endpoint based on provider type
 	const embeddingType = config.embedding.type || 'jina';
 	let url: string;
+	let ollamaMode: OllamaEmbeddingsMode | undefined;
 
 	if (embeddingType === 'ollama') {
-		// Ollama uses /embed endpoint
-		url = baseUrl.endsWith('/embed')
-			? baseUrl
-			: `${baseUrl.replace(/\/$/, '')}/embed`;
+		const resolved = resolveOllamaEmbeddingsEndpoint(baseUrl);
+		url = resolved.url;
+		ollamaMode = resolved.mode;
 	} else {
-		// Jina uses /embeddings endpoint
-		url = baseUrl.endsWith('/embeddings')
-			? baseUrl
-			: `${baseUrl.replace(/\/$/, '')}/embeddings`;
+		// Jina/OpenAI-compatible embeddings endpoint
+		url = resolveOpenAICompatibleEmbeddingsEndpoint(baseUrl);
 	}
 
 	// Build headers - only include Authorization if API key is provided
@@ -123,22 +293,14 @@ export async function createEmbeddings(
 
 	const data = await response.json();
 
-	// Convert Ollama response format to unified format
 	if (embeddingType === 'ollama') {
-		const ollamaData = data as OllamaEmbeddingResponse;
-		return {
-			model: ollamaData.model,
-			object: 'list',
-			usage: {
-				total_tokens: ollamaData.prompt_eval_count || 0,
-				prompt_tokens: ollamaData.prompt_eval_count || 0,
-			},
-			data: ollamaData.embeddings.map((embedding, index) => ({
-				object: 'embedding',
-				index,
-				embedding,
-			})),
-		};
+		return normalizeOllamaResponse({
+			data,
+			mode: ollamaMode || 'openai',
+			model,
+			expectedDimensions: dimensions,
+			url,
+		});
 	}
 
 	return data as EmbeddingResponse;


### PR DESCRIPTION
## Summary

- Normalize embeddings endpoint URLs for codebase configuration.
- Support Ollama OpenAI-compatible `/v1/embeddings` and native `/api/embed`.
- Warn when the returned embedding dimensions don’t match the config.

## Changes

- `source/api/embedding.ts`: endpoint resolution + response normalization (OpenAI-compatible + Ollama native).
- `docs/usage/en/04.Codebase Setup.md`: clarify supported BaseURL formats.
- `docs/usage/zh/04.代码库设置.md`: 同步更新 BaseURL 支持范围说明。

## Notes

- This PR only includes the currently-staged changes.
