### PR TITLE
fix: MCP HTTP服务连接问题修复

### DIFF
--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -68,6 +68,10 @@ async function loadDependencies() {
 	// Import utils/index.js to register all commands (side-effect import)
 	await import('./utils/index.js');
 
+	//初始化全局代理（让MCP HTTP请求走代理）
+	const {initGlobalProxy} = await import('./utils/core/proxyUtils.js');
+	initGlobalProxy();
+
 	const [
 		appModule,
 		vscodeModule,


### PR DESCRIPTION
## Summary
- 添加 `Accept: application/json, text/event-stream` 头，修复 deepwiki/github 等 SSE 服务连接失败
- 修复 `getPersistentClient` 缺少 headers 和认证头的问题
- 增加 HTTP 服务探测超时时间 (3s → 15s)
- 添加全局代理支持，自动检测系统环境变量 `https_proxy`/`HTTP_PROXY`

## Test plan
- [x] deepwiki MCP 服务连接成功
- [x] github MCP 服务连接成功
- [x] 代理环境下 HTTP MCP 服务正常工作