### PR TITLE
Fix: 修复 Windows 下 hook 脚本编码问题

### DIFF
--- a/source/utils/execution/unifiedHooksExecutor.ts
+++ b/source/utils/execution/unifiedHooksExecutor.ts
@@ -405,6 +405,10 @@ export class UnifiedHooksExecutor {
 				maxBuffer: this.maxOutputLength,
 				env: {
 					...process.env,
+					// Windows 下设置 UTF-8 编码
+					...(process.platform === 'win32' && {
+						PYTHONIOENCODING: 'utf-8',
+					}),
 					// Windows 下不需要设置 LANG
 					...(process.platform !== 'win32' && {
 						LANG: 'en_US.UTF-8',


### PR DESCRIPTION
## 问题描述

在 Windows 系统下执行 hook 脚本时，控制台输出可能出现中文乱码问题。

## 修复方案

- 在 Windows 上设置 `PYTHONIOENCODING='utf-8'` 环境变量
- 解决 Windows 控制台编码不一致导致的乱码问题

## 测试

- ✅ Windows 下 hook 脚本输出正常，中文显示无乱码
- ✅ 非 Windows 系统（Linux/macOS）使用 `LANG` 和 `LC_ALL` 环境变量，保持原有行为
