### PR TITLE
feat: 增加流式空闲超时重试机制(streamIdleTimeoutSec)

### DIFF
--- a/source/i18n/lang/en.ts
+++ b/source/i18n/lang/en.ts
@@ -188,6 +188,7 @@ export const en: TranslationKeys = {
 		basicModel: 'Basic Model(Type to search):',
 		maxContextTokens: 'Max Context Tokens:',
 		maxTokens: 'Max Tokens:',
+		streamIdleTimeoutSec: 'Stream Idle Timeout(sec):',
 		toolResultTokenLimit: 'Tool Result Token Limit:',
 		editSimilarityThreshold:
 			'Edit Similarity Threshold(0-1, change with caution):',

--- a/source/i18n/lang/zh-TW.ts
+++ b/source/i18n/lang/zh-TW.ts
@@ -174,6 +174,7 @@ export const zhTW: TranslationKeys = {
 		basicModel: '基礎模型(輸入後可以搜尋):',
 		maxContextTokens: '最大上下文令牌:',
 		maxTokens: '最大回复令牌數:',
+		streamIdleTimeoutSec: '流式閒置超時(秒):',
 		toolResultTokenLimit: '工具返回Token限制:',
 		editSimilarityThreshold: '檔案編輯相似度閾值(0-1, 非必要不改):',
 		notSet: '未設定',

--- a/source/i18n/lang/zh.ts
+++ b/source/i18n/lang/zh.ts
@@ -173,6 +173,7 @@ export const zh: TranslationKeys = {
 		basicModel: '基础模型(键入可搜索):',
 		maxContextTokens: '最大上下文令牌:',
 		maxTokens: '最大回复令牌数:',
+		streamIdleTimeoutSec: '流式空闲超时(秒):',
 		toolResultTokenLimit: '工具返回Token限制:',
 		editSimilarityThreshold: '文件编辑相似度阈值(0-1, 非必要不改):',
 		notSet: '未设置',

--- a/source/i18n/types.ts
+++ b/source/i18n/types.ts
@@ -174,6 +174,7 @@ export type TranslationKeys = {
 		basicModel: string;
 		maxContextTokens: string;
 		maxTokens: string;
+		streamIdleTimeoutSec: string;
 		toolResultTokenLimit: string;
 		editSimilarityThreshold: string;
 		notSet: string;

--- a/source/ui/pages/ConfigScreen.tsx
+++ b/source/ui/pages/ConfigScreen.tsx
@@ -57,6 +57,7 @@ type ConfigField =
 	| 'basicModel'
 	| 'maxContextTokens'
 	| 'maxTokens'
+	| 'streamIdleTimeoutSec'
 	| 'toolResultTokenLimit'
 	| 'editSimilarityThreshold';
 
@@ -162,6 +163,7 @@ export default function ConfigScreen({
 	const [basicModel, setBasicModel] = useState('');
 	const [maxContextTokens, setMaxContextTokens] = useState(4000);
 	const [maxTokens, setMaxTokens] = useState(4096);
+	const [streamIdleTimeoutSec, setStreamIdleTimeoutSec] = useState(180);
 	const [toolResultTokenLimit, setToolResultTokenLimit] = useState(100000);
 	const [editSimilarityThreshold, setEditSimilarityThreshold] = useState(0.75);
 
@@ -236,6 +238,7 @@ export default function ConfigScreen({
 			'basicModel',
 			'maxContextTokens',
 			'maxTokens',
+			'streamIdleTimeoutSec',
 			'toolResultTokenLimit',
 			'editSimilarityThreshold',
 		];
@@ -352,6 +355,7 @@ export default function ConfigScreen({
 		setBasicModel(config.basicModel || '');
 		setMaxContextTokens(config.maxContextTokens || 4000);
 		setMaxTokens(config.maxTokens || 4096);
+		setStreamIdleTimeoutSec(config.streamIdleTimeoutSec || 180);
 		setToolResultTokenLimit(config.toolResultTokenLimit || 100000);
 		setEditSimilarityThreshold(config.editSimilarityThreshold ?? 0.75);
 
@@ -416,6 +420,8 @@ export default function ConfigScreen({
 		if (currentField === 'basicModel') return basicModel;
 		if (currentField === 'maxContextTokens') return maxContextTokens.toString();
 		if (currentField === 'maxTokens') return maxTokens.toString();
+		if (currentField === 'streamIdleTimeoutSec')
+			return streamIdleTimeoutSec.toString();
 		if (currentField === 'toolResultTokenLimit')
 			return toolResultTokenLimit.toString();
 		if (currentField === 'editSimilarityThreshold')
@@ -587,6 +593,7 @@ export default function ConfigScreen({
 					basicModel,
 					maxContextTokens,
 					maxTokens,
+					streamIdleTimeoutSec,
 					toolResultTokenLimit,
 				},
 			};
@@ -680,6 +687,7 @@ export default function ConfigScreen({
 				basicModel,
 				maxContextTokens,
 				maxTokens,
+				streamIdleTimeoutSec,
 				toolResultTokenLimit,
 				editSimilarityThreshold,
 			};
@@ -741,6 +749,7 @@ export default function ConfigScreen({
 						basicModel,
 						maxContextTokens,
 						maxTokens,
+						streamIdleTimeoutSec,
 						toolResultTokenLimit,
 						editSimilarityThreshold,
 					},
@@ -875,26 +884,17 @@ export default function ConfigScreen({
 				let display = t.configScreen.followGlobalNone;
 				if (systemPromptId === '') {
 					display = t.configScreen.notUse;
-				} else if (
-					Array.isArray(systemPromptId) &&
-					systemPromptId.length > 0
-				) {
+				} else if (Array.isArray(systemPromptId) && systemPromptId.length > 0) {
 					display = systemPromptId
 						.map(id => getSystemPromptNameById(id))
 						.join(', ');
-				} else if (
-					systemPromptId &&
-					typeof systemPromptId === 'string'
-				) {
+				} else if (systemPromptId && typeof systemPromptId === 'string') {
 					display = getSystemPromptNameById(systemPromptId);
 				} else if (activeSystemPromptIds.length > 0) {
 					const activeNames = activeSystemPromptIds
 						.map(id => getSystemPromptNameById(id))
 						.join(', ');
-					display = t.configScreen.followGlobal.replace(
-						'{name}',
-						activeNames,
-					);
+					display = t.configScreen.followGlobal.replace('{name}', activeNames);
 				}
 				return (
 					<Box key={field} flexDirection="column">
@@ -1314,6 +1314,34 @@ export default function ConfigScreen({
 					</Box>
 				);
 
+			case 'streamIdleTimeoutSec':
+				return (
+					<Box key={field} flexDirection="column">
+						<Text
+							color={
+								isActive ? theme.colors.menuSelected : theme.colors.menuNormal
+							}
+						>
+							{isActive ? '❯ ' : '  '}
+							{t.configScreen.streamIdleTimeoutSec}
+						</Text>
+						{isCurrentlyEditing && (
+							<Box marginLeft={3}>
+								<Text color={theme.colors.menuInfo}>
+									{t.configScreen.enterValue} {streamIdleTimeoutSec}
+								</Text>
+							</Box>
+						)}
+						{!isCurrentlyEditing && (
+							<Box marginLeft={3}>
+								<Text color={theme.colors.menuSecondary}>
+									{streamIdleTimeoutSec}
+								</Text>
+							</Box>
+						)}
+					</Box>
+				);
+
 			case 'toolResultTokenLimit':
 				return (
 					<Box key={field} flexDirection="column">
@@ -1516,6 +1544,7 @@ export default function ConfigScreen({
 			if (
 				currentField === 'maxContextTokens' ||
 				currentField === 'maxTokens' ||
+				currentField === 'streamIdleTimeoutSec' ||
 				currentField === 'toolResultTokenLimit' ||
 				currentField === 'thinkingBudgetTokens' ||
 				currentField === 'geminiThinkingBudget' ||
@@ -1567,6 +1596,8 @@ export default function ConfigScreen({
 							? maxContextTokens
 							: currentField === 'maxTokens'
 							? maxTokens
+							: currentField === 'streamIdleTimeoutSec'
+							? streamIdleTimeoutSec
 							: currentField === 'toolResultTokenLimit'
 							? toolResultTokenLimit
 							: currentField === 'thinkingBudgetTokens'
@@ -1578,6 +1609,8 @@ export default function ConfigScreen({
 							setMaxContextTokens(newValue);
 						} else if (currentField === 'maxTokens') {
 							setMaxTokens(newValue);
+						} else if (currentField === 'streamIdleTimeoutSec') {
+							setStreamIdleTimeoutSec(newValue);
 						} else if (currentField === 'toolResultTokenLimit') {
 							setToolResultTokenLimit(newValue);
 						} else if (currentField === 'thinkingBudgetTokens') {
@@ -1592,6 +1625,8 @@ export default function ConfigScreen({
 							? maxContextTokens
 							: currentField === 'maxTokens'
 							? maxTokens
+							: currentField === 'streamIdleTimeoutSec'
+							? streamIdleTimeoutSec
 							: currentField === 'toolResultTokenLimit'
 							? toolResultTokenLimit
 							: currentField === 'thinkingBudgetTokens'
@@ -1604,6 +1639,8 @@ export default function ConfigScreen({
 						setMaxContextTokens(!isNaN(newValue) ? newValue : 0);
 					} else if (currentField === 'maxTokens') {
 						setMaxTokens(!isNaN(newValue) ? newValue : 0);
+					} else if (currentField === 'streamIdleTimeoutSec') {
+						setStreamIdleTimeoutSec(!isNaN(newValue) ? newValue : 0);
 					} else if (currentField === 'toolResultTokenLimit') {
 						setToolResultTokenLimit(!isNaN(newValue) ? newValue : 0);
 					} else if (currentField === 'thinkingBudgetTokens') {
@@ -1617,6 +1654,8 @@ export default function ConfigScreen({
 							? 4000
 							: currentField === 'maxTokens'
 							? 100
+							: currentField === 'streamIdleTimeoutSec'
+							? 1
 							: currentField === 'toolResultTokenLimit'
 							? 1000
 							: currentField === 'thinkingBudgetTokens'
@@ -1627,6 +1666,8 @@ export default function ConfigScreen({
 							? maxContextTokens
 							: currentField === 'maxTokens'
 							? maxTokens
+							: currentField === 'streamIdleTimeoutSec'
+							? streamIdleTimeoutSec
 							: currentField === 'toolResultTokenLimit'
 							? toolResultTokenLimit
 							: currentField === 'thinkingBudgetTokens'
@@ -1637,6 +1678,8 @@ export default function ConfigScreen({
 						setMaxContextTokens(finalValue);
 					} else if (currentField === 'maxTokens') {
 						setMaxTokens(finalValue);
+					} else if (currentField === 'streamIdleTimeoutSec') {
+						setStreamIdleTimeoutSec(finalValue);
 					} else if (currentField === 'toolResultTokenLimit') {
 						setToolResultTokenLimit(finalValue);
 					} else if (currentField === 'thinkingBudgetTokens') {
@@ -1689,6 +1732,7 @@ export default function ConfigScreen({
 				} else if (
 					currentField === 'maxContextTokens' ||
 					currentField === 'maxTokens' ||
+					currentField === 'streamIdleTimeoutSec' ||
 					currentField === 'toolResultTokenLimit' ||
 					currentField === 'thinkingBudgetTokens' ||
 					currentField === 'geminiThinkingBudget'
@@ -1719,10 +1763,7 @@ export default function ConfigScreen({
 					if (currentField === 'systemPromptId') {
 						if (Array.isArray(systemPromptId)) {
 							setPendingPromptIds(new Set(systemPromptId));
-						} else if (
-							systemPromptId &&
-							systemPromptId !== ''
-						) {
+						} else if (systemPromptId && systemPromptId !== '') {
 							setPendingPromptIds(new Set([systemPromptId]));
 						} else {
 							setPendingPromptIds(new Set());
@@ -2136,21 +2177,13 @@ export default function ConfigScreen({
 											limit={10}
 											initialIndex={Math.max(
 												0,
-												items.findIndex(
-													opt => opt.value === selected,
-												),
+												items.findIndex(opt => opt.value === selected),
 											)}
 											isFocused={true}
 											selectedValues={pendingPromptIds}
-											renderItem={({
-												label,
-												value,
-												isSelected,
-												isMarked,
-											}) => {
+											renderItem={({label, value, isSelected, isMarked}) => {
 												const isMeta =
-													value === '__FOLLOW__' ||
-													value === '__DISABLED__';
+													value === '__FOLLOW__' || value === '__DISABLED__';
 												return (
 													<Text
 														color={
@@ -2161,11 +2194,7 @@ export default function ConfigScreen({
 																: 'white'
 														}
 													>
-														{isMeta
-															? ''
-															: isMarked
-															? '[✓] '
-															: '[ ] '}
+														{isMeta ? '' : isMarked ? '[✓] ' : '[ ] '}
 														{label}
 													</Text>
 												);
@@ -2175,9 +2204,7 @@ export default function ConfigScreen({
 													item.value === '__FOLLOW__' ||
 													item.value === '__DISABLED__'
 												) {
-													applySystemPromptSelectValue(
-														item.value,
-													);
+													applySystemPromptSelectValue(item.value);
 													setPendingPromptIds(new Set());
 													setIsEditing(false);
 													return;
@@ -2197,9 +2224,7 @@ export default function ConfigScreen({
 													item.value === '__FOLLOW__' ||
 													item.value === '__DISABLED__'
 												) {
-													applySystemPromptSelectValue(
-														item.value,
-													);
+													applySystemPromptSelectValue(item.value);
 													setPendingPromptIds(new Set());
 													setIsEditing(false);
 													return;
@@ -2216,21 +2241,15 @@ export default function ConfigScreen({
 													finalIds.push(item.value);
 												}
 												setSystemPromptId(
-													finalIds.length === 1
-														? finalIds[0]!
-														: finalIds,
+													finalIds.length === 1 ? finalIds[0]! : finalIds,
 												);
 												setPendingPromptIds(new Set());
 												setIsEditing(false);
 											}}
 										/>
 										<Box marginTop={1}>
-											<Text
-												color={theme.colors.menuSecondary}
-												dimColor
-											>
-												{t.configScreen
-													.systemPromptMultiSelectHint ||
+											<Text color={theme.colors.menuSecondary} dimColor>
+												{t.configScreen.systemPromptMultiSelectHint ||
 													'Space: toggle | Enter: confirm | Esc: cancel'}
 											</Text>
 										</Box>

--- a/source/utils/config/configManager.ts
+++ b/source/utils/config/configManager.ts
@@ -12,6 +12,7 @@ import {
 	loadConfig,
 	saveConfig,
 	DEFAULT_CONFIG,
+	DEFAULT_STREAM_IDLE_TIMEOUT_SEC,
 	type AppConfig,
 } from './apiConfig.js';
 import {codebaseReviewAgent} from '../../agents/codebaseReviewAgent.js';
@@ -147,6 +148,18 @@ function migrateLegacyConfig(): void {
 }
 
 /**
+ * 归一化 streamIdleTimeoutSec.
+ * 缺失或非法值统一回退默认值(180秒).
+ */
+function normalizeStreamIdleTimeoutSec(value: unknown): number {
+	if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+		return DEFAULT_STREAM_IDLE_TIMEOUT_SEC;
+	}
+
+	return value;
+}
+
+/**
  * Load a specific profile with deep merge of default config
  * This ensures new config fields (like browserPath) are preserved
  */
@@ -170,6 +183,9 @@ export function loadProfile(profileName: string): AppConfig | undefined {
 			snowcfg: {
 				...DEFAULT_CONFIG.snowcfg,
 				...(parsedConfig.snowcfg || {}),
+				streamIdleTimeoutSec: normalizeStreamIdleTimeoutSec(
+					parsedConfig.snowcfg?.streamIdleTimeoutSec,
+				),
 			},
 		};
 

--- a/source/utils/core/streamGuards.ts
+++ b/source/utils/core/streamGuards.ts
@@ -1,0 +1,203 @@
+/**
+ * 流式读取保护工具
+ * 提供空闲超时检测和断开后消息丢弃机制
+ * 每次重试必须创建新的 guard 实例,禁止跨重试共享状态
+ */
+
+import {logger} from './logger.js';
+
+/**
+ * 流式读取空闲超时默认常量(3分钟)
+ * 作为兜底值使用,调用方可通过 createIdleTimeoutGuard 传入 idleTimeoutMs 覆盖
+ */
+export const STREAM_IDLE_TIMEOUT_MS = 180000;
+
+/**
+ * 流空闲超时错误
+ * 当流在指定时间内未收到任何数据时抛出
+ * 错误消息包含 [RETRIABLE] 和 idle timeout 关键字,便于 isRetriableError 识别
+ */
+export class StreamIdleTimeoutError extends Error {
+	override name = 'StreamIdleTimeoutError';
+
+	constructor(
+		message: string,
+		public readonly idleMs: number = STREAM_IDLE_TIMEOUT_MS,
+	) {
+		// 包含 [RETRIABLE] 标记和 idle timeout 关键字,确保被识别为可重试错误和流中断
+		super(`[API_ERROR] [RETRIABLE] Stream idle timeout: ${message}`);
+	}
+}
+
+/**
+ * 流读取保护器接口
+ */
+export interface StreamGuard {
+	/**
+	 * 标记当前流为已丢弃状态
+	 * 调用后,后续从该流读取的消息将被丢弃
+	 */
+	abandon: () => void;
+
+	/**
+	 * 检查当前流是否已被丢弃
+	 */
+	isAbandoned: () => boolean;
+
+	/**
+	 * 获取超时错误(如有)
+	 * 在读取循环中检查并抛出,确保异常被正确的 try/catch 捕获
+	 */
+	getTimeoutError: () => Error | null;
+
+	/**
+	 * 更新最后活动时间
+	 * 每次收到数据时调用,重置空闲计时器
+	 */
+	touch: () => void;
+
+	/**
+	 * 清理资源
+	 * 正常结束时调用,清除计时器
+	 */
+	dispose: () => void;
+}
+
+/**
+ * 创建流读取保护器
+ * 提供空闲超时检测和断开后消息丢弃功能
+ *
+ * @param reader - 可取消的 reader,用于断开时清理
+ * @param onTimeout - 超时回调(可选).允许在回调中 throw,但异常会被 guard 捕获并保存,调用方需在读取循环中通过 getTimeoutError() 取出并在循环上下文 throw,以进入业务 try/catch 和重试链路
+ * @returns StreamGuard 实例
+ *
+ * 使用示例:
+ * ```typescript
+ * const guard = createIdleTimeoutGuard({
+ *   reader,
+ *   onTimeout: () => {
+ *     throw new StreamIdleTimeoutError('No data for 3min');
+ *   },
+ * });
+ *
+ * try {
+ *   while (true) {
+ *     const {done, value} = await reader.read();
+ *     guard.touch();
+ *
+ *     const timeoutError = guard.getTimeoutError();
+ *     if (timeoutError) throw timeoutError;
+ *
+ *     if (guard.isAbandoned()) continue;
+ *     if (done) break;
+ *
+ *     yield value;
+ *   }
+ * } finally {
+ *   guard.dispose();
+ * }
+ * ```
+ */
+export function createIdleTimeoutGuard({
+	reader,
+	onTimeout,
+	idleTimeoutMs = STREAM_IDLE_TIMEOUT_MS,
+}: {
+	reader?: ReadableStreamDefaultReader<any>;
+	onTimeout?: () => void;
+	idleTimeoutMs?: number;
+}): StreamGuard {
+	let isAbandoned = false;
+	let lastChunkTime = Date.now();
+	let idleTimer: ReturnType<typeof setInterval> | null = null;
+	let timeoutError: Error | null = null;
+
+	// 启动空闲检测定时器(每5秒检查一次)
+	idleTimer = setInterval(() => {
+		try {
+			if (isAbandoned) return;
+
+			if (Date.now() - lastChunkTime <= idleTimeoutMs) return;
+
+			// 触发超时
+			isAbandoned = true;
+
+			// 即使调用方未提供 onTimeout,也要设置默认超时错误,避免超时后静默结束
+			if (!timeoutError) {
+				timeoutError = new StreamIdleTimeoutError(
+					`No data received for ${idleTimeoutMs}ms`,
+					idleTimeoutMs,
+				);
+			}
+
+			// 尝试取消 reader 以减少延迟消息(同步/异步异常都应吞掉)
+			try {
+				reader?.cancel().catch(() => {
+					// 忽略取消失败
+				});
+			} catch {
+				// 忽略取消失败
+			}
+
+			// 日志写入可能同步抛错,必须捕获,避免定时器回调触发 uncaughtException
+			try {
+				logger.warn(`Stream idle timeout detected after ${idleTimeoutMs}ms`);
+			} catch {
+				// 忽略日志写入失败
+			}
+
+			// 允许调用方在超时时构造更具体的错误,但必须捕获并通过 getTimeoutError 传递
+			if (onTimeout) {
+				try {
+					onTimeout();
+				} catch (error) {
+					timeoutError =
+						error instanceof Error ? error : new Error(String(error));
+				}
+			}
+		} catch (error) {
+			// 定时器回调中禁止异常冒泡到事件循环
+			isAbandoned = true;
+			if (!timeoutError) {
+				timeoutError =
+					error instanceof Error ? error : new Error(String(error));
+			}
+			try {
+				reader?.cancel().catch(() => {
+					// 忽略取消失败
+				});
+			} catch {
+				// 忽略取消失败
+			}
+		}
+	}, 5000);
+
+	return {
+		abandon: () => {
+			isAbandoned = true;
+			try {
+				reader?.cancel().catch(() => {
+					// 忽略取消失败
+				});
+			} catch {
+				// 忽略取消失败
+			}
+		},
+
+		isAbandoned: () => isAbandoned,
+
+		// 检查是否有超时错误需要抛出,在读取循环中调用以确保异常被正确捕获
+		getTimeoutError: () => timeoutError,
+
+		touch: () => {
+			lastChunkTime = Date.now();
+		},
+
+		dispose: () => {
+			if (idleTimer) {
+				clearInterval(idleTimer);
+				idleTimer = null;
+			}
+		},
+	};
+}


### PR DESCRIPTION
## 变更说明
- 新增 `streamIdleTimeoutSec` 配置项,默认 `180` 秒.
- 在配置加载与 profile 加载时统一做合法化归一化,非法值回退默认值.
- 在 `API和模型设置` 中增加该字段的展示与编辑,并确保主配置与当前 profile 均落盘.
- 新增 `streamGuards` 空闲超时保护能力,支持可配置 `idleTimeoutMs` 并保持断开后消息丢弃语义.
- 在 `withRetryGenerator` 中补充流中断特判,让 `idle timeout` 等流中断在已产出后仍可按规则重试.
- 对 Anthropic, Chat, Gemini, Responses 四个流式适配器统一接入空闲超时 guard 与重试链路.
