### PR TITLE
fix: profile panel 的当前标签统一使用内存状态

### DIFF
--- a/source/ui/pages/ChatScreen.tsx
+++ b/source/ui/pages/ChatScreen.tsx
@@ -1544,8 +1544,14 @@ export default function ChatScreen({
 						getFilteredProfiles={() => {
 							const allProfiles = getAllProfiles();
 							const query = panelState.profileSearchQuery.toLowerCase();
-							if (!query) return allProfiles;
-							return allProfiles.filter(
+							// 基于内存状态重新计算 isActive，而非依赖文件状态
+							const currentName = panelState.currentProfileName;
+							const profilesWithMemoryState = allProfiles.map(profile => ({
+								...profile,
+								isActive: profile.displayName === currentName,
+							}));
+							if (!query) return profilesWithMemoryState;
+							return profilesWithMemoryState.filter(
 								profile =>
 									profile.name.toLowerCase().includes(query) ||
 									profile.displayName.toLowerCase().includes(query),


### PR DESCRIPTION
## 问题描述

在 ChatScreen 的 `showProfilePanel` 中，当用户通过 `alt+p` 切换配置文件时，弹出的快捷选择栏中"当前"标签的判断逻辑是基于 `active-profile.json` 文件状态的，这与其他部分的内存状态逻辑不一致。

## 改动内容

将 `showProfilePanel` 中"当前"标签的判断逻辑改为基于内存状态（`panelState.currentProfileName`），而非依赖 `active-profile.json` 文件，与其他部分逻辑保持一致。

## 具体修改

在 `source/ui/pages/ChatScreen.tsx` 的 `getFilteredProfiles` 函数中：
- 添加基于 `panelState.currentProfileName` 重新计算 `isActive` 的逻辑
- 确保所有配置文件的 `isActive` 状态统一使用内存状态判断

## 影响范围

- 修改文件：`source/ui/pages/ChatScreen.tsx`
- 影响功能：`alt+p` 快捷键显示配置文件选择面板时的"当前"标签显示
- 向后兼容：完全兼容，无破坏性改动