### PR TITLE
fix: 修复AI模型错误合并工具名称的问题

### DIFF
--- a/source/utils/execution/mcpToolsManager.ts
+++ b/source/utils/execution/mcpToolsManager.ts
@@ -108,6 +108,47 @@ export function getTodoService(): TodoService {
 }
 
 /**
+ * Get all registered service prefixes (synchronous)
+ * Used for detecting merged tool names
+ * Returns cached service names if available, otherwise returns built-in services
+ */
+export function getRegisteredServicePrefixes(): string[] {
+	// 内置服务前缀（始终可用）
+	const builtInPrefixes = [
+		'todo-',
+		'notebook-',
+		'filesystem-',
+		'terminal-',
+		'ace-',
+		'websearch-',
+		'ide-',
+		'codebase-',
+		'askuser-',
+		'skill-',
+		'subagent-',
+	];
+
+	// 如果有缓存，从缓存中获取外部 MCP 服务名称
+	if (toolsCache?.servicesInfo) {
+		const cachedPrefixes = toolsCache.servicesInfo
+			.map(s => `${s.serviceName}-`)
+			.filter(p => !builtInPrefixes.includes(p));
+		return [...builtInPrefixes, ...cachedPrefixes];
+	}
+
+	// 尝试从 MCP 配置中获取外部服务名称
+	try {
+		const mcpConfig = getMCPConfig();
+		const externalPrefixes = Object.keys(mcpConfig.mcpServers || {}).map(
+			name => `${name}-`,
+		);
+		return [...builtInPrefixes, ...externalPrefixes];
+	} catch {
+		return builtInPrefixes;
+	}
+}
+
+/**
  * Generate a hash of the current MCP configuration and sub-agents
  */
 async function generateConfigHash(): Promise<string> {


### PR DESCRIPTION
## 问题描述

当AI模型错误地将两个工具名称合并在一起时（如 `ace-semantic_searchdesktop-commander-start_search`），系统会抛出 `Unknown ACE tool` 或 JSON 解析错误，导致工具调用失败。

## 修复内容

### 1. 添加 `fixMergedToolName()` 函数
- 检测工具名称中是否包含多个已知服务前缀
- 如果检测到合并，提取第一个有效的工具名称
- 输出警告日志帮助调试

### 2. 添加 `getRegisteredServicePrefixes()` 函数
- 动态获取所有已注册的服务前缀
- 包含内置服务（todo-, filesystem-, ace- 等）
- 支持用户自定义的 MCP 服务前缀

### 3. 使用 `safeParseToolArguments()` 替换直接的 `JSON.parse()` 调用
- 修复 `toolExecutor.ts` 中第324行未保护的 JSON.parse 调用

## 效果

修复前：
```
Error: Unknown ACE tool: semantic_searchdesktop-commander-start_search
```

修复后：
```
[Tool Name Fix] Detected merged tool names: "ace-semantic_searchdesktop-commander-start_search"
[Tool Name Fix] Extracted first tool: "ace-semantic_search"
[Tool Name Fix] Ignored second tool starting at: "desktop-commander-start_search"
✓ ace-semantic_search 执行成功
```

## 测试

- [x] TypeScript 编译通过
- [x] 实际测试验证修复生效