### PR TITLE
Preserve terminal title process title behavior

### DIFF
--- a/source/hooks/ui/useTerminalTitle.ts
+++ b/source/hooks/ui/useTerminalTitle.ts
@@ -3,7 +3,7 @@ import {useStdout} from 'ink';
 
 const titleControlCharacters = /[\u0000-\u001F\u007F]/g; // eslint-disable-line no-control-regex
 
-function cleanOscTitle(title: string): string {
+function cleanTerminalTitle(title: string): string {
 	return title
 		.replaceAll(titleControlCharacters, ' ')
 		.replaceAll(/\s+/g, ' ')
@@ -13,8 +13,24 @@ function cleanOscTitle(title: string): string {
 /**
  * 设置终端窗口/标签标题，组件卸载时自动清空。
  *
- * 只写 OSC 0；不要碰 process.title。Windows Terminal 顶层窗口标题可能
- * 由宿主加上 Administrator 等前缀，应用层不能也不应该伪装能删掉它。
+ * 跨平台兼容策略：
+ * 1. process.title：Windows 控制台直接生效，类 Unix 上仅修改进程名
+ * 2. OSC 转义序列 ESC]0;<title>BEL：所有支持 ANSI 的现代终端
+ *    （macOS Terminal/iTerm2、Windows Terminal、Linux 终端、mintty 等）
+ *
+ * 注意：
+ * - 非 TTY 环境（管道、重定向、CI 日志）会跳过，避免污染输出
+ * - 退出页面会写入空标题，多数终端会回退到默认值（如 cwd 或 shell 名）
+ * - tmux/screen 用户需启用 set-titles on 才能透传到外层终端
+ *
+ * @param title 要显示的标题；传入空字符串会清空标题
+ * @example
+ * ```tsx
+ * function MyScreen() {
+ *   useTerminalTitle('Snow CLI - 设置');
+ *   return <Box>...</Box>;
+ * }
+ * ```
  */
 export function useTerminalTitle(title: string): void {
 	const {stdout} = useStdout();
@@ -22,24 +38,46 @@ export function useTerminalTitle(title: string): void {
 	useEffect(() => {
 		if (!stdout?.isTTY) return;
 
-		const safeTitle = cleanOscTitle(title);
+		const safeTitle = cleanTerminalTitle(title);
 
+		// 保存原 process.title 以便卸载时恢复
+		let previousProcessTitle: string | undefined;
 		try {
-			stdout.write(`\u001B]0;${safeTitle}\u0007`);
+			previousProcessTitle = process.title;
 		} catch {
-			// Stdout 可能已关闭；标题是 best-effort，不能影响 UI。
+			// 某些受限环境读取 process.title 可能抛错，忽略即可
 		}
-	}, [stdout, title]);
 
-	useEffect(() => {
-		if (!stdout?.isTTY) return;
+		// 1. process.title：Windows 控制台直接生效，类 Unix 仅修改进程名
+		if (safeTitle) {
+			try {
+				process.title = safeTitle;
+			} catch {
+				// 某些平台（如部分容器/沙箱）写入 process.title 会失败，忽略
+			}
+		}
+
+		// 2. OSC 序列：所有支持 ANSI 的终端
+		try {
+			stdout.write(`\x1b]0;${safeTitle}\x07`);
+		} catch {
+			// stdout 已关闭或不可写时忽略，避免应用崩溃
+		}
 
 		return () => {
+			if (!stdout?.isTTY) return;
+			if (previousProcessTitle !== undefined) {
+				try {
+					process.title = previousProcessTitle;
+				} catch {
+					// 同上，忽略恢复失败
+				}
+			}
 			try {
-				stdout.write('\u001B]0;\u0007');
+				stdout.write('\x1b]0;\x07');
 			} catch {
-				// 卸载阶段 stdout 可能已关闭，忽略。
+				// 卸载阶段 stdout 可能已关闭，忽略
 			}
 		};
-	}, [stdout]);
+	}, [stdout, title]);
 }

--- a/source/ui/pages/ChatScreen.tsx
+++ b/source/ui/pages/ChatScreen.tsx
@@ -306,6 +306,7 @@ export default function ChatScreen({
 	}, [terminalTitleActive, hasPendingAction]);
 
 	const terminalTitle = formatTerminalTitle({
+		appTitle: t.chatScreen.headerTitle,
 		projectName,
 		activity: hasActiveProgress,
 		actionRequired: hasPendingAction,

--- a/source/utils/ui/terminal-title-formatter.test.ts
+++ b/source/utils/ui/terminal-title-formatter.test.ts
@@ -4,54 +4,74 @@ import {formatTerminalTitle} from './terminal-title-formatter.js';
 
 const test = anyTest as unknown as TestFn;
 
-test('formatTerminalTitle defaults to project only', t => {
-	t.is(formatTerminalTitle({projectName: 'my-project'}), 'my-project');
+test('formatTerminalTitle preserves Snow CLI header title prefix', t => {
+	t.is(
+		formatTerminalTitle({
+			appTitle: 'Programming efficiency x10!',
+			projectName: 'my-project',
+		}),
+		'Snow CLI - Programming efficiency x10! - my-project',
+	);
 });
 
 test('formatTerminalTitle falls back for empty project names', t => {
-	t.is(formatTerminalTitle({projectName: ''}), 'Unknown Project');
+	t.is(
+		formatTerminalTitle({
+			appTitle: 'Programming efficiency x10!',
+			projectName: '',
+		}),
+		'Snow CLI - Programming efficiency x10! - Unknown Project',
+	);
 });
 
 test('formatTerminalTitle removes control characters', t => {
 	t.is(
-		formatTerminalTitle({projectName: 'my\u001B\u0007project'}),
-		'my project',
+		formatTerminalTitle({
+			appTitle: 'Snow\u001B',
+			projectName: 'my\u0007project',
+		}),
+		'Snow CLI - Snow - my project',
 	);
 });
 
 test('formatTerminalTitle limits long project names', t => {
-	const title = formatTerminalTitle({projectName: 'P'.repeat(100)});
+	const title = formatTerminalTitle({
+		appTitle: 'Programming efficiency x10!',
+		projectName: 'P'.repeat(100),
+	});
 
-	t.true(title.length <= 24);
-	t.true(title.endsWith('...'));
+	t.true(title.endsWith(`${'P'.repeat(21)}...`));
 });
 
-test('formatTerminalTitle shows activity spinner before project', t => {
+test('formatTerminalTitle shows activity spinner before title', t => {
 	t.is(
 		formatTerminalTitle({
+			appTitle: 'Programming efficiency x10!',
 			projectName: 'my-project',
 			activity: true,
 			animationFrame: 1,
 		}),
-		'⠙ my-project',
+		'⠙ Snow CLI - Programming efficiency x10! - my-project',
 	);
 });
 
 test('formatTerminalTitle shows blinking action-required state', t => {
 	t.is(
 		formatTerminalTitle({
+			appTitle: 'Programming efficiency x10!',
 			projectName: 'my-project',
 			actionRequired: true,
 			animationFrame: 0,
 		}),
-		'[ ! ] Action Required - my-project',
+		'[ ! ] Action Required - Snow CLI - Programming efficiency x10! - my-project',
 	);
 	t.is(
 		formatTerminalTitle({
+			appTitle: 'Programming efficiency x10!',
 			projectName: 'my-project',
 			actionRequired: true,
 			animationFrame: 1,
 		}),
-		'[ . ] Action Required - my-project',
+		'[ . ] Action Required - Snow CLI - Programming efficiency x10! - my-project',
 	);
 });

--- a/source/utils/ui/terminal-title-formatter.ts
+++ b/source/utils/ui/terminal-title-formatter.ts
@@ -1,3 +1,4 @@
+const appName = 'Snow CLI';
 const defaultProjectName = 'Unknown Project';
 const maxProjectNameLength = 24;
 const controlCharacters = /[\u0000-\u001F\u007F]/g; // eslint-disable-line no-control-regex
@@ -17,6 +18,7 @@ export const terminalTitleSpinnerFrames = [
 export const terminalTitleFrameCount = terminalTitleSpinnerFrames.length;
 
 type TerminalTitleState = {
+	appTitle?: string;
 	projectName?: string;
 	activity?: boolean;
 	actionRequired?: boolean;
@@ -26,7 +28,7 @@ type TerminalTitleState = {
 function cleanTitlePart(
 	value: string | undefined,
 	fallback: string,
-	maxLength: number,
+	maxLength?: number,
 ): string {
 	const cleaned = (value ?? '')
 		.replaceAll(controlCharacters, ' ')
@@ -34,7 +36,7 @@ function cleanTitlePart(
 		.trim();
 	const safeValue = cleaned || fallback;
 
-	return safeValue.length > maxLength
+	return maxLength && safeValue.length > maxLength
 		? `${safeValue.slice(0, maxLength - 3)}...`
 		: safeValue;
 }
@@ -49,7 +51,13 @@ function formatActionRequiredPrefix(animationFrame: number): string {
 		: '[ . ] Action Required';
 }
 
+function formatBaseTitle(appTitle: string | undefined): string {
+	const safeAppTitle = cleanTitlePart(appTitle, '');
+	return safeAppTitle ? `${appName} - ${safeAppTitle}` : appName;
+}
+
 export function formatTerminalTitle({
+	appTitle,
 	projectName,
 	activity = false,
 	actionRequired = false,
@@ -60,17 +68,18 @@ export function formatTerminalTitle({
 		defaultProjectName,
 		maxProjectNameLength,
 	);
+	const title = `${formatBaseTitle(appTitle)} - ${safeProjectName}`;
 
 	if (actionRequired) {
-		return `${formatActionRequiredPrefix(animationFrame)} - ${safeProjectName}`;
+		return `${formatActionRequiredPrefix(animationFrame)} - ${title}`;
 	}
 
 	if (activity) {
 		const spinnerFrame =
 			terminalTitleSpinnerFrames[getFrameIndex(animationFrame)]!;
 
-		return `${spinnerFrame} ${safeProjectName}`;
+		return `${spinnerFrame} ${title}`;
 	}
 
-	return safeProjectName;
+	return title;
 }


### PR DESCRIPTION
## Summary
- restore the terminal title hook to the upstream `process.title` + OSC dual-path design
- keep unmount restoration/clear semantics and sanitize the formatted title before writing it
- restore the header title in the new status-aware terminal title formatter

## Verification
- git diff --check
- npx prettier --check source/hooks/ui/useTerminalTitle.ts source/ui/pages/ChatScreen.tsx source/utils/ui/terminal-title-formatter.ts source/utils/ui/terminal-title-formatter.test.ts source/utils/platform/windows-notification.ts source/utils/platform/windows-notification.test.ts source/hooks/conversation/chatLogic/useMessageProcessing.ts source/utils/task/taskExecutor.ts
- npx ava source/utils/platform/windows-notification.test.ts source/utils/ui/terminal-title-formatter.test.ts
- npx tsc --noEmit
- npm run build
