### PR TITLE
bufix: fix codebase and terminal execute confict.

### DIFF
--- a/source/agents/codebaseIndexAgent.ts
+++ b/source/agents/codebaseIndexAgent.ts
@@ -351,23 +351,34 @@ export class CodebaseIndexAgent {
 		}
 
 		try {
-			// Use chokidar for better cross-platform performance and reliability
-			// Reuse existing ignoreFilter to keep consistency with scanFiles
-			this.fileWatcher = chokidar.watch(this.projectRoot, {
-				ignored: (filePath: string) => {
-					const relativePath = path.relative(this.projectRoot, filePath);
-					// Skip empty paths (the root directory itself) and check ignore filter
-					if (!relativePath || relativePath === '.') {
-						return false;
-					}
-					return this.ignoreFilter.ignores(relativePath);
-				},
-				ignoreInitial: true, // Don't trigger events for initial scan
-				awaitWriteFinish: {
-					stabilityThreshold: 1000, // Wait 1s after last change
-					pollInterval: 100,
-				},
+			// Use glob patterns to only watch code files, reducing file descriptor usage
+			const patterns = Array.from(CodebaseIndexAgent.CODE_EXTENSIONS).map(
+				ext => path.join(this.projectRoot, '**', `*${ext}`),
+			);
+
+			this.fileWatcher = chokidar.watch(patterns, {
+				ignored: [
+					'**/node_modules/**',
+					'**/.git/**',
+					'**/.snow/**',
+					'**/dist/**',
+					'**/build/**',
+					'**/out/**',
+					'**/coverage/**',
+					'**/.next/**',
+					'**/.nuxt/**',
+					'**/.cache/**',
+					'**/*.min.js',
+					'**/*.min.css',
+					'**/*.map',
+					'**/package-lock.json',
+					'**/yarn.lock',
+					'**/pnpm-lock.yaml',
+				],
+				ignoreInitial: true,
 				persistent: true,
+				depth: 20,
+				// Removed awaitWriteFinish - using debounce instead to reduce polling overhead
 			});
 
 			// Handle file added or changed

--- a/source/mcp/bash.ts
+++ b/source/mcp/bash.ts
@@ -8,6 +8,7 @@ import {
 } from './utils/bash/security.utils.js';
 import {processManager} from '../utils/core/processManager.js';
 import {appendTerminalOutput} from '../hooks/execution/useTerminalExecutionState.js';
+import {logger} from '../utils/core/logger.js';
 
 // Global flag to track if command should be moved to background
 let shouldMoveToBackground = false;
@@ -172,6 +173,18 @@ export class TerminalCommandService {
 
 				childProcess.on('error', error => {
 					clearInterval(backgroundCheckInterval);
+
+					// Enhanced error logging for debugging spawn failures
+					const errnoError = error as NodeJS.ErrnoException;
+					logger.error('Spawn process failed', {
+						command,
+						errorMessage: error.message,
+						errorCode: errnoError.code,
+						errno: errnoError.errno,
+						syscall: errnoError.syscall,
+						cwd: this.workingDirectory,
+					});
+
 					// Update process status
 					if (backgroundProcessId) {
 						import('../hooks/execution/useBackgroundProcesses.js')


### PR DESCRIPTION
### 问题背景

  感谢repo主开发的snow-cli, 帮我解决了大量的问题。当我在较大项目里（比如 https://github.com/jd-opensource/xllm 这个项目有超过3000个文件）使用snow-cli 时发现当 snow-cli 的 codebase 功能（语义代码搜索）启用时，`terminal_execute` MCP 工具执行任何命令都会失败。关闭 codebase 功能后可恢复正常。删除 `.snow/codebase/embeddings.db` 有一定概率可以恢复执行。

  ### 根本原因分析

  定位了以下三个问题：

  1. **chokidar 文件监视器配置不当**
     - `chokidar.watch(this.projectRoot)` 监视整个项目根目录，对于大型代码库（31000+ 文件）会占用大量文件描述符
     - `awaitWriteFinish` 高频轮询（100ms）可能与 `spawn` 的 stdio 管道产生竞争

  2. **sql.js WASM 模块重复加载**
     - 每次刷新 MCP 工具缓存都会调用 `initSqlJs()`，可能加载多个 WASM 实例

  3. **spawn 错误日志不完善**
     - 错误处理未记录详细错误码（如 EBADF、EMFILE），难以诊断

  ### 解决方案

  #### 1. 优化 chokidar 配置 (`source/agents/codebaseIndexAgent.ts`)

  - 使用 glob 模式只监视代码文件：`['**/*.ts', '**/*.js', '**/*.py', ...]`
  - 添加 `depth: 20` 限制监视深度
  - 移除 `awaitWriteFinish`（已有 debounce 机制）
  - 显式忽略更多目录（node_modules、.git、.snow 等）

  #### 2. sql.js 单例模式 (`source/utils/codebase/codebaseDatabase.ts`)

  - 添加模块级 `sqlJsStatic` 和 `sqlJsInitPromise` 变量
  - 实现 `getSqlJs()` 确保 WASM 模块只加载一次

  #### 3. 增强错误日志 (`source/mcp/bash.ts`)

  - 在 `spawn` error 事件中记录 `errorCode`、`errno`、`syscall`、`cwd` 等详细信息

  ### 测试

  - [x] codebase 功能启用时，`terminal_execute` 可正常执行命令
  - [x] 大型代码库（31000+ 文件）下无性能问题

  ### Changed Files

  - `source/mcp/bash.ts`
  - `source/agents/codebaseIndexAgent.ts`
  - `source/utils/codebase/codebaseDatabase.ts`