### PR TITLE
fix: 修复ACE文本搜索中rg调用参数与stdio问题

### DIFF
--- a/source/mcp/aceCodeSearch.ts
+++ b/source/mcp/aceCodeSearch.ts
@@ -827,7 +827,7 @@ export class ACECodeSearchService {
 
 		return new Promise((resolve, reject) => {
 			const args = isRipgrep
-				? ['-n', '-i', '--no-heading', pattern]
+				? ['-n', '-i', '--no-heading']
 				: ['-r', '-n', '-H', '-E', '-i'];
 
 			// Add exclusion patterns
@@ -863,12 +863,13 @@ export class ACECodeSearchService {
 					const expandedGlobs = expandGlobBraces(normalizedGlob);
 					expandedGlobs.forEach(glob => args.push(`--include=${glob}`));
 				}
-				args.push(pattern, '.');
 			}
+			args.push(pattern, '.');
 
 			const child = spawn(grepCommand, args, {
 				cwd: this.basePath,
 				windowsHide: true,
+				stdio: ['ignore', 'pipe', 'pipe'],
 			});
 
 			// Register child process for cleanup

--- a/source/test/rg-spawn-repro/rg-spawn-repro-fixed.mjs
+++ b/source/test/rg-spawn-repro/rg-spawn-repro-fixed.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+import {spawn} from 'node:child_process';
+import process from 'node:process';
+
+/**
+ * Reproduce rg spawn behavior with fixed args.
+ * Usage:
+ *   node source/test/rg-spawn-repro/rg-spawn-repro-fixed.mjs --pattern "foo|bar" --fileGlob "source/**.ts" --cwd "." --maxResults 100 --timeoutMs 300000
+ */
+
+function parseArgs(argv) {
+	const args = {
+		pattern: 'TODO',
+		fileGlob: undefined,
+		cwd: process.cwd(),
+		maxResults: 100,
+		timeoutMs: 300000,
+	};
+
+	for (let index = 2; index < argv.length; index++) {
+		const token = argv[index];
+		if (token === '--pattern' && argv[index + 1]) {
+			args.pattern = argv[++index];
+			continue;
+		}
+
+		if (token === '--fileGlob' && argv[index + 1]) {
+			args.fileGlob = argv[++index];
+			continue;
+		}
+
+		if (token === '--cwd' && argv[index + 1]) {
+			args.cwd = argv[++index];
+			continue;
+		}
+
+		if (token === '--maxResults' && argv[index + 1]) {
+			args.maxResults = Number.parseInt(argv[++index], 10);
+			continue;
+		}
+
+		if (token === '--timeoutMs' && argv[index + 1]) {
+			args.timeoutMs = Number.parseInt(argv[++index], 10);
+		}
+	}
+
+	return args;
+}
+
+function buildRipgrepArgs(pattern, fileGlob) {
+	const args = ['-n', '-i', '--no-heading'];
+	const excludeDirs = [
+		'node_modules',
+		'.git',
+		'dist',
+		'build',
+		'__pycache__',
+		'target',
+		'.next',
+		'.nuxt',
+		'coverage',
+	];
+
+	for (const directory of excludeDirs) {
+		args.push('--glob', `!${directory}/`);
+	}
+
+	if (fileGlob) {
+		const normalizedGlob = fileGlob.replace(/\\/g, '/');
+		args.push('--glob', normalizedGlob);
+	}
+
+	args.push(pattern, '.');
+	return args;
+}
+
+async function main() {
+	const options = parseArgs(process.argv);
+	const rgArgs = buildRipgrepArgs(options.pattern, options.fileGlob);
+	const startedAt = Date.now();
+
+	console.log('=== rg spawn reproduce fixed ===');
+	console.log(`cwd=${options.cwd}`);
+	console.log(`pattern=${options.pattern}`);
+	console.log(`fileGlob=${options.fileGlob ?? '<none>'}`);
+	console.log(`timeoutMs=${options.timeoutMs}`);
+	console.log(`args=${JSON.stringify(rgArgs)}`);
+
+	const child = spawn('rg', rgArgs, {
+		cwd: options.cwd,
+		windowsHide: true,
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+
+	let stdoutSize = 0;
+	let stderrSize = 0;
+	let lineCount = 0;
+	let stdoutBuffer = '';
+	const previewLines = [];
+
+	const heartbeat = setInterval(() => {
+		const elapsed = Date.now() - startedAt;
+		console.log(
+			`[heartbeat] elapsedMs=${elapsed} stdoutBytes=${stdoutSize} stderrBytes=${stderrSize} lines=${lineCount}`,
+		);
+	}, 5000);
+
+	const timeout = setTimeout(() => {
+		const elapsed = Date.now() - startedAt;
+		console.error(
+			`[timeout] rg did not finish in ${options.timeoutMs}ms. elapsedMs=${elapsed}. killing process...`,
+		);
+		child.kill('SIGTERM');
+		setTimeout(() => child.kill('SIGKILL'), 2000);
+	}, options.timeoutMs);
+
+	child.stdout.on('data', chunk => {
+		const text = chunk.toString('utf8');
+		stdoutSize += chunk.length;
+		stdoutBuffer += text;
+
+		let splitIndex = stdoutBuffer.indexOf('\n');
+		while (splitIndex !== -1) {
+			const line = stdoutBuffer.slice(0, splitIndex).trimEnd();
+			stdoutBuffer = stdoutBuffer.slice(splitIndex + 1);
+			if (line.length > 0) {
+				lineCount += 1;
+				if (previewLines.length < options.maxResults) {
+					previewLines.push(line);
+				}
+			}
+			splitIndex = stdoutBuffer.indexOf('\n');
+		}
+	});
+
+	child.stderr.on('data', chunk => {
+		stderrSize += chunk.length;
+		process.stderr.write(chunk);
+	});
+
+	child.on('error', error => {
+		clearInterval(heartbeat);
+		clearTimeout(timeout);
+		console.error(`[error] failed to start rg: ${error.message}`);
+		process.exitCode = 1;
+	});
+
+	child.on('close', code => {
+		clearInterval(heartbeat);
+		clearTimeout(timeout);
+		const elapsed = Date.now() - startedAt;
+
+		if (stdoutBuffer.trim().length > 0) {
+			lineCount += 1;
+			if (previewLines.length < options.maxResults) {
+				previewLines.push(stdoutBuffer.trimEnd());
+			}
+		}
+
+		console.log(`\n[done] code=${code} elapsedMs=${elapsed}`);
+		console.log(`stdoutBytes=${stdoutSize} stderrBytes=${stderrSize} totalLines=${lineCount}`);
+		console.log(`previewCount=${previewLines.length}`);
+		if (previewLines.length > 0) {
+			console.log('--- preview ---');
+			for (const line of previewLines) {
+				console.log(line);
+			}
+			console.log('--- end preview ---');
+		}
+
+		if (code === null) {
+			process.exitCode = 2;
+			return;
+		}
+
+		if (code !== 0 && code !== 1) {
+			process.exitCode = code;
+		}
+	});
+}
+
+main();

--- a/source/test/rg-spawn-repro/rg-spawn-repro.mjs
+++ b/source/test/rg-spawn-repro/rg-spawn-repro.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import {spawn} from 'node:child_process';
+import process from 'node:process';
+
+/**
+ * Reproduce rg spawn behavior used by ACE text search.
+ * Usage:
+ *   node source/test/rg-spawn-repro/rg-spawn-repro.mjs --pattern "foo|bar" --fileGlob "source/**.ts" --cwd "." --maxResults 100 --timeoutMs 300000
+ */
+
+function parseArgs(argv) {
+	const args = {
+		pattern: 'TODO',
+		fileGlob: undefined,
+		cwd: process.cwd(),
+		maxResults: 100,
+		timeoutMs: 300000,
+	};
+
+	for (let index = 2; index < argv.length; index++) {
+		const token = argv[index];
+		if (token === '--pattern' && argv[index + 1]) {
+			args.pattern = argv[++index];
+			continue;
+		}
+
+		if (token === '--fileGlob' && argv[index + 1]) {
+			args.fileGlob = argv[++index];
+			continue;
+		}
+
+		if (token === '--cwd' && argv[index + 1]) {
+			args.cwd = argv[++index];
+			continue;
+		}
+
+		if (token === '--maxResults' && argv[index + 1]) {
+			args.maxResults = Number.parseInt(argv[++index], 10);
+			continue;
+		}
+
+		if (token === '--timeoutMs' && argv[index + 1]) {
+			args.timeoutMs = Number.parseInt(argv[++index], 10);
+		}
+	}
+
+	return args;
+}
+
+function buildRipgrepArgs(pattern, fileGlob) {
+	const args = ['-n', '-i', '--no-heading', pattern];
+	const excludeDirs = [
+		'node_modules',
+		'.git',
+		'dist',
+		'build',
+		'__pycache__',
+		'target',
+		'.next',
+		'.nuxt',
+		'coverage',
+	];
+
+	for (const directory of excludeDirs) {
+		args.push('--glob', `!${directory}/`);
+	}
+
+	if (fileGlob) {
+		const normalizedGlob = fileGlob.replace(/\\/g, '/');
+		args.push('--glob', normalizedGlob);
+	}
+
+	return args;
+}
+
+async function main() {
+	const options = parseArgs(process.argv);
+	const rgArgs = buildRipgrepArgs(options.pattern, options.fileGlob);
+	const startedAt = Date.now();
+
+	console.log('=== rg spawn reproduce ===');
+	console.log(`cwd=${options.cwd}`);
+	console.log(`pattern=${options.pattern}`);
+	console.log(`fileGlob=${options.fileGlob ?? '<none>'}`);
+	console.log(`timeoutMs=${options.timeoutMs}`);
+	console.log(`args=${JSON.stringify(rgArgs)}`);
+
+	const child = spawn('rg', rgArgs, {
+		cwd: options.cwd,
+		windowsHide: true,
+	});
+
+	let stdoutSize = 0;
+	let stderrSize = 0;
+	let lineCount = 0;
+	let stdoutBuffer = '';
+	const previewLines = [];
+
+	const heartbeat = setInterval(() => {
+		const elapsed = Date.now() - startedAt;
+		console.log(
+			`[heartbeat] elapsedMs=${elapsed} stdoutBytes=${stdoutSize} stderrBytes=${stderrSize} lines=${lineCount}`,
+		);
+	}, 5000);
+
+	const timeout = setTimeout(() => {
+		const elapsed = Date.now() - startedAt;
+		console.error(
+			`[timeout] rg did not finish in ${options.timeoutMs}ms. elapsedMs=${elapsed}. killing process...`,
+		);
+		child.kill('SIGTERM');
+		setTimeout(() => child.kill('SIGKILL'), 2000);
+	}, options.timeoutMs);
+
+	child.stdout.on('data', chunk => {
+		const text = chunk.toString('utf8');
+		stdoutSize += chunk.length;
+		stdoutBuffer += text;
+
+		let splitIndex = stdoutBuffer.indexOf('\n');
+		while (splitIndex !== -1) {
+			const line = stdoutBuffer.slice(0, splitIndex).trimEnd();
+			stdoutBuffer = stdoutBuffer.slice(splitIndex + 1);
+			if (line.length > 0) {
+				lineCount += 1;
+				if (previewLines.length < options.maxResults) {
+					previewLines.push(line);
+				}
+			}
+			splitIndex = stdoutBuffer.indexOf('\n');
+		}
+	});
+
+	child.stderr.on('data', chunk => {
+		stderrSize += chunk.length;
+		process.stderr.write(chunk);
+	});
+
+	child.on('error', error => {
+		clearInterval(heartbeat);
+		clearTimeout(timeout);
+		console.error(`[error] failed to start rg: ${error.message}`);
+		process.exitCode = 1;
+	});
+
+	child.on('close', code => {
+		clearInterval(heartbeat);
+		clearTimeout(timeout);
+		const elapsed = Date.now() - startedAt;
+
+		if (stdoutBuffer.trim().length > 0) {
+			lineCount += 1;
+			if (previewLines.length < options.maxResults) {
+				previewLines.push(stdoutBuffer.trimEnd());
+			}
+		}
+
+		console.log(`\n[done] code=${code} elapsedMs=${elapsed}`);
+		console.log(`stdoutBytes=${stdoutSize} stderrBytes=${stderrSize} totalLines=${lineCount}`);
+		console.log(`previewCount=${previewLines.length}`);
+		if (previewLines.length > 0) {
+			console.log('--- preview ---');
+			for (const line of previewLines) {
+				console.log(line);
+			}
+			console.log('--- end preview ---');
+		}
+
+		if (code === null) {
+			process.exitCode = 2;
+			return;
+		}
+
+		if (code !== 0 && code !== 1) {
+			process.exitCode = code;
+		}
+	});
+}
+
+main();


### PR DESCRIPTION
## 变更说明
- 修复 `source/mcp/aceCodeSearch.ts` 中 `rg` 调用参数构造.
  - `rg` 参数初始化不再提前放入 `pattern`.
  - 统一在参数末尾追加 `pattern` 和 `.`.
  - `spawn` 显式设置 `stdio: ['ignore', 'pipe', 'pipe']`,避免 stdin 相关挂起问题.

## 测试与复现脚本
- 新增 `source/test/rg-spawn-repro/rg-spawn-repro.mjs`.
  - 用于复现旧调用行为.
- 新增 `source/test/rg-spawn-repro/rg-spawn-repro-fixed.mjs`.
  - 用于复现修复后行为.

## 范围边界
- 本 PR 只修复 `rg` 调用链路问题与复现脚本.
- 本 PR **没有**修改 Windows 上临时绕过 `rg` 的逻辑.
- 后续请上游在完成 Windows 场景验证后,再自行评估并解除该绕过逻辑.
