### PR TITLE
修复终端输出显示的渲染抖动问题

### DIFF
--- a/source/ui/components/bash/BashCommandConfirmation.tsx
+++ b/source/ui/components/bash/BashCommandConfirmation.tsx
@@ -82,7 +82,7 @@ export function BashCommandConfirmation({
 	}, [command, sensitiveCheck.isSensitive]);
 
 	// Calculate max command display width (leave space for padding and borders)
-	const maxCommandWidth = Math.max(40, terminalWidth - 10);
+	const maxCommandWidth = Math.max(40, terminalWidth - 20);
 	const displayCommand = truncateCommand(command, maxCommandWidth);
 
 	return (
@@ -133,12 +133,15 @@ interface BashCommandExecutionStatusProps {
 
 /**
  * Truncate text to prevent overflow
+ * Strips leading/trailing whitespace and normalizes tabs to prevent render jitter
  */
 function truncateText(text: string, maxWidth: number = 80): string {
-	if (text.length <= maxWidth) {
-		return text;
+	// Normalize: trim and replace tabs with spaces (tab width varies in terminals)
+	const normalized = text.trim().replace(/\t/g, '  ');
+	if (normalized.length <= maxWidth) {
+		return normalized;
 	}
-	return text.slice(0, maxWidth - 3) + '...';
+	return normalized.slice(0, maxWidth - 3) + '...';
 }
 
 export function BashCommandExecutionStatus({
@@ -152,7 +155,7 @@ export function BashCommandExecutionStatus({
 	const timeoutSeconds = Math.round(timeout / 1000);
 
 	// Calculate max command display width (leave space for padding and borders)
-	const maxCommandWidth = Math.max(40, terminalWidth - 10);
+	const maxCommandWidth = Math.max(40, terminalWidth - 20);
 	const displayCommand = truncateCommand(command, maxCommandWidth);
 
 	// Process output: split by newlines and limit total lines


### PR DESCRIPTION
## 问题描述

在 Windows 平台上，实时显示命令运行效果时会出现渲染抖动。

## 可能原因

制表符在不同平台的终端中显示宽度不一致：
- **字符长度计算**：`text.length` 中制表符只算 1 个字符
- **实际显示宽度**：终端显示时制表符可能占 4-8 列宽度
- **平台差异**：Windows 终端对制表符的对齐计算与 macOS 有细微差异
- **结果**：截取后实际显示宽度不稳定，导致渲染抖动

## 解决方案

### 1. 标准化空白符处理（truncateText 函数）
```typescript
function truncateText(text: string, maxWidth: number = 80): string {
	// Normalize: trim and replace tabs with spaces (tab width varies in terminals)
	const normalized = text.trim().replace(/\t/g, '  ');
	if (normalized.length <= maxWidth) {
		return normalized;
	}
	return normalized.slice(0, maxWidth - 3) + '...';
}
```

- 使用 `trim()` 去除首尾空白符
- 将制表符统一替换为 2 个空格
- 在标准化后的文本上进行长度计算和截取

### 2. 调整命令显示最大宽度
- 从 `terminalWidth - 10` 改为 `terminalWidth - 20`
- 给边框和 padding 预留更多空间，以防内容被挤压

## 影响范围

- `BashCommandConfirmation` 组件
- `BashCommandExecutionStatus` 组件

## 相关文件

- `source/ui/components/bash/BashCommandConfirmation.tsx`