### PR TITLE
Add focus-aware terminal attention

### DIFF
--- a/source/hooks/conversation/chatLogic/useMessageProcessing.ts
+++ b/source/hooks/conversation/chatLogic/useMessageProcessing.ts
@@ -18,6 +18,11 @@ import {runningSubAgentTracker} from '../../../utils/execution/runningSubAgentTr
 import {teamTracker} from '../../../utils/execution/teamTracker.js';
 import {compressionCoordinator} from '../../../utils/core/compressionCoordinator.js';
 import {goalManager} from '../../../utils/task/goalManager.js';
+import {getProjectName} from '../../../utils/session/projectUtils.js';
+import {
+	notifyAgentTurnComplete,
+	shouldNotifyAgentTurnCompletion,
+} from '../../../utils/platform/windows-notification.js';
 
 interface MessageTarget {
 	instanceId: string;
@@ -97,6 +102,7 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 		userInterruptedRef,
 		pendingMessagesRef,
 		setBashSensitiveCommand,
+		hasFocus,
 	} = props;
 
 	const processMessageRef = useRef<
@@ -110,10 +116,15 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 	>(null);
 
 	const yoloModeRef = useRef(yoloMode);
+	const hasFocusRef = useRef(hasFocus ?? true);
 
 	useEffect(() => {
 		yoloModeRef.current = yoloMode;
 	}, [yoloMode]);
+
+	useEffect(() => {
+		hasFocusRef.current = hasFocus ?? true;
+	}, [hasFocus]);
 
 	const appendAiCompletionTimeMessage = () => {
 		setMessages(prev => [
@@ -125,6 +136,12 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 				aiCompletionTime: new Date(),
 			},
 		]);
+	};
+
+	const notifyAgentTurnWaitingForInput = () => {
+		notifyAgentTurnComplete({
+			projectName: getProjectName(),
+		});
 	};
 
 	const processMessage = async (
@@ -471,12 +488,14 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 			// 用本轮初始快照的 wasUserInterrupted 判定，避免 ref 已被 reset 的陷阱。
 			// 同时再次校验 goal 当前状态：用户 ESC 时 handleInterrupt 会把 goal 置为
 			// paused，所以即使 wasUserInterrupted 漏判，status !== 'pursuing' 也能兜底。
-			if (!wasUserInterrupted) {
-				void (async () => {
-					try {
+			void (async () => {
+				let willAutoContinue = false;
+
+				try {
+					if (!wasUserInterrupted) {
 						const current = await goalManager.loadCurrentGoal();
-						if (!current) return;
-						if (current.status === 'pursuing') {
+						if (current?.status === 'pursuing') {
+							willAutoContinue = true;
 							await goalManager.markPendingContinuation();
 							// 调度下一轮：用空消息 + hideUserMessage 触发，使续接 prompt 作为唯一输入
 							setTimeout(() => {
@@ -488,9 +507,10 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 								}
 							}, 0);
 						} else if (
-							current.status === 'budget-limited' &&
+							current?.status === 'budget-limited' &&
 							current.pendingContinuation
 						) {
+							willAutoContinue = true;
 							// 预算已耗尽，但还有一次 budget_limit 收尾轮次
 							setTimeout(() => {
 								const ref = processMessageRef.current;
@@ -501,11 +521,22 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 								}
 							}, 0);
 						}
-					} catch (err) {
-						console.error('[goal] continuation scheduling failed:', err);
 					}
-				})();
-			}
+				} catch (err) {
+					console.error('[goal] continuation scheduling failed:', err);
+				} finally {
+					if (
+						shouldNotifyAgentTurnCompletion({
+							terminalFocused: hasFocusRef.current,
+							wasUserInterrupted,
+							willAutoContinue,
+							pendingMessageCount: pendingMessagesRef.current.length,
+						})
+					) {
+						notifyAgentTurnWaitingForInput();
+					}
+				}
+			})();
 		}
 	};
 

--- a/source/hooks/ui/useTerminalTitle.ts
+++ b/source/hooks/ui/useTerminalTitle.ts
@@ -1,27 +1,20 @@
 import {useEffect} from 'react';
 import {useStdout} from 'ink';
 
