### PR TITLE
修复：重试消息和用户中断消息的国际化

### DIFF
--- a/source/ui/components/chat/LoadingIndicator.tsx
+++ b/source/ui/components/chat/LoadingIndicator.tsx
@@ -97,18 +97,28 @@ export default function LoadingIndicator({
 							<Box flexDirection="column">
 								{retryStatus.errorMessage && (
 									<Text color="red" dimColor>
-										✗ Error: {retryStatus.errorMessage}
+										{t.chatScreen.retryError.replace(
+											'{message}',
+											retryStatus.errorMessage,
+										)}
 									</Text>
 								)}
 								{retryStatus.remainingSeconds !== undefined &&
 								retryStatus.remainingSeconds > 0 ? (
 									<Text color="yellow" dimColor>
-										⟳ Retry {retryStatus.attempt}/5 in{' '}
-										{retryStatus.remainingSeconds}s...
+										{t.chatScreen.retryAttempt
+											.replace('{current}', String(retryStatus.attempt))
+											.replace('{max}', '5')}{' '}
+										{t.chatScreen.retryIn.replace(
+											'{seconds}',
+											String(retryStatus.remainingSeconds),
+										)}
 									</Text>
 								) : (
 									<Text color="yellow" dimColor>
-										⟳ Resending... (Attempt {retryStatus.attempt}/5)
+										{t.chatScreen.retryResending
+											.replace('{current}', String(retryStatus.attempt))
+											.replace('{max}', '5')}
 									</Text>
 								)}
 							</Box>

--- a/source/ui/components/chat/MessageList.tsx
+++ b/source/ui/components/chat/MessageList.tsx
@@ -2,6 +2,7 @@ import React, {memo} from 'react';
 import {Box, Text} from 'ink';
 import {SelectedFile} from '../../../utils/core/fileUtils.js';
 import MarkdownRenderer from '../common/MarkdownRenderer.js';
+import {useI18n} from '../../../i18n/I18nContext.js';
 
 export interface Message {
 	role: 'user' | 'assistant' | 'command' | 'subagent';
@@ -78,6 +79,7 @@ const STREAM_COLORS = ['#FF6EBF', 'green', 'blue', 'cyan', '#B588F8'] as const;
 
 const MessageList = memo(
 	({messages, animationFrame, maxMessages = 6}: Props) => {
+		const {t} = useI18n();
 		if (messages.length === 0) {
 			return null;
 		}
@@ -240,7 +242,7 @@ const MessageList = memo(
 											)}
 										{message.discontinued && (
 											<Text color="red" bold>
-												└─ user discontinue
+												{t.chatScreen.discontinuedMessage}
 											</Text>
 										)}
 									</>

--- a/source/ui/components/chat/MessageRenderer.tsx
+++ b/source/ui/components/chat/MessageRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Box, Text} from 'ink';
 import {useTheme} from '../../contexts/ThemeContext.js';
+import {useI18n} from '../../../i18n/I18nContext.js';
 import {type Message} from './MessageList.js';
 import MarkdownRenderer from '../common/MarkdownRenderer.js';
 import DiffViewer from '../tools/DiffViewer.js';
@@ -25,6 +26,7 @@ export default function MessageRenderer({
 	showThinking = true,
 }: Props) {
 	const {theme} = useTheme();
+	const {t} = useI18n();
 
 	// Helper function to remove ANSI escape codes
 	const removeAnsiCodes = (text: string): string => {
@@ -439,7 +441,7 @@ export default function MessageRenderer({
 										)}
 									{message.discontinued && (
 										<Text color="red" bold>
-											└─ user discontinue
+											{t.chatScreen.discontinuedMessage}
 										</Text>
 									)}
 								</>

--- a/source/ui/pages/HeadlessModeScreen.tsx
+++ b/source/ui/pages/HeadlessModeScreen.tsx
@@ -10,6 +10,7 @@ import {useToolConfirmation} from '../../hooks/conversation/useToolConfirmation.
 import {useVSCodeState} from '../../hooks/integration/useVSCodeState.js';
 import {useSessionSave} from '../../hooks/session/useSessionSave.js';
 import {sessionManager} from '../../utils/session/sessionManager.js';
+import {useI18n} from '../../i18n/I18nContext.js';
 import {
 	parseAndValidateFileReferences,
 	createMessageWithFileInstructions,
@@ -357,6 +358,7 @@ export default function HeadlessModeScreen({
 	const [isWaitingForInput, setIsWaitingForInput] = useState(false);
 	const {stdout} = useStdout();
 	const workingDirectory = process.cwd();
+	const {t} = useI18n();
 
 	// Use custom hooks
 	const streamingState = useStreamingState();
@@ -435,7 +437,10 @@ export default function HeadlessModeScreen({
 				// Show retry status with colors
 				if (streamingState.retryStatus.errorMessage) {
 					console.log(
-						`\n\x1b[31m✗ Error: ${streamingState.retryStatus.errorMessage}\x1b[0m`,
+						`\n\x1b[31m${t.chatScreen.retryError.replace(
+							'{message}',
+							streamingState.retryStatus.errorMessage,
+						)}\x1b[0m`,
 					);
 				}
 				if (
@@ -443,11 +448,18 @@ export default function HeadlessModeScreen({
 					streamingState.retryStatus.remainingSeconds > 0
 				) {
 					console.log(
-						`\n\x1b[93m⟳ Retry \x1b[33m${streamingState.retryStatus.attempt}/5\x1b[93m in \x1b[32m${streamingState.retryStatus.remainingSeconds}s\x1b[93m...\x1b[0m`,
+						`\n\x1b[93m${t.chatScreen.retryAttempt
+							.replace('{current}', String(streamingState.retryStatus.attempt))
+							.replace('{max}', '5')} \x1b[93m${t.chatScreen.retryIn.replace(
+							'{seconds}',
+							String(streamingState.retryStatus.remainingSeconds),
+						)}\x1b[93m...\x1b[0m`,
 					);
 				} else {
 					console.log(
-						`\n\x1b[93m⟳ Resending... \x1b[33m(Attempt ${streamingState.retryStatus.attempt}/5)\x1b[0m`,
+						`\n\x1b[93m${t.chatScreen.retryResending
+							.replace('{current}', String(streamingState.retryStatus.attempt))
+							.replace('{max}', '5')}\x1b[0m`,
 					);
 				}
 			} else {
@@ -469,6 +481,7 @@ export default function HeadlessModeScreen({
 		streamingState.streamTokenCount,
 		streamingState.retryStatus,
 		isWaitingForInput,
+		t,
 	]);
 	const processMessage = async () => {
 		try {


### PR DESCRIPTION
## 📋 概述

修复重试消息和用户中断消息的国际化问题，将硬编码的英文文本替换为多语言支持。

## 🎯 修改内容

### 1. LoadingIndicator.tsx
- ✅ 替换硬编码的重试错误消息为国际化翻译
- ✅ 使用 `t.chatScreen.retryError`, `t.chatScreen.retryAttempt`, `t.chatScreen.retryIn`, `t.chatScreen.retryResending`

### 2. HeadlessModeScreen.tsx
- ✅ 添加 `useI18n` 导入和初始化
- ✅ 替换控制台输出中的硬编码重试消息为国际化翻译
- ✅ 将 `t` 添加到 useEffect 依赖数组

### 3. MessageList.tsx
- ✅ 添加 `useI18n` 初始化
- ✅ 替换硬编码的用户中断消息为国际化翻译

### 4. MessageRenderer.tsx
- ✅ 添加 `useI18n` 导入和初始化
- ✅ 替换硬编码的用户中断消息为国际化翻译

## 🔧 修复的翻译键

| 翻译键 | 英文 | 中文 | 繁中 |
|--------|------|------|------|
| `retryError` | `✗ Error: {message}` | `✗ 错误: {message}` | `✗ 錯誤: {message}` |
| `retryAttempt` | `Retry {current}/{max}` | `重试 {current}/{max}` | `重試 {current}/{max}` |
| `retryIn` | `in {seconds}s...` | `{seconds}秒后...` | `{seconds}秒後...` |
| `retryResending` | `⟳ Resending... (Attempt {current}/{max})` | `⟳ 重新发送... (尝试 {current}/{max})` | `⟳ 重新發送... (嘗試 {current}/{max})` |
| `discontinuedMessage` | `└─ user discontinue` | `└─ 用户中断` | `└─ 使用者中斷` |

## ✅ 测试验证

- ✅ 构建成功 (`npm run build`)
- ✅ TypeScript 类型检查通过
- ✅ 代码审核通过
- ✅ 符合项目规范

## 📝 影响

现在重试和用户中断消息会根据用户的语言设置显示相应的中文或英文文本，提升用户体验。

## 📦 变更文件

- `source/ui/components/chat/LoadingIndicator.tsx`
- `source/ui/components/chat/MessageList.tsx`
- `source/ui/components/chat/MessageRenderer.tsx`
- `source/ui/pages/HeadlessModeScreen.tsx`