### PR TITLE
fix: 修复baseUrl末尾斜杠导致的双斜杠问题

### DIFF
--- a/source/api/anthropic.ts
+++ b/source/api/anthropic.ts
@@ -578,10 +578,12 @@ export async function* createStreamingAnthropicCompletion(
 			// }
 
 			// Use configured baseUrl or default Anthropic URL
-			const baseUrl =
+			//移除末尾斜杠，避免拼接时出现双斜杠（如 /v1//messages）
+			const baseUrl = (
 				config.baseUrl && config.baseUrl !== 'https://api.openai.com/v1'
 					? config.baseUrl
-					: 'https://api.anthropic.com/v1';
+					: 'https://api.anthropic.com/v1'
+			).replace(/\/+$/, '');
 
 			const url = config.anthropicBeta
 				? `${baseUrl}/messages?beta=true`


### PR DESCRIPTION
## Summary
- 修复当用户配置的 baseUrl 末尾带斜杠时（如 `https://xxx.com/v1/`），拼接 `/messages` 会产生双斜杠（`/v1//messages`）导致 404 错误的问题
- 自动移除 baseUrl 末尾的斜杠

## Test plan
- [x] 配置末尾带斜杠的 baseUrl，验证请求 URL 正确
- [x] 配置末尾不带斜杠的 baseUrl，验证请求 URL 正确
- [x] 使用默认 Anthropic API 地址，验证请求正常