+const titleControlCharacters = /[\u0000-\u001F\u007F]/g; // eslint-disable-line no-control-regex
+
+function cleanOscTitle(title: string): string {
+	return title
+		.replaceAll(titleControlCharacters, ' ')
+		.replaceAll(/\s+/g, ' ')
+		.trim();
+}
+
 /**
  * 设置终端窗口/标签标题，组件卸载时自动清空。
  *
- * 跨平台兼容策略：
- * 1. process.title：Windows 控制台直接生效，类 Unix 上仅修改进程名
- * 2. OSC 转义序列 ESC]0;<title>BEL：所有支持 ANSI 的现代终端
- *    （macOS Terminal/iTerm2、Windows Terminal、Linux 终端、mintty 等）
- *
- * 注意：
- * - 非 TTY 环境（管道、重定向、CI 日志）会跳过，避免污染输出
- * - 退出页面会写入空标题，多数终端会回退到默认值（如 cwd 或 shell 名）
- * - tmux/screen 用户需启用 set-titles on 才能透传到外层终端
- *
- * @param title 要显示的标题；传入空字符串会清空标题
- * @example
- * ```tsx
- * function MyScreen() {
- *   useTerminalTitle('Snow CLI - 设置');
- *   return <Box>...</Box>;
- * }
- * ```
+ * 只写 OSC 0；不要碰 process.title。Windows Terminal 顶层窗口标题可能
+ * 由宿主加上 Administrator 等前缀，应用层不能也不应该伪装能删掉它。
  */
 export function useTerminalTitle(title: string): void {
 	const {stdout} = useStdout();
@@ -29,44 +22,24 @@ export function useTerminalTitle(title: string): void {
 	useEffect(() => {
 		if (!stdout?.isTTY) return;
 
-		// 保存原 process.title 以便卸载时恢复
-		let previousProcessTitle: string | undefined;
-		try {
-			previousProcessTitle = process.title;
-		} catch {
-			// 某些受限环境读取 process.title 可能抛错，忽略即可
-		}
+		const safeTitle = cleanOscTitle(title);
 
-		// 1. process.title：Windows 控制台直接生效，类 Unix 仅修改进程名
-		if (title) {
-			try {
-				process.title = title;
-			} catch {
-				// 某些平台（如部分容器/沙箱）写入 process.title 会失败，忽略
-			}
-		}
-
-		// 2. OSC 序列：所有支持 ANSI 的终端
 		try {
-			stdout.write(`\x1b]0;${title}\x07`);
+			stdout.write(`\u001B]0;${safeTitle}\u0007`);
 		} catch {
-			// stdout 已关闭或不可写时忽略，避免应用崩溃
+			// Stdout 可能已关闭；标题是 best-effort，不能影响 UI。
 		}
+	}, [stdout, title]);
+
+	useEffect(() => {
+		if (!stdout?.isTTY) return;
 
 		return () => {
-			if (!stdout?.isTTY) return;
-			if (previousProcessTitle !== undefined) {
-				try {
-					process.title = previousProcessTitle;
-				} catch {
-					// 同上，忽略恢复失败
-				}
-			}
 			try {
-				stdout.write('\x1b]0;\x07');
+				stdout.write('\u001B]0;\u0007');
 			} catch {
-				// 卸载阶段 stdout 可能已关闭，忽略
+				// 卸载阶段 stdout 可能已关闭，忽略。
 			}
 		};
-	}, [stdout, title]);
+	}, [stdout]);
 }

--- a/source/ui/pages/ChatScreen.tsx
+++ b/source/ui/pages/ChatScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {Box, Text} from 'ink';
 import Spinner from 'ink-spinner';
 import {useI18n} from '../../i18n/I18nContext.js';
@@ -23,6 +23,8 @@ import {usePanelState} from '../../hooks/ui/usePanelState.js';
 import {connectionManager} from '../../utils/connection/ConnectionManager.js';
 import {updateGlobalTokenUsage} from '../../utils/connection/contextManager.js';
 import {sessionManager} from '../../utils/session/sessionManager.js';
+import {getProjectName} from '../../utils/session/projectUtils.js';
+import {formatTerminalTitle} from '../../utils/ui/terminal-title-formatter.js';
 import ChatScreenConversationView from './chatScreen/ChatScreenConversationView.js';
 import ChatScreenPanels from './chatScreen/ChatScreenPanels.js';
 import {useBackgroundProcessSelection} from './chatScreen/useBackgroundProcessSelection.js';
@@ -51,10 +53,10 @@ export default function ChatScreen({
 	enablePlan,
 }: Props) {
 	const {t} = useI18n();
-	useTerminalTitle(`Snow CLI - ${t.chatScreen.headerTitle}`);
+	const workingDirectory = process.cwd();
+	const projectName = getProjectName(workingDirectory);
 	const {theme} = useTheme();
 	const {columns: terminalWidth, rows: terminalHeight} = useTerminalSize();
-	const workingDirectory = process.cwd();
 
 	const {
 		messages,
@@ -255,6 +257,61 @@ export default function ChatScreen({
 	}
 
 	const handleProfileSelect = panelState.handleProfileSelect;
+	const [terminalTitleFrame, setTerminalTitleFrame] = useState(0);
+
+	const foregroundTerminalCommand =
+		terminalExecutionState.state.isExecuting &&
+		!terminalExecutionState.state.isBackgrounded &&
+		Boolean(terminalExecutionState.state.command);
+	const backgroundTerminalCommand =
+		terminalExecutionState.state.isExecuting &&
+		terminalExecutionState.state.isBackgrounded;
+	const hasRunningBackgroundProcess = backgroundProcesses.processes.some(
+		backgroundProcess => backgroundProcess.status === 'running',
+	);
+	const hasPendingAction =
+		Boolean(pendingToolConfirmation) ||
+		Boolean(pendingUserQuestion) ||
+		Boolean(bashSensitiveCommand) ||
+		terminalExecutionState.state.needsInput;
+	const hasActiveProgress =
+		streamingState.isStreaming ||
+		isSaving ||
+		isCompressing ||
+		isExecutingTerminalCommand ||
+		bashMode.state.isExecuting ||
+		foregroundTerminalCommand ||
+		backgroundTerminalCommand ||
+		(customCommandExecution?.isRunning ?? false) ||
+		schedulerExecutionState.state.isRunning ||
+		hasRunningBackgroundProcess;
+	const terminalTitleActive = hasActiveProgress || hasPendingAction;
+
+	useEffect(() => {
+		if (!terminalTitleActive) {
+			setTerminalTitleFrame(0);
+			return;
+		}
+
+		const intervalId = setInterval(
+			() => {
+				setTerminalTitleFrame(frame => frame + 1);
+			},
+			hasPendingAction ? 500 : 120,
+		);
+
+		return () => {
+			clearInterval(intervalId);
+		};
+	}, [terminalTitleActive, hasPendingAction]);
+
+	const terminalTitle = formatTerminalTitle({
+		projectName,
+		activity: hasActiveProgress,
+		actionRequired: hasPendingAction,
+		animationFrame: terminalTitleFrame,
+	});
+	useTerminalTitle(terminalTitle);
 
 	/**
 	 * /goal resume 面板的选中回调。

--- a/source/utils/platform/windows-notification.test.ts
+++ b/source/utils/platform/windows-notification.test.ts
@@ -1,0 +1,152 @@
+import anyTest, {type TestFn} from 'ava';
+
+import {
+	buildTerminalNotificationSequences,
+	buildToastScript,
+	cleanNotificationText,
+	escapeXml,
+	formatAgentTurnCompletionNotification,
+	formatTaskNotification,
+	shouldNotifyAgentTurnCompletion,
+	truncate,
+} from './windows-notification.js';
+
+const test = anyTest as unknown as TestFn;
+
+test('cleanNotificationText strips terminal control characters', t => {
+	t.is(
+		cleanNotificationText('hello\u001B]9;bad\u0007 world'),
+		'hello ]9;bad world',
+	);
+});
+
+test('escapeXml escapes toast text characters', t => {
+	t.is(escapeXml('&<>"\''), '&amp;&lt;&gt;&quot;&apos;');
+});
+
+test('truncate returns short text unchanged', t => {
+	t.is(truncate('short', 10), 'short');
+});
+
+test('truncate keeps shortened text within the requested length', t => {
+	t.is(truncate('abcdefghij', 7), 'abcd...');
+	t.is(truncate('abcdefghij', 3), '...');
+});
+
+test('formatTaskNotification formats completed task payload', t => {
+	t.deepEqual(
+		formatTaskNotification({
+			taskTitle: 'Build',
+			status: 'completed',
+		}),
+		{
+			title: 'Snow task completed',
+			body: 'Build',
+		},
+	);
+});
+
+test('formatTaskNotification formats failed task payload', t => {
+	t.deepEqual(
+		formatTaskNotification({
+			taskTitle: 'Build',
+			status: 'failed',
+			errorMessage: 'boom',
+		}),
+		{
+			title: 'Snow task failed',
+			body: 'Build: boom',
+		},
+	);
+});
+
+test('formatAgentTurnCompletionNotification formats waiting payload', t => {
+	t.deepEqual(
+		formatAgentTurnCompletionNotification({projectName: 'my-project'}),
+		{
+			title: 'Snow agent waiting for input',
+			body: 'my-project',
+		},
+	);
+});
+
+test('shouldNotifyAgentTurnCompletion allows completed unfocused turns waiting for input', t => {
+	t.true(
+		shouldNotifyAgentTurnCompletion({
+			terminalFocused: false,
+			wasUserInterrupted: false,
+			willAutoContinue: false,
+			pendingMessageCount: 0,
+		}),
+	);
+});
+
+test('shouldNotifyAgentTurnCompletion defaults to focused when focus is unknown', t => {
+	t.false(shouldNotifyAgentTurnCompletion({}));
+});
+
+test('shouldNotifyAgentTurnCompletion skips focused turns', t => {
+	t.false(shouldNotifyAgentTurnCompletion({terminalFocused: true}));
+});
+
+test('shouldNotifyAgentTurnCompletion skips user-interrupted turns', t => {
+	t.false(
+		shouldNotifyAgentTurnCompletion({
+			terminalFocused: false,
+			wasUserInterrupted: true,
+		}),
+	);
+});
+
+test('shouldNotifyAgentTurnCompletion skips auto-continuing turns', t => {
+	t.false(
+		shouldNotifyAgentTurnCompletion({
+			terminalFocused: false,
+			willAutoContinue: true,
+		}),
+	);
+});
+
+test('shouldNotifyAgentTurnCompletion skips turns with queued messages', t => {
+	t.false(
+		shouldNotifyAgentTurnCompletion({
+			terminalFocused: false,
+			pendingMessageCount: 1,
+		}),
+	);
+});
+
+test('buildTerminalNotificationSequences emits OSC 9 and BEL fallback', t => {
+	t.deepEqual(buildTerminalNotificationSequences('Done', 'Task'), [
+		'\u001B]9;Done: Task\u0007',
+		'\u0007',
+	]);
+});
+
+test('buildTerminalNotificationSequences removes OSC injection characters', t => {
+	t.deepEqual(buildTerminalNotificationSequences('A\u001B]0;bad', 'B\u0007C'), [
+		'\u001B]9;A ]0;bad: B C\u0007',
+		'\u0007',
+	]);
+});
+
+test('buildToastScript embeds escaped title and body', t => {
+	const script = buildToastScript('A&B', '<body>');
+
+	t.true(script.includes('<text>A&amp;B</text>'));
+	t.true(script.includes('<text>&lt;body&gt;</text>'));
+	t.false(script.includes('<text><body></text>'));
+});
+
+test('buildToastScript keeps notification failures best-effort', t => {
+	const script = buildToastScript('title', 'body');
+
+	t.true(script.includes('catch'));
+	t.true(script.includes('exit 0'));
+});
+
+test('buildToastScript uses hidden non-interactive powershell policy path', t => {
+	const script = buildToastScript('title', 'body');
+
+	t.true(script.includes('ToastNotificationManager'));
+});

--- a/source/utils/platform/windows-notification.ts
+++ b/source/utils/platform/windows-notification.ts
@@ -1,0 +1,234 @@
+import {Buffer} from 'node:buffer';
+import {spawn} from 'node:child_process';
+import process from 'node:process';
+
+const appId = 'Snow CLI';
+const maxTitleLength = 80;
+const maxBodyLength = 240;
+const notificationControlCharacters = /[\u0000-\u001F\u007F]/g; // eslint-disable-line no-control-regex
+
+export type TaskNotificationStatus = 'completed' | 'failed';
+
+export type TaskNotification = {
+	taskTitle: string;
+	status: TaskNotificationStatus;
+	errorMessage?: string;
+};
+
+export type SessionNotification = {
+	projectName: string;
+};
+
+export type AgentTurnCompletionNotificationState = {
+	terminalFocused?: boolean;
+	wasUserInterrupted?: boolean;
+	willAutoContinue?: boolean;
+	pendingMessageCount?: number;
+};
+
+type NotificationPayload = {
+	title: string;
+	body: string;
+};
+
+type NotificationChannels = {
+	terminal?: boolean;
+	toast?: boolean;
+};
+
+const agentTurnCompletionChannels: NotificationChannels = {toast: false};
+
+export function truncate(value: string, maxLength: number): string {
+	if (maxLength <= 0) {
+		return '';
+	}
+
+	if (value.length <= maxLength) {
+		return value;
+	}
+
+	if (maxLength <= 3) {
+		return '.'.repeat(maxLength);
+	}
+
+	return `${value.slice(0, maxLength - 3)}...`;
+}
+
+export function cleanNotificationText(value: string): string {
+	return value
+		.replaceAll(notificationControlCharacters, ' ')
+		.replaceAll(/\s+/g, ' ')
+		.trim();
+}
+
+export function escapeXml(value: string): string {
+	return cleanNotificationText(value)
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&apos;');
+}
+
+export function formatTaskNotification({
+	taskTitle,
+	status,
+	errorMessage,
+}: TaskNotification): NotificationPayload {
+	const title =
+		status === 'completed' ? 'Snow task completed' : 'Snow task failed';
+	const body =
+		status === 'completed'
+			? taskTitle
+			: `${taskTitle}: ${errorMessage ?? 'Unknown error'}`;
+
+	return formatNotificationPayload(title, body);
+}
+
+export function formatAgentTurnCompletionNotification({
+	projectName,
+}: SessionNotification): NotificationPayload {
+	return formatNotificationPayload('Snow agent waiting for input', projectName);
+}
+
+export function shouldNotifyAgentTurnCompletion({
+	terminalFocused = true,
+	wasUserInterrupted = false,
+	willAutoContinue = false,
+	pendingMessageCount = 0,
+}: AgentTurnCompletionNotificationState): boolean {
+	// Codex only asks the terminal for attention when it is actually unfocused.
+	return (
+		!terminalFocused &&
+		!wasUserInterrupted &&
+		!willAutoContinue &&
+		pendingMessageCount === 0
+	);
+}
+
+function formatNotificationPayload(
+	title: string,
+	body: string,
+): NotificationPayload {
+	return {
+		title: truncate(cleanNotificationText(title), maxTitleLength),
+		body: truncate(cleanNotificationText(body), maxBodyLength),
+	};
+}
+
+export function buildTerminalNotificationSequences(
+	title: string,
+	body: string,
+): string[] {
+	const message = [cleanNotificationText(title), cleanNotificationText(body)]
+		.filter(Boolean)
+		.join(': ');
+
+	return message ? [`\u001B]9;${message}\u0007`, '\u0007'] : ['\u0007'];
+}
+
+export function buildToastScript(title: string, body: string): string {
+	const safeTitle = escapeXml(title);
+	const safeBody = escapeXml(body);
+	const safeAppId = appId.replaceAll("'", "''");
+
+	return `
+try {
+	[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+	[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null
+
+	$xml = @"
+<toast>
+	<visual>
+		<binding template="ToastGeneric">
+			<text>${safeTitle}</text>
+			<text>${safeBody}</text>
+		</binding>
+	</visual>
+</toast>
+"@
+	$document = New-Object Windows.Data.Xml.Dom.XmlDocument
+	$document.LoadXml($xml)
+	$toast = [Windows.UI.Notifications.ToastNotification]::new($document)
+	[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('${safeAppId}').Show($toast)
+} catch {
+	exit 0
+}
+`;
+}
+
+function writeTerminalNotification(title: string, body: string): void {
+	if (!process.stdout?.isTTY) {
+		return;
+	}
+
+	for (const sequence of buildTerminalNotificationSequences(title, body)) {
+		try {
+			process.stdout.write(sequence);
+		} catch {
+			// Terminal notifications are best-effort.
+		}
+	}
+}
+
+function showWindowsNotification(
+	{title, body}: NotificationPayload,
+	channels: NotificationChannels = {},
+): void {
+	if (process.platform !== 'win32') {
+		return;
+	}
+
+	const {terminal = true, toast = true} = channels;
+	if (terminal) {
+		writeTerminalNotification(title, body);
+	}
+
+	if (!toast) {
+		return;
+	}
+
+	const script = buildToastScript(title, body);
+	const encodedCommand = Buffer.from(script, 'utf16le').toString('base64');
+
+	try {
+		const child = spawn(
+			'powershell.exe',
+			[
+				'-NoProfile',
+				'-NonInteractive',
+				'-ExecutionPolicy',
+				'Bypass',
+				'-EncodedCommand',
+				encodedCommand,
+			],
+			{
+				detached: true,
+				stdio: 'ignore',
+				windowsHide: true,
+			},
+		);
+
+		child.on('error', () => undefined);
+		child.unref();
+	} catch {
+		// Notifications are best-effort and must never affect task execution.
+	}
+}
+
+export function notifyTaskFinished(
+	notification: TaskNotification,
+	channels: NotificationChannels = {},
+): void {
+	showWindowsNotification(formatTaskNotification(notification), channels);
+}
+
+export function notifyAgentTurnComplete(
+	notification: SessionNotification,
+	channels: NotificationChannels = agentTurnCompletionChannels,
+): void {
+	showWindowsNotification(
+		formatAgentTurnCompletionNotification(notification),
+		channels,
+	);
+}

--- a/source/utils/task/taskExecutor.ts
+++ b/source/utils/task/taskExecutor.ts
@@ -1,8 +1,9 @@
 import {spawn} from 'child_process';
-import {taskManager} from './taskManager.js';
 import {writeFileSync, appendFileSync, existsSync, mkdirSync} from 'fs';
 import {join} from 'path';
 import {homedir} from 'os';
+import {notifyTaskFinished} from '../platform/windows-notification.js';
+import {taskManager} from './taskManager.js';
 
 const TASK_LOG_DIR = join(homedir(), '.snow', 'task-logs');
 
@@ -24,6 +25,26 @@ function writeLog(taskId: string, message: string) {
 		appendFileSync(logPath, `[${timestamp}] ${message}\n`, 'utf-8');
 	} catch (error) {
 		// Fail silently - don't break task execution
+	}
+}
+
+async function notifyTaskExitFromParent(taskId: string): Promise<void> {
+	try {
+		const task = await taskManager.loadTask(taskId);
+		if (!task || (task.status !== 'completed' && task.status !== 'failed')) {
+			return;
+		}
+
+		notifyTaskFinished(
+			{
+				taskTitle: task.title,
+				status: task.status,
+				errorMessage: task.error,
+			},
+			{toast: false},
+		);
+	} catch {
+		// Parent-side terminal fallback is best-effort.
 	}
 }
 
@@ -81,6 +102,7 @@ export async function executeTaskInBackground(
 			taskId,
 			`[EXIT] Process exited with code ${code}, signal ${signal}`,
 		);
+		void notifyTaskExitFromParent(taskId);
 	});
 
 	// Save the PID to the task for process management
@@ -364,6 +386,10 @@ export async function executeTask(
 		if (completedTask) {
 			delete completedTask.pid;
 			await taskManager.saveTask(completedTask);
+			notifyTaskFinished({
+				taskTitle: completedTask.title,
+				status: 'completed',
+			});
 		}
 
 		log('Task execution finished successfully');
@@ -384,6 +410,11 @@ export async function executeTask(
 		if (failedTask) {
 			delete failedTask.pid;
 			await taskManager.saveTask(failedTask);
+			notifyTaskFinished({
+				taskTitle: failedTask.title,
+				status: 'failed',
+				errorMessage,
+			});
 		}
 
 		// Don't use console in detached process - errors already logged to file

--- a/source/utils/ui/terminal-title-formatter.test.ts
+++ b/source/utils/ui/terminal-title-formatter.test.ts
@@ -1,0 +1,57 @@
+import anyTest, {type TestFn} from 'ava';
+
+import {formatTerminalTitle} from './terminal-title-formatter.js';
+
+const test = anyTest as unknown as TestFn;
+
+test('formatTerminalTitle defaults to project only', t => {
+	t.is(formatTerminalTitle({projectName: 'my-project'}), 'my-project');
+});
+
+test('formatTerminalTitle falls back for empty project names', t => {
+	t.is(formatTerminalTitle({projectName: ''}), 'Unknown Project');
+});
+
+test('formatTerminalTitle removes control characters', t => {
+	t.is(
+		formatTerminalTitle({projectName: 'my\u001B\u0007project'}),
+		'my project',
+	);
+});
+
+test('formatTerminalTitle limits long project names', t => {
+	const title = formatTerminalTitle({projectName: 'P'.repeat(100)});
+
+	t.true(title.length <= 24);
+	t.true(title.endsWith('...'));
+});
+
+test('formatTerminalTitle shows activity spinner before project', t => {
+	t.is(
+		formatTerminalTitle({
+			projectName: 'my-project',
+			activity: true,
+			animationFrame: 1,
+		}),
+		'⠙ my-project',
+	);
+});
+
+test('formatTerminalTitle shows blinking action-required state', t => {
+	t.is(
+		formatTerminalTitle({
+			projectName: 'my-project',
+			actionRequired: true,
+			animationFrame: 0,
+		}),
+		'[ ! ] Action Required - my-project',
+	);
+	t.is(
+		formatTerminalTitle({
+			projectName: 'my-project',
+			actionRequired: true,
+			animationFrame: 1,
+		}),
+		'[ . ] Action Required - my-project',
+	);
+});

--- a/source/utils/ui/terminal-title-formatter.ts
+++ b/source/utils/ui/terminal-title-formatter.ts
@@ -1,0 +1,76 @@
+const defaultProjectName = 'Unknown Project';
+const maxProjectNameLength = 24;
+const controlCharacters = /[\u0000-\u001F\u007F]/g; // eslint-disable-line no-control-regex
+
+export const terminalTitleSpinnerFrames = [
+	'⠋',
+	'⠙',
+	'⠹',
+	'⠸',
+	'⠼',
+	'⠴',
+	'⠦',
+	'⠧',
+	'⠇',
+	'⠏',
+] as const;
+export const terminalTitleFrameCount = terminalTitleSpinnerFrames.length;
+
+type TerminalTitleState = {
+	projectName?: string;
+	activity?: boolean;
+	actionRequired?: boolean;
+	animationFrame?: number;
+};
+
+function cleanTitlePart(
+	value: string | undefined,
+	fallback: string,
+	maxLength: number,
+): string {
+	const cleaned = (value ?? '')
+		.replaceAll(controlCharacters, ' ')
+		.replaceAll(/\s+/g, ' ')
+		.trim();
+	const safeValue = cleaned || fallback;
+
+	return safeValue.length > maxLength
+		? `${safeValue.slice(0, maxLength - 3)}...`
+		: safeValue;
+}
+
+function getFrameIndex(animationFrame: number): number {
+	return Math.trunc(Math.abs(animationFrame)) % terminalTitleFrameCount;
+}
+
+function formatActionRequiredPrefix(animationFrame: number): string {
+	return getFrameIndex(animationFrame) % 2 === 0
+		? '[ ! ] Action Required'
+		: '[ . ] Action Required';
+}
+
+export function formatTerminalTitle({
+	projectName,
+	activity = false,
+	actionRequired = false,
+	animationFrame = 0,
+}: TerminalTitleState): string {
+	const safeProjectName = cleanTitlePart(
+		projectName,
+		defaultProjectName,
+		maxProjectNameLength,
+	);
+
+	if (actionRequired) {
+		return `${formatActionRequiredPrefix(animationFrame)} - ${safeProjectName}`;
+	}
+
+	if (activity) {
+		const spinnerFrame =
+			terminalTitleSpinnerFrames[getFrameIndex(animationFrame)]!;
+
+		return `${spinnerFrame} ${safeProjectName}`;
+	}
+
+	return safeProjectName;
+}


### PR DESCRIPTION
## Summary
- notify only when an agent turn waits for user input and the terminal is unfocused
- keep task notifications separate from agent-waiting attention
- preserve existing `process.title` + OSC terminal-title behavior while adding sanitized status formatting

## Verification
- git diff --check
- npx prettier --check source/hooks/ui/useTerminalTitle.ts source/ui/pages/ChatScreen.tsx source/utils/ui/terminal-title-formatter.ts source/utils/ui/terminal-title-formatter.test.ts source/utils/platform/windows-notification.ts source/utils/platform/windows-notification.test.ts source/hooks/conversation/chatLogic/useMessageProcessing.ts source/utils/task/taskExecutor.ts
- npx ava source/utils/platform/windows-notification.test.ts source/utils/ui/terminal-title-formatter.test.ts
- npx tsc --noEmit
- npm run build
