### PR TITLE
feat: add configurable OpenTelemetry tracing

### DIFF
--- a/source/hooks/conversation/useConversation.ts
+++ b/source/hooks/conversation/useConversation.ts
@@ -2,6 +2,8 @@ import type {ChatMessage} from '../../api/chat.js';
 import {getSnowConfig} from '../../utils/config/apiConfig.js';
 import type {Message} from '../../ui/components/chat/MessageList.js';
 import {connectionManager} from '../../utils/connection/ConnectionManager.js';
+import {sessionManager} from '../../utils/session/sessionManager.js';
+import {recordTurnContent, withTurnSpan} from '../../utils/telemetry/otel.js';
 import {extractThinkingContent} from './utils/thinkingExtractor.js';
 import {EncoderManager} from './core/encoderManager.js';
 import {
@@ -26,6 +28,33 @@ export type {
  * Returns the usage data collected during the conversation.
  */
 export async function handleConversationWithTools(
+	options: ConversationHandlerOptions,
+): Promise<{usage: ConversationUsage | null}> {
+	const config = getSnowConfig();
+	const model = options.useBasicModel
+		? config.basicModel || config.advancedModel || 'gpt-5'
+		: config.advancedModel || 'gpt-5';
+	const currentSession = sessionManager.getCurrentSession();
+	const turnId = currentSession
+		? `${currentSession.id}:${currentSession.messageCount + 1}`
+		: undefined;
+
+	return withTurnSpan(
+		{
+			sessionId: currentSession?.id,
+			conversationId: currentSession?.id,
+			turnId,
+			model,
+			requestMethod: config.requestMethod,
+			planMode: options.planMode,
+			vulnerabilityHuntingMode: options.vulnerabilityHuntingMode,
+			teamMode: options.teamMode,
+		},
+		() => runConversationWithTools(options),
+	);
+}
+
+async function runConversationWithTools(
 	options: ConversationHandlerOptions,
 ): Promise<{usage: ConversationUsage | null}> {
 	const {
@@ -69,6 +98,12 @@ export async function handleConversationWithTools(
 		imageContents,
 		saveMessage,
 		abortSignal: controller.signal,
+	});
+	recordTurnContent('request', userContent, {
+		'snow.content.source': 'user',
+		...(imageContents?.length
+			? {'snow.content.image_count': imageContents.length}
+			: {}),
 	});
 
 	const encoderManager = new EncoderManager();
@@ -161,10 +196,15 @@ export async function handleConversationWithTools(
 			}
 
 			if (streamResult.streamedContent.trim()) {
+				const assistantContent = streamResult.streamedContent.trim();
+				recordTurnContent('response', assistantContent, {
+					'snow.content.source': 'assistant',
+				});
+
 				if (!streamResult.hasStreamedLines) {
 					const finalAssistantMessage: Message = {
 						role: 'assistant',
-						content: streamResult.streamedContent.trim(),
+						content: assistantContent,
 						streaming: false,
 						discontinued: controller.signal.aborted,
 						thinking: extractThinkingContent(
@@ -178,7 +218,7 @@ export async function handleConversationWithTools(
 
 				const assistantMessage: ChatMessage = {
 					role: 'assistant',
-					content: streamResult.streamedContent.trim(),
+					content: assistantContent,
 					reasoning: streamResult.receivedReasoning,
 					thinking: streamResult.receivedThinking,
 					reasoning_content: streamResult.receivedReasoningContent,

--- a/source/i18n/lang/en.ts
+++ b/source/i18n/lang/en.ts
@@ -633,6 +633,7 @@ export const en: TranslationKeys = {
 		description2:
 			'Settings are saved to Snow JSON project settings and are passed directly to OpenTelemetry exporters. Environment variables are not used.',
 		enableTelemetry: 'Enable telemetry',
+		serviceName: 'Service name',
 		tracesExporter: 'Traces exporter',
 		metricsExporter: 'Metrics exporter',
 		logsExporter: 'Logs exporter',
@@ -640,7 +641,11 @@ export const en: TranslationKeys = {
 		otlpEndpoint: 'OTLP base endpoint',
 		otlpHeaders: 'OTLP headers',
 		injectSessionIdHeader: 'Inject Session-Id header',
+		captureContent: 'Capture prompt/tool content',
+		contentMaxLength: 'Content max length',
 		hintEnabled: 'Stored in Snow JSON project settings',
+		hintServiceName:
+			'OpenTelemetry resource service.name. Empty uses the default snow-cli. Restart Snow after changing.',
 		hintTracesExporter: 'Options: otlp, console, none',
 		hintMetricsExporter: 'Options: otlp, prometheus, console, none',
 		hintLogsExporter: 'Options: otlp, console, none',
@@ -650,6 +655,10 @@ export const en: TranslationKeys = {
 		hintOtlpHeaders: 'Example: Authorization=Bearer your-token',
 		hintInjectSessionIdHeader:
 			'When enabled, injects Session-Id from the current trace tag snow.session_id if Session-Id is not configured manually.',
+		hintCaptureContent:
+			'On by default. Disable if traces must not include prompts, completions, tool args, or tool results.',
+		hintContentMaxLength:
+			'Max characters per captured content event when content capture is enabled.',
 		empty: '(empty)',
 		savedMessage:
 			'OpenTelemetry telemetry settings saved. Restart Snow to reinitialize exporters.',

--- a/source/i18n/lang/zh-TW.ts
+++ b/source/i18n/lang/zh-TW.ts
@@ -600,6 +600,7 @@ export const zhTW: TranslationKeys = {
 		description2:
 			'設定儲存到 Snow JSON 專案設定中，並直接傳遞給 OpenTelemetry 匯出器。不使用環境變數。',
 		enableTelemetry: '啟用遙測',
+		serviceName: 'Service 名稱',
 		tracesExporter: 'Traces 匯出器',
 		metricsExporter: 'Metrics 匯出器',
 		logsExporter: 'Logs 匯出器',
@@ -607,7 +608,11 @@ export const zhTW: TranslationKeys = {
 		otlpEndpoint: 'OTLP 基礎端點',
 		otlpHeaders: 'OTLP 標頭',
 		injectSessionIdHeader: '注入 Session-Id 標頭',
+		captureContent: '收集 prompt/tool 原文',
+		contentMaxLength: '原文最大長度',
 		hintEnabled: '儲存在 Snow JSON 專案設定中',
+		hintServiceName:
+			'OpenTelemetry resource.service.name。留空使用預設 snow-cli。修改後需重啟 Snow 生效。',
 		hintTracesExporter: '可選: otlp, console, none',
 		hintMetricsExporter: '可選: otlp, prometheus, console, none',
 		hintLogsExporter: '可選: otlp, console, none',
@@ -617,6 +622,9 @@ export const zhTW: TranslationKeys = {
 		hintOtlpHeaders: '例如: Authorization=Bearer your-token',
 		hintInjectSessionIdHeader:
 			'啟用後若未手動設定 Session-Id，則使用目前鏈路 Tags 中的 snow.session_id 注入標頭',
+		hintCaptureContent:
+			'預設開啟。如果 trace 不應包含 prompt、completion、tool 參數或 tool 結果，請關閉。',
+		hintContentMaxLength: '開啟原文收集後，每個 content 事件最多保留的字元數。',
 		empty: '(空)',
 		savedMessage:
 			'OpenTelemetry 遙測設定已儲存。重啟 Snow 以重新初始化匯出器。',

--- a/source/i18n/lang/zh.ts
+++ b/source/i18n/lang/zh.ts
@@ -599,6 +599,7 @@ export const zh: TranslationKeys = {
 		description2:
 			'设置保存到 Snow JSON 项目配置中，并直接传递给 OpenTelemetry 导出器。不使用环境变量。',
 		enableTelemetry: '启用遥测',
+		serviceName: 'Service 名称',
 		tracesExporter: 'Traces 导出器',
 		metricsExporter: 'Metrics 导出器',
 		logsExporter: 'Logs 导出器',
@@ -606,7 +607,11 @@ export const zh: TranslationKeys = {
 		otlpEndpoint: 'OTLP 基础端点',
 		otlpHeaders: 'OTLP 请求头',
 		injectSessionIdHeader: '注入 Session-Id 请求头',
+		captureContent: '采集 prompt/tool 原文',
+		contentMaxLength: '原文最大长度',
 		hintEnabled: '存储在 Snow JSON 项目配置中',
+		hintServiceName:
+			'OpenTelemetry resource.service.name。留空使用默认 snow-cli。修改后需重启 Snow 生效。',
 		hintTracesExporter: '可选: otlp, console, none',
 		hintMetricsExporter: '可选: otlp, prometheus, console, none',
 		hintLogsExporter: '可选: otlp, console, none',
@@ -616,6 +621,9 @@ export const zh: TranslationKeys = {
 		hintOtlpHeaders: '例如: Authorization=Bearer your-token',
 		hintInjectSessionIdHeader:
 			'启用后若未手动设置 Session-Id，则使用当前链路 Tags 中的 snow.session_id 注入请求头',
+		hintCaptureContent:
+			'默认开启。如果 trace 不应包含 prompt、completion、tool 参数或 tool 结果，请关闭。',
+		hintContentMaxLength: '开启原文采集后，每个 content 事件最多保留的字符数。',
 		empty: '(空)',
 		savedMessage:
 			'OpenTelemetry 遥测设置已保存。重启 Snow 以重新初始化导出器。',

--- a/source/i18n/types.ts
+++ b/source/i18n/types.ts
@@ -579,12 +579,12 @@ export type TranslationKeys = {
 		useCommandPrefix: string;
 		useCommandSuffix: string;
 	};
-	// Telemetry Panel
 	telemetryPanel: {
 		title: string;
 		description1: string;
 		description2: string;
 		enableTelemetry: string;
+		serviceName: string;
 		tracesExporter: string;
 		metricsExporter: string;
 		logsExporter: string;
@@ -592,7 +592,10 @@ export type TranslationKeys = {
 		otlpEndpoint: string;
 		otlpHeaders: string;
 		injectSessionIdHeader: string;
+		captureContent: string;
+		contentMaxLength: string;
 		hintEnabled: string;
+		hintServiceName: string;
 		hintTracesExporter: string;
 		hintMetricsExporter: string;
 		hintLogsExporter: string;
@@ -600,6 +603,8 @@ export type TranslationKeys = {
 		hintOtlpEndpoint: string;
 		hintOtlpHeaders: string;
 		hintInjectSessionIdHeader: string;
+		hintCaptureContent: string;
+		hintContentMaxLength: string;
 		empty: string;
 		savedMessage: string;
 		navigationHint: string;

--- a/source/ui/components/panels/TelemetryPanel.tsx
+++ b/source/ui/components/panels/TelemetryPanel.tsx
@@ -5,6 +5,7 @@ import {useTheme} from '../../contexts/ThemeContext.js';
 import {useI18n} from '../../../i18n/index.js';
 import {useTerminalSize} from '../../../hooks/ui/useTerminalSize.js';
 import {
+	DEFAULT_TELEMETRY_SERVICE_NAME,
 	getTelemetryConfig,
 	setTelemetryConfig,
 	type TelemetryConfig,
@@ -16,16 +17,20 @@ interface Props {
 
 type FieldKey =
 	| 'enabled'
+	| 'serviceName'
 	| 'tracesExporter'
 	| 'metricsExporter'
 	| 'logsExporter'
 	| 'otlpProtocol'
 	| 'otlpEndpoint'
 	| 'otlpHeaders'
-	| 'injectSessionIdHeader';
+	| 'injectSessionIdHeader'
+	| 'captureContent'
+	| 'contentMaxLength';
 
 const FIELD_ORDER: FieldKey[] = [
 	'enabled',
+	'serviceName',
 	'tracesExporter',
 	'metricsExporter',
 	'logsExporter',
@@ -33,6 +38,8 @@ const FIELD_ORDER: FieldKey[] = [
 	'otlpEndpoint',
 	'otlpHeaders',
 	'injectSessionIdHeader',
+	'captureContent',
+	'contentMaxLength',
 ];
 
 const EXPORTER_OPTIONS = ['otlp', 'console', 'none'] as const;
@@ -60,6 +67,7 @@ function cycleOption<T extends readonly string[]>(
 function normalizeConfig(config: TelemetryConfig): Required<TelemetryConfig> {
 	return {
 		enabled: config.enabled ?? false,
+		serviceName: config.serviceName?.trim() || DEFAULT_TELEMETRY_SERVICE_NAME,
 		tracesExporter: config.tracesExporter ?? 'otlp',
 		metricsExporter: config.metricsExporter ?? 'otlp',
 		logsExporter: config.logsExporter ?? 'none',
@@ -67,6 +75,8 @@ function normalizeConfig(config: TelemetryConfig): Required<TelemetryConfig> {
 		otlpEndpoint: config.otlpEndpoint ?? 'http://localhost:4317',
 		otlpHeaders: config.otlpHeaders ?? '',
 		injectSessionIdHeader: config.injectSessionIdHeader ?? false,
+		captureContent: config.captureContent ?? true,
+		contentMaxLength: config.contentMaxLength ?? 4096,
 	};
 }
 
@@ -109,7 +119,7 @@ export const TelemetryPanel: React.FC<Props> = ({onClose}) => {
 	}, [focusIndex, visibleFieldCount]);
 
 	const save = useCallback(() => {
-		setTelemetryConfig(config);
+		setTelemetryConfig(normalizeConfig(config));
 		setMessage(t.telemetryPanel.savedMessage);
 		setTimeout(() => setMessage(''), 2000);
 	}, [config, t.telemetryPanel.savedMessage]);
@@ -173,6 +183,10 @@ export const TelemetryPanel: React.FC<Props> = ({onClose}) => {
 						};
 					}
 
+					case 'captureContent': {
+						return {...previous, captureContent: !previous.captureContent};
+					}
+
 					default: {
 						return previous;
 					}
@@ -212,7 +226,12 @@ export const TelemetryPanel: React.FC<Props> = ({onClose}) => {
 
 		if (key.return) {
 			// Enter no longer saves; just cycle to the next field
-			if (focusedField !== 'otlpEndpoint' && focusedField !== 'otlpHeaders') {
+			if (
+				focusedField !== 'serviceName' &&
+				focusedField !== 'otlpEndpoint' &&
+				focusedField !== 'otlpHeaders' &&
+				focusedField !== 'contentMaxLength'
+			) {
 				cycleFocused(1);
 			}
 			return;
@@ -235,6 +254,12 @@ export const TelemetryPanel: React.FC<Props> = ({onClose}) => {
 				label: t.telemetryPanel.enableTelemetry,
 				value: config.enabled ? 'on' : 'off',
 				hint: t.telemetryPanel.hintEnabled,
+			},
+			{
+				key: 'serviceName' as const,
+				label: t.telemetryPanel.serviceName,
+				value: config.serviceName,
+				hint: t.telemetryPanel.hintServiceName,
 			},
 			{
 				key: 'tracesExporter' as const,
@@ -277,6 +302,18 @@ export const TelemetryPanel: React.FC<Props> = ({onClose}) => {
 				label: t.telemetryPanel.injectSessionIdHeader,
 				value: config.injectSessionIdHeader ? 'on' : 'off',
 				hint: t.telemetryPanel.hintInjectSessionIdHeader,
+			},
+			{
+				key: 'captureContent' as const,
+				label: t.telemetryPanel.captureContent,
+				value: config.captureContent ? 'on' : 'off',
+				hint: t.telemetryPanel.hintCaptureContent,
+			},
+			{
+				key: 'contentMaxLength' as const,
+				label: t.telemetryPanel.contentMaxLength,
+				value: String(config.contentMaxLength),
+				hint: t.telemetryPanel.hintContentMaxLength,
 			},
 		],
 		[config, t.telemetryPanel],
@@ -323,7 +360,10 @@ export const TelemetryPanel: React.FC<Props> = ({onClose}) => {
 					const actualIndex = scrollOffset + index;
 					const selected = actualIndex === focusIndex;
 					const editable =
-						field.key === 'otlpEndpoint' || field.key === 'otlpHeaders';
+						field.key === 'serviceName' ||
+						field.key === 'otlpEndpoint' ||
+						field.key === 'otlpHeaders' ||
+						field.key === 'contentMaxLength';
 					const valueColor = selected
 						? theme.colors.menuInfo
 						: theme.colors.text;
@@ -345,7 +385,13 @@ export const TelemetryPanel: React.FC<Props> = ({onClose}) => {
 									<TextInput
 										value={field.value}
 										onChange={value =>
-											setConfig(previous => ({...previous, [field.key]: value}))
+											setConfig(previous => ({
+												...previous,
+												[field.key]:
+													field.key === 'contentMaxLength'
+														? Math.max(0, Number.parseInt(value, 10) || 0)
+														: value,
+											}))
 										}
 										focus
 									/>

--- a/source/utils/config/projectSettings.ts
+++ b/source/utils/config/projectSettings.ts
@@ -21,6 +21,7 @@ export interface ProjectSettings {
 
 export interface TelemetryConfig {
 	enabled?: boolean;
+	serviceName?: string;
 	tracesExporter?: 'otlp' | 'console' | 'none';
 	metricsExporter?: 'otlp' | 'prometheus' | 'console' | 'none';
 	logsExporter?: 'otlp' | 'console' | 'none';
@@ -28,8 +29,11 @@ export interface TelemetryConfig {
 	otlpEndpoint?: string;
 	otlpHeaders?: string;
 	injectSessionIdHeader?: boolean;
+	captureContent?: boolean;
+	contentMaxLength?: number;
 }
 
+export const DEFAULT_TELEMETRY_SERVICE_NAME = 'snow-cli';
 export const DEFAULT_SUB_AGENT_MAX_SPAWN_DEPTH = 1;
 
 /**
@@ -179,6 +183,8 @@ export function getTelemetryConfig(): TelemetryConfig {
 	const settings = loadSettings();
 	return {
 		enabled: settings.telemetry?.enabled ?? false,
+		serviceName:
+			settings.telemetry?.serviceName?.trim() || DEFAULT_TELEMETRY_SERVICE_NAME,
 		tracesExporter: settings.telemetry?.tracesExporter ?? 'otlp',
 		metricsExporter: settings.telemetry?.metricsExporter ?? 'otlp',
 		logsExporter: settings.telemetry?.logsExporter ?? 'none',
@@ -186,6 +192,8 @@ export function getTelemetryConfig(): TelemetryConfig {
 		otlpEndpoint: settings.telemetry?.otlpEndpoint ?? 'http://localhost:4317',
 		otlpHeaders: settings.telemetry?.otlpHeaders ?? '',
 		injectSessionIdHeader: settings.telemetry?.injectSessionIdHeader ?? false,
+		captureContent: settings.telemetry?.captureContent ?? true,
+		contentMaxLength: settings.telemetry?.contentMaxLength ?? 4096,
 	};
 }
 

--- a/source/utils/config/unifiedSettings.ts
+++ b/source/utils/config/unifiedSettings.ts
@@ -42,12 +42,16 @@ export interface UnifiedSettings {
 	ultraTodoEnabled?: boolean;
 	telemetry?: {
 		enabled?: boolean;
+		serviceName?: string;
 		tracesExporter?: 'otlp' | 'console' | 'none';
 		metricsExporter?: 'otlp' | 'prometheus' | 'console' | 'none';
 		logsExporter?: 'otlp' | 'console' | 'none';
 		otlpProtocol?: 'grpc' | 'http/protobuf' | 'http/json';
 		otlpEndpoint?: string;
 		otlpHeaders?: string;
+		injectSessionIdHeader?: boolean;
+		captureContent?: boolean;
+		contentMaxLength?: number;
 	};
 
 	// === 来自旧 codebase.json ===

--- a/source/utils/core/autoCompress.ts
+++ b/source/utils/core/autoCompress.ts
@@ -1,5 +1,6 @@
 import type {CompressionStatus} from '../../ui/components/compression/CompressionStatus.js';
 import {executeContextCompression} from '../../hooks/conversation/useCommandHandler.js';
+import {withCompactSpan} from '../telemetry/otel.js';
 
 const COMPRESSION_MAX_RETRIES = 3;
 const COMPRESSION_RETRY_BASE_DELAY = 1000;
@@ -19,89 +20,94 @@ export function shouldAutoCompress(
 }
 
 /**
- * 执行自动压缩（含自动重试，失败提示 5s 后自动消失）
- * @param sessionId - 可选的会话ID，如果提供则使用该ID加载会话进行压缩
- * @param onStatusUpdate - 可选的状态更新回调，用于在UI中显示压缩进度
- * @returns 压缩结果，如果失败返回null或包含hookFailed的结果
+ * 执行自动上下文压缩，失败时最多重试 3 次。
  */
 export async function performAutoCompression(
 	sessionId?: string,
 	onStatusUpdate?: (status: CompressionStatus | null) => void,
 ) {
-	let lastError = '';
+	return withCompactSpan(
+		{
+			name: 'snow.cli.compact',
+			sessionId,
+			conversationId: sessionId,
+		},
+		async () => {
+			let lastError = '';
 
-	for (let attempt = 0; attempt <= COMPRESSION_MAX_RETRIES; attempt++) {
-		try {
-			let failedInAttempt = false;
+			for (let attempt = 0; attempt <= COMPRESSION_MAX_RETRIES; attempt++) {
+				try {
+					let failedInAttempt = false;
 
-			const result = await executeContextCompression(
-				sessionId,
-				(status) => {
-					if (status.step === 'failed') {
-						failedInAttempt = true;
-						lastError = status.message || 'Unknown error';
-						// Don't forward failed status to UI during retries;
-						// retry logic below will show 'retrying' or final 'failed' instead.
-						return;
+					const result = await executeContextCompression(sessionId, status => {
+						if (status.step === 'failed') {
+							failedInAttempt = true;
+							lastError = status.message || 'Unknown error';
+							// Don't forward failed status to UI during retries;
+							// retry logic below will show 'retrying' or final 'failed' instead.
+							return;
+						}
+
+						onStatusUpdate?.(status);
+					});
+
+					if (result && (result as {hookFailed?: boolean}).hookFailed) {
+						return result;
 					}
-					onStatusUpdate?.(status);
-				},
-			);
 
-			if (result && (result as any).hookFailed) {
-				return result;
+					if (result) {
+						return result;
+					}
+
+					// null + not a failure (e.g. skipped) → don't retry
+					if (!failedInAttempt) {
+						return null;
+					}
+
+					// Failed – retry if attempts remain
+					if (attempt < COMPRESSION_MAX_RETRIES) {
+						const retryDelay =
+							COMPRESSION_RETRY_BASE_DELAY * Math.pow(2, attempt);
+						onStatusUpdate?.({
+							step: 'retrying',
+							message: lastError,
+							sessionId,
+							retryAttempt: attempt + 1,
+							maxRetries: COMPRESSION_MAX_RETRIES,
+						});
+						await new Promise(resolve => setTimeout(resolve, retryDelay));
+						continue;
+					}
+				} catch (error) {
+					lastError = error instanceof Error ? error.message : 'Unknown error';
+
+					if (attempt < COMPRESSION_MAX_RETRIES) {
+						const retryDelay =
+							COMPRESSION_RETRY_BASE_DELAY * Math.pow(2, attempt);
+						onStatusUpdate?.({
+							step: 'retrying',
+							message: lastError,
+							sessionId,
+							retryAttempt: attempt + 1,
+							maxRetries: COMPRESSION_MAX_RETRIES,
+						});
+						await new Promise(resolve => setTimeout(resolve, retryDelay));
+						continue;
+					}
+				}
 			}
 
-			if (result) {
-				return result;
+			// All retries exhausted
+			onStatusUpdate?.({
+				step: 'failed',
+				message: `Failed after ${COMPRESSION_MAX_RETRIES} retries: ${lastError}`,
+				sessionId,
+			});
+			if (onStatusUpdate) {
+				setTimeout(() => onStatusUpdate(null), COMPRESSION_ERROR_DISMISS_MS);
 			}
 
-			// null + not a failure (e.g. skipped) → don't retry
-			if (!failedInAttempt) {
-				return null;
-			}
-
-			// Failed – retry if attempts remain
-			if (attempt < COMPRESSION_MAX_RETRIES) {
-				const retryDelay =
-					COMPRESSION_RETRY_BASE_DELAY * Math.pow(2, attempt);
-				onStatusUpdate?.({
-					step: 'retrying',
-					message: lastError,
-					sessionId,
-					retryAttempt: attempt + 1,
-					maxRetries: COMPRESSION_MAX_RETRIES,
-				});
-				await new Promise(resolve => setTimeout(resolve, retryDelay));
-				continue;
-			}
-		} catch (error) {
-			lastError = error instanceof Error ? error.message : 'Unknown error';
-
-			if (attempt < COMPRESSION_MAX_RETRIES) {
-				const retryDelay =
-					COMPRESSION_RETRY_BASE_DELAY * Math.pow(2, attempt);
-				onStatusUpdate?.({
-					step: 'retrying',
-					message: lastError,
-					sessionId,
-					retryAttempt: attempt + 1,
-					maxRetries: COMPRESSION_MAX_RETRIES,
-				});
-				await new Promise(resolve => setTimeout(resolve, retryDelay));
-				continue;
-			}
-		}
-	}
-
-	// All retries exhausted
-	onStatusUpdate?.({
-		step: 'failed',
-		message: `Failed after ${COMPRESSION_MAX_RETRIES} retries: ${lastError}`,
-		sessionId,
-	});
-	if (onStatusUpdate) {
-		setTimeout(() => onStatusUpdate(null), COMPRESSION_ERROR_DISMISS_MS);
-	}
-	return null;
+			return null;
+		},
+	);
 }

--- a/source/utils/execution/subAgentExecutor.ts
+++ b/source/utils/execution/subAgentExecutor.ts
@@ -1,3 +1,5 @@
+import type {Context} from '@opentelemetry/api';
+
 import {collectAllMCPTools} from './mcpToolsManager.js';
 import {getSnowConfig} from '../config/apiConfig.js';
 import {sessionManager} from '../session/sessionManager.js';
@@ -23,6 +25,7 @@ import {
 import {checkAndApproveTools, executeMcpTools} from './subAgentToolApproval.js';
 import {emitSubAgentMessage} from './subAgentTypes.js';
 import {compressionCoordinator} from '../core/compressionCoordinator.js';
+import {withAgentSpan} from '../telemetry/otel.js';
 import type {
 	SubAgentExecutionContext,
 	SubAgentMessage,
@@ -59,6 +62,7 @@ export async function executeSubAgent(
 	requestUserQuestion?: UserQuestionCallback,
 	instanceId?: string,
 	spawnDepth: number = 0,
+	parentContext?: Context,
 ): Promise<SubAgentResult> {
 	let ctx: SubAgentExecutionContext | undefined;
 	try {
@@ -68,155 +72,173 @@ export async function executeSubAgent(
 			return {success: false, result: '', error: resolveError};
 		}
 
-		// 2. Filter tools + inject builtin tools
-		const allTools = await collectAllMCPTools();
-		const allowedTools = filterAllowedTools(agent, allTools);
-		if (allowedTools.length === 0) {
-			return {
-				success: false,
-				result: '',
-				error: `Sub-agent "${agent.name}" has no valid tools configured`,
-			};
-		}
-		injectBuiltinTools(allowedTools, spawnDepth);
-
-		// 3. Build initial messages
-		const messages = await buildInitialMessages(
-			agent,
-			prompt,
-			instanceId,
-			spawnDepth,
-		);
-
-		// 4. Build execution context
-		ctx = {
-			agent,
-			instanceId,
-			messages,
-			onMessage,
-			abortSignal,
-			requestToolConfirmation,
-			isToolAutoApproved,
-			yoloMode: yoloMode ?? false,
-			addToAlwaysApproved,
-			requestUserQuestion,
-			spawnDepth,
-			sessionApprovedTools: new Set<string>(),
-			spawnedChildInstanceIds: new Set<string>(),
-			collectedInjectedMessages: [],
-			collectedTerminationInstructions: [],
-			latestTotalTokens: 0,
-			totalUsage: undefined,
-			finalResponse: '',
-		};
-
-		// 5. Main loop
-		// eslint-disable-next-line no-constant-condition
-		while (true) {
-			if (abortSignal?.aborted) {
-				emitSubAgentMessage(ctx, {type: 'done'});
-				return {
-					success: false,
-					result: ctx.finalResponse,
-					error: 'Sub-agent execution aborted',
-				};
-			}
-
-			// Wait if the main flow (or another participant) is compressing.
-			await compressionCoordinator.waitUntilFree(ctx.instanceId);
-
-			// Inject pending user / inter-agent messages
-			injectPendingMessages(ctx);
-
-			// Resolve config + create API stream
-			const {config, model} = await resolveConfig(agent);
-			const currentSession = sessionManager.getCurrentSession();
-			const stream = createApiStream(
-				config,
-				model,
-				ctx.messages,
-				allowedTools,
-				currentSession?.id,
-				agent.configProfile,
-				abortSignal,
-			);
-
-			// Process stream events
-			ctx.latestTotalTokens = 0;
-			const {toolCalls, hasError, errorMessage} = await processStreamEvents(
-				ctx,
-				stream,
-				config,
-			);
-
-			if (hasError) {
-				return {
-					success: false,
-					result: ctx.finalResponse,
-					error: errorMessage,
-				};
-			}
-
-			// Context compression
-			const compressed = await handleContextCompression(ctx, config, model);
-			if (compressed && toolCalls.length === 0) {
-				// Remove premature exit response, inject continuation
-				while (
-					ctx.messages.length > 0 &&
-					ctx.messages[ctx.messages.length - 1]?.role === 'assistant'
-				) {
-					ctx.messages.pop();
+		const currentSession = sessionManager.getCurrentSession();
+		return await withAgentSpan(
+			{
+				agentId: agent.id ?? agentId,
+				agentName: agent.name ?? agentId,
+				instanceId,
+				sessionId: currentSession?.id,
+				conversationId: currentSession?.id,
+				spawnDepth,
+				parentContext,
+			},
+			async () => {
+				// 2. Filter tools + inject builtin tools
+				const allTools = await collectAllMCPTools();
+				const allowedTools = filterAllowedTools(agent, allTools);
+				if (allowedTools.length === 0) {
+					return {
+						success: false,
+						result: '',
+						error: `Sub-agent "${agent.name}" has no valid tools configured`,
+					};
 				}
-				ctx.messages.push({
-					role: 'user',
-					content:
-						'[System] Your context has been auto-compressed to free up space. Your task is NOT finished. Continue working based on the compressed context above. Pick up where you left off.',
-				});
-				continue;
-			}
+				injectBuiltinTools(allowedTools, spawnDepth);
 
-			// No tool calls → check spawned children / completion hooks → break
-			if (toolCalls.length === 0) {
-				if (await handleSpawnedChildren(ctx)) continue;
-				if (await handleCompletionHooks(ctx)) continue;
-				break;
-			}
+				// 3. Build initial messages
+				const messages = await buildInitialMessages(
+					agent,
+					prompt,
+					instanceId,
+					spawnDepth,
+				);
 
-			// Intercept builtin tools
-			let remaining = toolCalls;
-			remaining = interceptSendMessage(ctx, remaining).remainingToolCalls;
-			remaining = interceptQueryStatus(ctx, remaining).remainingToolCalls;
-			remaining = interceptSpawnSubAgent(
-				ctx,
-				remaining,
-				executeSubAgent,
-			).remainingToolCalls;
-			remaining = (await interceptAskUser(ctx, remaining)).remainingToolCalls;
-			if (remaining.length === 0) continue;
+				// 4. Build execution context
+				ctx = {
+					agent,
+					instanceId,
+					messages,
+					onMessage,
+					abortSignal,
+					requestToolConfirmation,
+					isToolAutoApproved,
+					yoloMode: yoloMode ?? false,
+					addToAlwaysApproved,
+					requestUserQuestion,
+					spawnDepth,
+					sessionApprovedTools: new Set<string>(),
+					spawnedChildInstanceIds: new Set<string>(),
+					collectedInjectedMessages: [],
+					collectedTerminationInstructions: [],
+					latestTotalTokens: 0,
+					totalUsage: undefined,
+					finalResponse: '',
+				};
 
-			// Approve + execute MCP tools
-			const approval = await checkAndApproveTools(ctx, remaining);
-			if (approval.shouldContinue) continue;
+				// 5. Main loop
+				// eslint-disable-next-line no-constant-condition
+				while (true) {
+					if (abortSignal?.aborted) {
+						emitSubAgentMessage(ctx, {type: 'done'});
+						return {
+							success: false,
+							result: ctx.finalResponse,
+							error: 'Sub-agent execution aborted',
+						};
+					}
 
-			const execResult = await executeMcpTools(ctx, approval.approvedToolCalls);
-			if (execResult.aborted && execResult.abortResult) {
-				return execResult.abortResult;
-			}
-		}
+					// Wait if the main flow (or another participant) is compressing.
+					await compressionCoordinator.waitUntilFree(ctx.instanceId);
 
-		return {
-			success: true,
-			result: ctx.finalResponse,
-			usage: ctx.totalUsage,
-			injectedUserMessages:
-				ctx.collectedInjectedMessages.length > 0
-					? ctx.collectedInjectedMessages
-					: undefined,
-			terminationInstructions:
-				ctx.collectedTerminationInstructions.length > 0
-					? ctx.collectedTerminationInstructions
-					: undefined,
-		};
+					// Inject pending user / inter-agent messages
+					injectPendingMessages(ctx);
+
+					// Resolve config + create API stream
+					const {config, model} = await resolveConfig(agent);
+					const currentSession = sessionManager.getCurrentSession();
+					const stream = createApiStream(
+						config,
+						model,
+						ctx.messages,
+						allowedTools,
+						currentSession?.id,
+						agent.configProfile,
+						abortSignal,
+					);
+
+					// Process stream events
+					ctx.latestTotalTokens = 0;
+					const {toolCalls, hasError, errorMessage} = await processStreamEvents(
+						ctx,
+						stream,
+						config,
+					);
+
+					if (hasError) {
+						return {
+							success: false,
+							result: ctx.finalResponse,
+							error: errorMessage,
+						};
+					}
+
+					// Context compression
+					const compressed = await handleContextCompression(ctx, config, model);
+					if (compressed && toolCalls.length === 0) {
+						// Remove premature exit response, inject continuation
+						while (
+							ctx.messages.length > 0 &&
+							ctx.messages[ctx.messages.length - 1]?.role === 'assistant'
+						) {
+							ctx.messages.pop();
+						}
+						ctx.messages.push({
+							role: 'user',
+							content:
+								'[System] Your context has been auto-compressed to free up space. Your task is NOT finished. Continue working based on the compressed context above. Pick up where you left off.',
+						});
+						continue;
+					}
+
+					// No tool calls → check spawned children / completion hooks → break
+					if (toolCalls.length === 0) {
+						if (await handleSpawnedChildren(ctx)) continue;
+						if (await handleCompletionHooks(ctx)) continue;
+						break;
+					}
+
+					// Intercept builtin tools
+					let remaining = toolCalls;
+					remaining = (await interceptSendMessage(ctx, remaining))
+						.remainingToolCalls;
+					remaining = (await interceptQueryStatus(ctx, remaining))
+						.remainingToolCalls;
+					remaining = (
+						await interceptSpawnSubAgent(ctx, remaining, executeSubAgent)
+					).remainingToolCalls;
+					remaining = (await interceptAskUser(ctx, remaining))
+						.remainingToolCalls;
+					if (remaining.length === 0) continue;
+
+					// Approve + execute MCP tools
+					const approval = await checkAndApproveTools(ctx, remaining);
+					if (approval.shouldContinue) continue;
+
+					const execResult = await executeMcpTools(
+						ctx,
+						approval.approvedToolCalls,
+					);
+					if (execResult.aborted && execResult.abortResult) {
+						return execResult.abortResult;
+					}
+				}
+
+				return {
+					success: true,
+					result: ctx.finalResponse,
+					usage: ctx.totalUsage,
+					injectedUserMessages:
+						ctx.collectedInjectedMessages.length > 0
+							? ctx.collectedInjectedMessages
+							: undefined,
+					terminationInstructions:
+						ctx.collectedTerminationInstructions.length > 0
+							? ctx.collectedTerminationInstructions
+							: undefined,
+				};
+			},
+		);
 	} catch (error) {
 		return {
 			success: false,

--- a/source/utils/execution/subAgentToolApproval.ts
+++ b/source/utils/execution/subAgentToolApproval.ts
@@ -4,6 +4,13 @@ import {interpretHookResult} from './hookResultInterpreter.js';
 import {checkYoloPermission} from './yoloPermissionChecker.js';
 import {emitSubAgentMessage} from './subAgentTypes.js';
 import {extractFilesystemEditDiffFromRawResult} from '../config/toolDisplayConfig.js';
+import {sessionManager} from '../session/sessionManager.js';
+import {
+	endToolSpan,
+	recordToolContent,
+	startToolSpan,
+	withActiveTelemetrySpan,
+} from '../telemetry/otel.js';
 import type {
 	SubAgentExecutionContext,
 	ChatMessage,
@@ -193,6 +200,7 @@ export async function executeMcpTools(
 		}
 
 		let args: any = {};
+		let telemetry: ReturnType<typeof startToolSpan> | undefined;
 		try {
 			args = JSON.parse(toolCall.function.arguments);
 
@@ -231,10 +239,22 @@ export async function executeMcpTools(
 				);
 			}
 
-			const result = await executeMCPTool(
-				toolCall.function.name,
+			const currentSession = sessionManager.getCurrentSession();
+			telemetry = startToolSpan({
+				toolName: toolCall.function.name,
+				toolCallId: toolCall.id,
+				sessionId: currentSession?.id,
+				conversationId: currentSession?.id,
+			});
+			recordToolContent(
+				telemetry.span,
+				'tool.input',
 				args,
-				ctx.abortSignal,
+				telemetry.metricAttributes,
+			);
+
+			const result = await withActiveTelemetrySpan(telemetry.span, () =>
+				executeMCPTool(toolCall.function.name, args, ctx.abortSignal),
 			);
 
 			let contentSource: unknown = result;
@@ -280,6 +300,22 @@ export async function executeMcpTools(
 				...(editDiffData ? {editDiffData} : {}),
 			});
 
+			if (telemetry) {
+				const telemetryAttributes = {
+					...telemetry.metricAttributes,
+					'snow.tool.status': 'success',
+					'snow.tool.output.length': resultContent.length,
+				};
+				recordToolContent(
+					telemetry.span,
+					'tool.output',
+					resultContent,
+					telemetryAttributes,
+				);
+				endToolSpan(telemetry.span, telemetry.startTime, telemetryAttributes);
+				telemetry = undefined;
+			}
+
 			// Execute afterToolCall hook
 			try {
 				const afterHookResult = await unifiedHooksExecutor.executeHooks(
@@ -313,9 +349,29 @@ export async function executeMcpTools(
 				);
 			}
 		} catch (error) {
-			const errorContent = `Error: ${
-				error instanceof Error ? error.message : 'Tool execution failed'
-			}`;
+			const normalizedError =
+				error instanceof Error ? error : new Error(String(error));
+			const errorContent = `Error: ${normalizedError.message}`;
+			if (telemetry) {
+				const telemetryAttributes = {
+					...telemetry.metricAttributes,
+					'snow.tool.status': 'error',
+					'snow.tool.output.length': errorContent.length,
+				};
+				recordToolContent(
+					telemetry.span,
+					'tool.output',
+					errorContent,
+					telemetryAttributes,
+				);
+				endToolSpan(
+					telemetry.span,
+					telemetry.startTime,
+					telemetryAttributes,
+					normalizedError,
+				);
+				telemetry = undefined;
+			}
 			toolResults.push({
 				role: 'tool' as const,
 				tool_call_id: toolCall.id,
@@ -337,7 +393,7 @@ export async function executeMcpTools(
 						role: 'tool',
 						content: errorContent,
 					},
-					error: error instanceof Error ? error : new Error(String(error)),
+					error: normalizedError,
 				});
 			} catch (hookError) {
 				console.warn(

--- a/source/utils/execution/subAgentToolInterceptor.ts
+++ b/source/utils/execution/subAgentToolInterceptor.ts
@@ -1,4 +1,13 @@
+import {context, type Context} from '@opentelemetry/api';
+
 import {getSubAgent} from '../config/subAgentConfig.js';
+import {sessionManager} from '../session/sessionManager.js';
+import {
+	endToolSpan,
+	recordToolContent,
+	startToolSpan,
+	withActiveTelemetrySpan,
+} from '../telemetry/otel.js';
 import {runningSubAgentTracker} from './runningSubAgentTracker.js';
 import {unifiedHooksExecutor} from './unifiedHooksExecutor.js';
 import {interpretHookResult} from './hookResultInterpreter.js';
@@ -10,12 +19,79 @@ export interface InterceptResult {
 	remainingToolCalls: any[];
 }
 
+type InterceptedToolExecution<T> = {
+	result: T;
+	outputContent: string;
+};
+
+async function withInterceptedToolSpan<T>(
+	toolCall: any,
+	args: unknown,
+	fn: () => Promise<InterceptedToolExecution<T>> | InterceptedToolExecution<T>,
+): Promise<T> {
+	const currentSession = sessionManager.getCurrentSession();
+	const telemetry = startToolSpan({
+		toolName: toolCall.function.name,
+		toolCallId: toolCall.id,
+		sessionId: currentSession?.id,
+		conversationId: currentSession?.id,
+	});
+	recordToolContent(
+		telemetry.span,
+		'tool.input',
+		args,
+		telemetry.metricAttributes,
+	);
+
+	try {
+		const {result, outputContent} = await withActiveTelemetrySpan(
+			telemetry.span,
+			async () => fn(),
+		);
+		const telemetryAttributes = {
+			...telemetry.metricAttributes,
+			'snow.tool.status': 'success',
+			'snow.tool.output.length': outputContent.length,
+		};
+		recordToolContent(
+			telemetry.span,
+			'tool.output',
+			outputContent,
+			telemetryAttributes,
+		);
+		endToolSpan(telemetry.span, telemetry.startTime, telemetryAttributes);
+		return result;
+	} catch (error) {
+		const normalizedError =
+			error instanceof Error ? error : new Error(String(error));
+		const errorContent = `Error: ${normalizedError.message}`;
+		const telemetryAttributes = {
+			...telemetry.metricAttributes,
+			'snow.tool.status': 'error',
+			'snow.tool.output.length': errorContent.length,
+		};
+		recordToolContent(
+			telemetry.span,
+			'tool.output',
+			errorContent,
+			telemetryAttributes,
+		);
+		endToolSpan(
+			telemetry.span,
+			telemetry.startTime,
+			telemetryAttributes,
+			normalizedError,
+		);
+		throw error;
+	}
+}
+
 // ── send_message_to_agent ──
 
-export function interceptSendMessage(
+export async function interceptSendMessage(
 	ctx: SubAgentExecutionContext,
 	toolCalls: any[],
-): InterceptResult {
+): Promise<InterceptResult> {
 	const sendMsgTools = toolCalls.filter(
 		(tc: any) => tc.function.name === 'send_message_to_agent',
 	);
@@ -25,90 +101,99 @@ export function interceptSendMessage(
 	}
 
 	for (const sendMsgTool of sendMsgTools) {
-		let targetAgentId: string | undefined;
-		let targetInstanceId: string | undefined;
-		let msgContent = '';
+		await withInterceptedToolSpan(
+			sendMsgTool,
+			sendMsgTool.function.arguments,
+			() => {
+				let targetAgentId: string | undefined;
+				let targetInstanceId: string | undefined;
+				let msgContent = '';
 
-		try {
-			const args = JSON.parse(sendMsgTool.function.arguments);
-			targetAgentId = args.target_agent_id;
-			targetInstanceId = args.target_instance_id;
-			msgContent = args.message || '';
-		} catch (error) {
-			console.error(
-				'Failed to parse send_message_to_agent arguments:',
-				error,
-			);
-		}
-
-		let success = false;
-		let resultText = '';
-
-		if (!msgContent) {
-			resultText = 'Error: message content is empty';
-		} else if (targetInstanceId) {
-			success = runningSubAgentTracker.sendInterAgentMessage(
-				ctx.instanceId!,
-				targetInstanceId,
-				msgContent,
-			);
-			if (success) {
-				const targetAgent = runningSubAgentTracker
-					.getRunningAgents()
-					.find(a => a.instanceId === targetInstanceId);
-				resultText = `Message sent to ${
-					targetAgent?.agentName || targetInstanceId
-				}`;
-			} else {
-				resultText = `Error: Target agent instance "${targetInstanceId}" is not running`;
-			}
-		} else if (targetAgentId) {
-			const targetAgent =
-				runningSubAgentTracker.findInstanceByAgentId(targetAgentId);
-			if (targetAgent && targetAgent.instanceId !== ctx.instanceId) {
-				success = runningSubAgentTracker.sendInterAgentMessage(
-					ctx.instanceId!,
-					targetAgent.instanceId,
-					msgContent,
-				);
-				if (success) {
-					resultText = `Message sent to ${targetAgent.agentName} (instance: ${targetAgent.instanceId})`;
-				} else {
-					resultText = `Error: Failed to send message to ${targetAgentId}`;
+				try {
+					const args = JSON.parse(sendMsgTool.function.arguments);
+					targetAgentId = args.target_agent_id;
+					targetInstanceId = args.target_instance_id;
+					msgContent = args.message || '';
+				} catch (error) {
+					console.error(
+						'Failed to parse send_message_to_agent arguments:',
+						error,
+					);
 				}
-			} else if (targetAgent && targetAgent.instanceId === ctx.instanceId) {
-				resultText = 'Error: Cannot send a message to yourself';
-			} else {
-				resultText = `Error: No running agent found with ID "${targetAgentId}"`;
-			}
-		} else {
-			resultText =
-				'Error: Either target_agent_id or target_instance_id must be provided';
-		}
 
-		ctx.messages.push({
-			role: 'tool' as const,
-			tool_call_id: sendMsgTool.id,
-			content: JSON.stringify({success, result: resultText}),
-		});
+				let success = false;
+				let resultText = '';
 
-		emitSubAgentMessage(ctx, {
-			type: 'inter_agent_sent',
-			targetAgentId: targetAgentId || targetInstanceId || 'unknown',
-			targetAgentName:
-				(targetInstanceId
-					? runningSubAgentTracker
+				if (!msgContent) {
+					resultText = 'Error: message content is empty';
+				} else if (targetInstanceId) {
+					success = runningSubAgentTracker.sendInterAgentMessage(
+						ctx.instanceId!,
+						targetInstanceId,
+						msgContent,
+					);
+					if (success) {
+						const targetAgent = runningSubAgentTracker
 							.getRunningAgents()
-							.find(a => a.instanceId === targetInstanceId)?.agentName
-					: targetAgentId
-					? runningSubAgentTracker.findInstanceByAgentId(targetAgentId)
-							?.agentName
-					: undefined) ||
-				targetAgentId ||
-				'unknown',
-			content: msgContent,
-			success,
-		});
+							.find(a => a.instanceId === targetInstanceId);
+						resultText = `Message sent to ${
+							targetAgent?.agentName || targetInstanceId
+						}`;
+					} else {
+						resultText = `Error: Target agent instance "${targetInstanceId}" is not running`;
+					}
+				} else if (targetAgentId) {
+					const targetAgent =
+						runningSubAgentTracker.findInstanceByAgentId(targetAgentId);
+					if (targetAgent && targetAgent.instanceId !== ctx.instanceId) {
+						success = runningSubAgentTracker.sendInterAgentMessage(
+							ctx.instanceId!,
+							targetAgent.instanceId,
+							msgContent,
+						);
+						if (success) {
+							resultText = `Message sent to ${targetAgent.agentName} (instance: ${targetAgent.instanceId})`;
+						} else {
+							resultText = `Error: Failed to send message to ${targetAgentId}`;
+						}
+					} else if (targetAgent && targetAgent.instanceId === ctx.instanceId) {
+						resultText = 'Error: Cannot send a message to yourself';
+					} else {
+						resultText = `Error: No running agent found with ID "${targetAgentId}"`;
+					}
+				} else {
+					resultText =
+						'Error: Either target_agent_id or target_instance_id must be provided';
+				}
+
+				const resultContent = JSON.stringify({success, result: resultText});
+				ctx.messages.push({
+					role: 'tool' as const,
+					tool_call_id: sendMsgTool.id,
+					content: resultContent,
+				});
+
+				emitSubAgentMessage(ctx, {
+					type: 'inter_agent_sent',
+					targetAgentId: targetAgentId || targetInstanceId || 'unknown',
+					targetAgentName:
+						(targetInstanceId
+							? runningSubAgentTracker
+									.getRunningAgents()
+									.find(a => a.instanceId === targetInstanceId)?.agentName
+							: targetAgentId
+							? runningSubAgentTracker.findInstanceByAgentId(targetAgentId)
+									?.agentName
+							: undefined) ||
+						targetAgentId ||
+						'unknown',
+					content: msgContent,
+					success,
+				});
+
+				return {result: undefined, outputContent: resultContent};
+			},
+		);
 	}
 
 	const remaining = toolCalls.filter(
@@ -119,10 +204,10 @@ export function interceptSendMessage(
 
 // ── query_agents_status ──
 
-export function interceptQueryStatus(
+export async function interceptQueryStatus(
 	ctx: SubAgentExecutionContext,
 	toolCalls: any[],
-): InterceptResult {
+): Promise<InterceptResult> {
 	const queryStatusTools = toolCalls.filter(
 		(tc: any) => tc.function.name === 'query_agents_status',
 	);
@@ -132,26 +217,35 @@ export function interceptQueryStatus(
 	}
 
 	for (const queryTool of queryStatusTools) {
-		const allAgents = runningSubAgentTracker.getRunningAgents();
-		const statusList = allAgents.map(a => ({
-			instanceId: a.instanceId,
-			agentId: a.agentId,
-			agentName: a.agentName,
-			prompt: a.prompt ? a.prompt.substring(0, 150) : 'N/A',
-			runningFor: `${Math.floor(
-				(Date.now() - a.startedAt.getTime()) / 1000,
-			)}s`,
-			isSelf: a.instanceId === ctx.instanceId,
-		}));
+		await withInterceptedToolSpan(
+			queryTool,
+			queryTool.function.arguments,
+			() => {
+				const allAgents = runningSubAgentTracker.getRunningAgents();
+				const statusList = allAgents.map(a => ({
+					instanceId: a.instanceId,
+					agentId: a.agentId,
+					agentName: a.agentName,
+					prompt: a.prompt ? a.prompt.substring(0, 150) : 'N/A',
+					runningFor: `${Math.floor(
+						(Date.now() - a.startedAt.getTime()) / 1000,
+					)}s`,
+					isSelf: a.instanceId === ctx.instanceId,
+				}));
+				const resultContent = JSON.stringify({
+					totalRunning: allAgents.length,
+					agents: statusList,
+				});
 
-		ctx.messages.push({
-			role: 'tool' as const,
-			tool_call_id: queryTool.id,
-			content: JSON.stringify({
-				totalRunning: allAgents.length,
-				agents: statusList,
-			}),
-		});
+				ctx.messages.push({
+					role: 'tool' as const,
+					tool_call_id: queryTool.id,
+					content: resultContent,
+				});
+
+				return {result: undefined, outputContent: resultContent};
+			},
+		);
 	}
 
 	const remaining = toolCalls.filter(
@@ -162,7 +256,7 @@ export function interceptQueryStatus(
 
 // ── spawn_sub_agent ──
 
-export function interceptSpawnSubAgent(
+export async function interceptSpawnSubAgent(
 	ctx: SubAgentExecutionContext,
 	toolCalls: any[],
 	executeSubAgentFn: (
@@ -177,8 +271,9 @@ export function interceptSpawnSubAgent(
 		requestUserQuestion?: any,
 		instanceId?: string,
 		spawnDepth?: number,
+		parentContext?: Context,
 	) => Promise<any>,
-): InterceptResult {
+): Promise<InterceptResult> {
 	const spawnTools = toolCalls.filter(
 		(tc: any) => tc.function.name === 'spawn_sub_agent',
 	);
@@ -187,145 +282,160 @@ export function interceptSpawnSubAgent(
 		return {remainingToolCalls: toolCalls};
 	}
 
+	const parentInstanceId = ctx.instanceId;
+
 	for (const spawnTool of spawnTools) {
-		let spawnAgentId = '';
-		let spawnPrompt = '';
+		await withInterceptedToolSpan(
+			spawnTool,
+			spawnTool.function.arguments,
+			() => {
+				let spawnAgentId = '';
+				let spawnPrompt = '';
 
-		try {
-			const args = JSON.parse(spawnTool.function.arguments);
-			spawnAgentId = args.agent_id || '';
-			spawnPrompt = args.prompt || '';
-		} catch (error) {
-			console.error('Failed to parse spawn_sub_agent arguments:', error);
-		}
+				try {
+					const args = JSON.parse(spawnTool.function.arguments);
+					spawnAgentId = args.agent_id || '';
+					spawnPrompt = args.prompt || '';
+				} catch (error) {
+					console.error('Failed to parse spawn_sub_agent arguments:', error);
+				}
 
-		if (!spawnAgentId || !spawnPrompt) {
-			ctx.messages.push({
-				role: 'tool' as const,
-				tool_call_id: spawnTool.id,
-				content: JSON.stringify({
-					success: false,
-					error: 'Both agent_id and prompt are required',
-				}),
-			});
-			continue;
-		}
+				if (!spawnAgentId || !spawnPrompt) {
+					const resultContent = JSON.stringify({
+						success: false,
+						error: 'Both agent_id and prompt are required',
+					});
+					ctx.messages.push({
+						role: 'tool' as const,
+						tool_call_id: spawnTool.id,
+						content: resultContent,
+					});
+					return {result: undefined, outputContent: resultContent};
+				}
 
-		if (spawnAgentId === ctx.agent.id) {
-			ctx.messages.push({
-				role: 'tool' as const,
-				tool_call_id: spawnTool.id,
-				content: JSON.stringify({
-					success: false,
-					error: `REJECTED: You (${ctx.agent.name}) attempted to spawn another "${spawnAgentId}" which is the SAME type as yourself. This is not allowed because it wastes resources and delegates work you should complete yourself. If you need help from a DIFFERENT specialization, spawn a different agent type. If the task is within your capabilities, do it yourself.`,
-				}),
-			});
-			continue;
-		}
+				if (spawnAgentId === ctx.agent.id) {
+					const resultContent = JSON.stringify({
+						success: false,
+						error: `REJECTED: You (${ctx.agent.name}) attempted to spawn another "${spawnAgentId}" which is the SAME type as yourself. This is not allowed because it wastes resources and delegates work you should complete yourself. If you need help from a DIFFERENT specialization, spawn a different agent type. If the task is within your capabilities, do it yourself.`,
+					});
+					ctx.messages.push({
+						role: 'tool' as const,
+						tool_call_id: spawnTool.id,
+						content: resultContent,
+					});
+					return {result: undefined, outputContent: resultContent};
+				}
 
-		let spawnAgentName = spawnAgentId;
-		try {
-			const agentConfig = getSubAgent(spawnAgentId);
-			if (agentConfig) {
-				spawnAgentName = agentConfig.name;
-			}
-		} catch {
-			const builtinNames: Record<string, string> = {
-				agent_explore: 'Explore Agent',
-				agent_plan: 'Plan Agent',
-				agent_general: 'General Purpose Agent',
-				agent_analyze: 'Requirement Analysis Agent',
-				agent_qa: 'QA Agent',
-				agent_debug: 'Debug Assistant',
-			};
-			spawnAgentName = builtinNames[spawnAgentId] || spawnAgentId;
-		}
+				let spawnAgentName = spawnAgentId;
+				try {
+					const agentConfig = getSubAgent(spawnAgentId);
+					if (agentConfig) {
+						spawnAgentName = agentConfig.name;
+					}
+				} catch {
+					const builtinNames: Record<string, string> = {
+						agent_explore: 'Explore Agent',
+						agent_plan: 'Plan Agent',
+						agent_general: 'General Purpose Agent',
+						agent_analyze: 'Requirement Analysis Agent',
+						agent_qa: 'QA Agent',
+						agent_debug: 'Debug Assistant',
+					};
+					spawnAgentName = builtinNames[spawnAgentId] || spawnAgentId;
+				}
 
-		const spawnInstanceId = `spawn-${Date.now()}-${Math.random()
-			.toString(36)
-			.slice(2, 8)}`;
+				const spawnInstanceId = `spawn-${Date.now()}-${Math.random()
+					.toString(36)
+					.slice(2, 8)}`;
 
-		const spawnerInfo = {
-			instanceId: ctx.instanceId,
-			agentId: ctx.agent.id,
-			agentName: ctx.agent.name,
-		};
+				const spawnerInfo = {
+					instanceId: parentInstanceId,
+					agentId: ctx.agent.id,
+					agentName: ctx.agent.name,
+				};
 
-		ctx.spawnedChildInstanceIds.add(spawnInstanceId);
+				ctx.spawnedChildInstanceIds.add(spawnInstanceId);
 
-		runningSubAgentTracker.register({
-			instanceId: spawnInstanceId,
-			agentId: spawnAgentId,
-			agentName: spawnAgentName,
-			prompt: spawnPrompt,
-			startedAt: new Date(),
-		});
-
-		executeSubAgentFn(
-			spawnAgentId,
-			spawnPrompt,
-			ctx.onMessage,
-			ctx.abortSignal,
-			ctx.requestToolConfirmation,
-			ctx.isToolAutoApproved,
-			ctx.yoloMode,
-			ctx.addToAlwaysApproved,
-			ctx.requestUserQuestion,
-			spawnInstanceId,
-			ctx.spawnDepth + 1,
-		)
-			.then(result => {
-				runningSubAgentTracker.storeSpawnedResult({
+				runningSubAgentTracker.register({
 					instanceId: spawnInstanceId,
 					agentId: spawnAgentId,
 					agentName: spawnAgentName,
-					prompt:
-						spawnPrompt.length > 200
-							? spawnPrompt.substring(0, 200) + '...'
-							: spawnPrompt,
-					success: result.success,
-					result: result.result,
-					error: result.error,
-					completedAt: new Date(),
-					spawnedBy: spawnerInfo,
+					prompt: spawnPrompt,
+					startedAt: new Date(),
 				});
-			})
-			.catch(error => {
-				runningSubAgentTracker.storeSpawnedResult({
-					instanceId: spawnInstanceId,
-					agentId: spawnAgentId,
-					agentName: spawnAgentName,
-					prompt:
-						spawnPrompt.length > 200
-							? spawnPrompt.substring(0, 200) + '...'
-							: spawnPrompt,
-					success: false,
-					result: '',
-					error: error instanceof Error ? error.message : 'Unknown error',
-					completedAt: new Date(),
-					spawnedBy: spawnerInfo,
+
+				const parentContext = context.active();
+				executeSubAgentFn(
+					spawnAgentId,
+					spawnPrompt,
+					ctx.onMessage,
+					ctx.abortSignal,
+					ctx.requestToolConfirmation,
+					ctx.isToolAutoApproved,
+					ctx.yoloMode,
+					ctx.addToAlwaysApproved,
+					ctx.requestUserQuestion,
+					spawnInstanceId,
+					ctx.spawnDepth + 1,
+					parentContext,
+				)
+					.then(result => {
+						runningSubAgentTracker.storeSpawnedResult({
+							instanceId: spawnInstanceId,
+							agentId: spawnAgentId,
+							agentName: spawnAgentName,
+							prompt:
+								spawnPrompt.length > 200
+									? spawnPrompt.substring(0, 200) + '...'
+									: spawnPrompt,
+							success: result.success,
+							result: result.result,
+							error: result.error,
+							completedAt: new Date(),
+							spawnedBy: spawnerInfo,
+						});
+					})
+					.catch(error => {
+						runningSubAgentTracker.storeSpawnedResult({
+							instanceId: spawnInstanceId,
+							agentId: spawnAgentId,
+							agentName: spawnAgentName,
+							prompt:
+								spawnPrompt.length > 200
+									? spawnPrompt.substring(0, 200) + '...'
+									: spawnPrompt,
+							success: false,
+							result: '',
+							error: error instanceof Error ? error.message : 'Unknown error',
+							completedAt: new Date(),
+							spawnedBy: spawnerInfo,
+						});
+					})
+					.finally(() => {
+						runningSubAgentTracker.unregister(spawnInstanceId);
+					});
+
+				emitSubAgentMessage(ctx, {
+					type: 'agent_spawned',
+					spawnedAgentId: spawnAgentId,
+					spawnedAgentName: spawnAgentName,
+					spawnedInstanceId: spawnInstanceId,
+					spawnedPrompt: spawnPrompt,
 				});
-			})
-			.finally(() => {
-				runningSubAgentTracker.unregister(spawnInstanceId);
-			});
 
-		emitSubAgentMessage(ctx, {
-			type: 'agent_spawned',
-			spawnedAgentId: spawnAgentId,
-			spawnedAgentName: spawnAgentName,
-			spawnedInstanceId: spawnInstanceId,
-			spawnedPrompt: spawnPrompt,
-		});
+				const resultContent = JSON.stringify({
+					success: true,
+					result: `Agent "${spawnAgentName}" (${spawnAgentId}) has been spawned and is now running in the background with instance ID "${spawnInstanceId}". Its results will be automatically reported to the main workflow when it completes.`,
+				});
+				ctx.messages.push({
+					role: 'tool' as const,
+					tool_call_id: spawnTool.id,
+					content: resultContent,
+				});
 
-		ctx.messages.push({
-			role: 'tool' as const,
-			tool_call_id: spawnTool.id,
-			content: JSON.stringify({
-				success: true,
-				result: `Agent "${spawnAgentName}" (${spawnAgentId}) has been spawned and is now running in the background with instance ID "${spawnInstanceId}". Its results will be automatically reported to the main workflow when it completes.`,
-			}),
-		});
+				return {result: undefined, outputContent: resultContent};
+			},
+		);
 	}
 
 	const remaining = toolCalls.filter(
@@ -343,121 +453,140 @@ export async function interceptAskUser(
 	const askUserTool = toolCalls.find((tc: any) =>
 		tc.function.name.startsWith('askuser-'),
 	);
+	const requestUserQuestion = ctx.requestUserQuestion;
 
-	if (!askUserTool || !ctx.requestUserQuestion) {
+	if (!askUserTool || !requestUserQuestion) {
 		return {remainingToolCalls: toolCalls};
 	}
 
-	let question = 'Please select an option:';
-	let options: string[] = ['Yes', 'No'];
-	let multiSelect = false;
-	let parsedArgs: Record<string, any> = {};
+	await withInterceptedToolSpan(
+		askUserTool,
+		askUserTool.function.arguments,
+		async () => {
+			let question = 'Please select an option:';
+			let options: string[] = ['Yes', 'No'];
+			let multiSelect = false;
+			let parsedArgs: Record<string, any> = {};
 
-	try {
-		parsedArgs = JSON.parse(askUserTool.function.arguments);
-		if (parsedArgs['question']) question = parsedArgs['question'];
-		if (parsedArgs['options'] && Array.isArray(parsedArgs['options'])) {
-			options = parsedArgs['options'];
-		}
-		if (parsedArgs['multiSelect'] === true) {
-			multiSelect = true;
-		}
-	} catch (error) {
-		console.error('Failed to parse askuser tool arguments:', error);
-	}
+			try {
+				parsedArgs = JSON.parse(askUserTool.function.arguments);
+				if (parsedArgs['question']) question = parsedArgs['question'];
+				if (parsedArgs['options'] && Array.isArray(parsedArgs['options'])) {
+					options = parsedArgs['options'];
+				}
+				if (parsedArgs['multiSelect'] === true) {
+					multiSelect = true;
+				}
+			} catch (error) {
+				console.error('Failed to parse askuser tool arguments:', error);
+			}
 
-	// Execute beforeToolCall hook
-	try {
-		const hookResult = await unifiedHooksExecutor.executeHooks(
-			'beforeToolCall',
-			{toolName: askUserTool.function.name, args: parsedArgs},
-		);
-		const interpreted = interpretHookResult('beforeToolCall', hookResult);
-		if (interpreted.action === 'block') {
-			const content = interpreted.replacedContent || '';
-			ctx.messages.push({
+			// Execute beforeToolCall hook inside the askuser tool span.
+			try {
+				const hookResult = await unifiedHooksExecutor.executeHooks(
+					'beforeToolCall',
+					{toolName: askUserTool.function.name, args: parsedArgs},
+				);
+				const interpreted = interpretHookResult('beforeToolCall', hookResult);
+				if (interpreted.action === 'block') {
+					const content = interpreted.replacedContent || '';
+					ctx.messages.push({
+						role: 'tool' as const,
+						tool_call_id: askUserTool.id,
+						content,
+						...(interpreted.hookFailed
+							? {
+									hookFailed: true,
+									hookErrorDetails: interpreted.errorDetails,
+							  }
+							: {}),
+					} as ChatMessage);
+					emitSubAgentMessage(ctx, {
+						type: 'tool_result',
+						tool_call_id: askUserTool.id,
+						tool_name: askUserTool.function.name,
+						content,
+						...(interpreted.hookFailed
+							? {
+									hookFailed: true,
+									hookErrorDetails: interpreted.errorDetails,
+							  }
+							: {}),
+					});
+					return {result: undefined, outputContent: content};
+				}
+			} catch (hookError) {
+				console.warn(
+					'Failed to execute beforeToolCall hook for askuser in sub-agent:',
+					hookError,
+				);
+			}
+
+			// Notify server that user interaction is needed.
+			if (connectionManager.isConnected()) {
+				await connectionManager.notifyUserInteractionNeeded(
+					question,
+					options,
+					askUserTool.id,
+					multiSelect,
+				);
+			}
+
+			const userAnswer = await requestUserQuestion(
+				question,
+				options,
+				multiSelect,
+			);
+
+			const answerText = userAnswer.customInput
+				? `${
+						Array.isArray(userAnswer.selected)
+							? userAnswer.selected.join(', ')
+							: userAnswer.selected
+				  }: ${userAnswer.customInput}`
+				: Array.isArray(userAnswer.selected)
+				? userAnswer.selected.join(', ')
+				: userAnswer.selected;
+
+			const resultContent = JSON.stringify({
+				answer: answerText,
+				selected: userAnswer.selected,
+				customInput: userAnswer.customInput,
+			});
+
+			const toolResult = {
 				role: 'tool' as const,
 				tool_call_id: askUserTool.id,
-				content,
-				...(interpreted.hookFailed ? {hookFailed: true, hookErrorDetails: interpreted.errorDetails} : {}),
-			} as ChatMessage);
+				content: resultContent,
+			};
+
+			ctx.messages.push(toolResult);
+
 			emitSubAgentMessage(ctx, {
 				type: 'tool_result',
 				tool_call_id: askUserTool.id,
 				tool_name: askUserTool.function.name,
-				content,
-				...(interpreted.hookFailed ? {hookFailed: true, hookErrorDetails: interpreted.errorDetails} : {}),
+				content: resultContent,
 			});
-			const remainingTools = toolCalls.filter(
-				(tc: any) => tc.id !== askUserTool.id,
-			);
-			return {remainingToolCalls: remainingTools};
-		}
-	} catch (hookError) {
-		console.warn(
-			'Failed to execute beforeToolCall hook for askuser in sub-agent:',
-			hookError,
-		);
-	}
 
-	// Notify server that user interaction is needed
-	if (connectionManager.isConnected()) {
-		await connectionManager.notifyUserInteractionNeeded(
-			question,
-			options,
-			askUserTool.id,
-			multiSelect,
-		);
-	}
+			// Execute afterToolCall hook inside the askuser tool span.
+			try {
+				await unifiedHooksExecutor.executeHooks('afterToolCall', {
+					toolName: askUserTool.function.name,
+					args: parsedArgs,
+					result: toolResult,
+					error: null,
+				});
+			} catch (hookError) {
+				console.warn(
+					'Failed to execute afterToolCall hook for askuser in sub-agent:',
+					hookError,
+				);
+			}
 
-	const userAnswer = await ctx.requestUserQuestion(
-		question,
-		options,
-		multiSelect,
+			return {result: undefined, outputContent: resultContent};
+		},
 	);
-
-	const answerText = userAnswer.customInput
-		? `${
-				Array.isArray(userAnswer.selected)
-					? userAnswer.selected.join(', ')
-					: userAnswer.selected
-		  }: ${userAnswer.customInput}`
-		: Array.isArray(userAnswer.selected)
-		? userAnswer.selected.join(', ')
-		: userAnswer.selected;
-
-	const resultContent = JSON.stringify({
-		answer: answerText,
-		selected: userAnswer.selected,
-		customInput: userAnswer.customInput,
-	});
-
-	const toolResult = {
-		role: 'tool' as const,
-		tool_call_id: askUserTool.id,
-		content: resultContent,
-	};
-
-	ctx.messages.push(toolResult);
-
-	emitSubAgentMessage(ctx, {
-		type: 'tool_result',
-		tool_call_id: askUserTool.id,
-		tool_name: askUserTool.function.name,
-		content: resultContent,
-	});
-
-	// Execute afterToolCall hook
-	try {
-		await unifiedHooksExecutor.executeHooks('afterToolCall', {
-			toolName: askUserTool.function.name,
-			args: parsedArgs,
-			result: toolResult,
-			error: null,
-		});
-	} catch (hookError) {
-		console.warn('Failed to execute afterToolCall hook for askuser in sub-agent:', hookError);
-	}
 
 	const remaining = toolCalls.filter((tc: any) => tc.id !== askUserTool.id);
 	return {remainingToolCalls: remaining};

--- a/source/utils/execution/toolExecutor.ts
+++ b/source/utils/execution/toolExecutor.ts
@@ -6,6 +6,7 @@ import {
 	endToolSpan,
 	recordToolContent,
 	startToolSpan,
+	withActiveTelemetrySpan,
 } from '../telemetry/otel.js';
 
 import type {SubAgentMessage} from './subAgentExecutor.js';
@@ -236,440 +237,455 @@ export async function executeToolCall(
 		toolName: toolCall.function.name,
 		toolCallId: toolCall.id,
 		sessionId,
+		conversationId: sessionId,
 	});
 
-	// Setup ESC key listener for terminal commands (allows user to interrupt long-running commands)
-	let escKeyListener: ((data: Buffer) => void) | undefined;
-	let abortController: AbortController | undefined;
+	return withActiveTelemetrySpan(telemetry.span, async () => {
+		// Setup ESC key listener for terminal commands (allows user to interrupt long-running commands)
+		let escKeyListener: ((data: Buffer) => void) | undefined;
+		let abortController: AbortController | undefined;
 
-	// Only enable ESC interruption for terminal-execute tool
-	if (toolCall.function.name === 'terminal-execute' && !abortSignal) {
-		abortController = new AbortController();
-		abortSignal = abortController.signal;
+		// Only enable ESC interruption for terminal-execute tool
+		if (toolCall.function.name === 'terminal-execute' && !abortSignal) {
+			abortController = new AbortController();
+			abortSignal = abortController.signal;
 
-		escKeyListener = (data: Buffer) => {
-			const str = data.toString();
-			// ESC key: \x1b
-			if (str === '\x1b' && abortController && !abortSignal?.aborted) {
-				console.log('\n[ESC] Interrupting command execution...');
-				abortController.abort();
-			}
-		};
-
-		// Enable raw mode to capture ESC key immediately
-		if (process.stdin.isTTY && process.stdin.setRawMode) {
-			process.stdin.setRawMode(true);
-			process.stdin.on('data', escKeyListener);
-		}
-	}
-
-	try {
-		const args = safeParseToolArguments(toolCall.function.arguments);
-		recordToolContent(
-			telemetry.span,
-			'tool.input',
-			args,
-			telemetry.metricAttributes,
-		);
-
-		// Execute beforeToolCall hook
-		try {
-			const {unifiedHooksExecutor} = await import(
-				'../execution/unifiedHooksExecutor.js'
-			);
-			const {interpretHookResult} = await import('./hookResultInterpreter.js');
-			const hookResult = await unifiedHooksExecutor.executeHooks(
-				'beforeToolCall',
-				{toolName: toolCall.function.name, args},
-			);
-			const interpreted = interpretHookResult('beforeToolCall', hookResult);
-			if (interpreted.action === 'block') {
-				result = {
-					tool_call_id: toolCall.id,
-					role: 'tool',
-					content: interpreted.replacedContent || '',
-					hookFailed: interpreted.hookFailed,
-					hookErrorDetails: interpreted.errorDetails,
-				};
-				return result;
-			}
-		} catch (error) {
-			console.warn('Failed to execute beforeToolCall hook:', error);
-		}
-
-		// Check if this is a team tool
-		if (toolCall.function.name.startsWith('team-')) {
-			const teamToolName = toolCall.function.name.substring('team-'.length);
-			const teamArgs = args as Record<string, any>;
-
-			try {
-				const teamResult = await teamService.execute({
-					toolName: teamToolName,
-					args: teamArgs,
-					onMessage: onSubAgentMessage,
-					abortSignal,
-					requestToolConfirmation: requestToolConfirmation
-						? async (toolName: string, toolArgs: any) => {
-								const fakeToolCall = {
-									id: 'team-tool',
-									type: 'function' as const,
-									function: {
-										name: toolName,
-										arguments: JSON.stringify(toolArgs),
-									},
-								};
-								return await requestToolConfirmation(fakeToolCall);
-						  }
-						: undefined,
-					isToolAutoApproved,
-					yoloMode,
-					addToAlwaysApproved: addToAlwaysApproved
-						? (name: string) => addToAlwaysApproved(name)
-						: undefined,
-					requestUserQuestion: onUserInteractionNeeded
-						? async (q: string, opts: string[], multi?: boolean) => {
-								const r = await onUserInteractionNeeded(q, opts, multi);
-								return {selected: r.selected, customInput: r.customInput};
-						  }
-						: undefined,
-				});
-
-				result = {
-					tool_call_id: toolCall.id,
-					role: 'tool',
-					content: JSON.stringify(teamResult),
-				};
-			} catch (error: any) {
-				result = {
-					tool_call_id: toolCall.id,
-					role: 'tool',
-					content: JSON.stringify({success: false, error: error.message}),
-				};
-			}
-		}
-		// Check if this is a sub-agent tool
-		else if (toolCall.function.name.startsWith('subagent-')) {
-			const agentId = toolCall.function.name.substring('subagent-'.length);
-			const subAgentPrompt = (args['prompt'] as string) || '';
-
-			// Look up agent name from config for tracking
-			let agentName = agentId;
-			try {
-				const {getSubAgent} = await import('../config/subAgentConfig.js');
-				const agentConfig = getSubAgent(agentId);
-				if (agentConfig) {
-					agentName = agentConfig.name;
+			escKeyListener = (data: Buffer) => {
+				const str = data.toString();
+				// ESC key: \x1b
+				if (str === '\x1b' && abortController && !abortSignal?.aborted) {
+					console.log('\n[ESC] Interrupting command execution...');
+					abortController.abort();
 				}
-			} catch {
-				// Fallback to agentId if lookup fails
+			};
+
+			// Enable raw mode to capture ESC key immediately
+			if (process.stdin.isTTY && process.stdin.setRawMode) {
+				process.stdin.setRawMode(true);
+				process.stdin.on('data', escKeyListener);
+			}
+		}
+
+		try {
+			const args = safeParseToolArguments(toolCall.function.arguments);
+			recordToolContent(
+				telemetry.span,
+				'tool.input',
+				args,
+				telemetry.metricAttributes,
+			);
+
+			// Execute beforeToolCall hook
+			try {
+				const {unifiedHooksExecutor} = await import(
+					'../execution/unifiedHooksExecutor.js'
+				);
+				const {interpretHookResult} = await import(
+					'./hookResultInterpreter.js'
+				);
+				const hookResult = await unifiedHooksExecutor.executeHooks(
+					'beforeToolCall',
+					{toolName: toolCall.function.name, args},
+				);
+				const interpreted = interpretHookResult('beforeToolCall', hookResult);
+				if (interpreted.action === 'block') {
+					result = {
+						tool_call_id: toolCall.id,
+						role: 'tool',
+						content: interpreted.replacedContent || '',
+						hookFailed: interpreted.hookFailed,
+						hookErrorDetails: interpreted.errorDetails,
+					};
+					return result;
+				}
+			} catch (error) {
+				console.warn('Failed to execute beforeToolCall hook:', error);
 			}
 
-			// Register this sub-agent as running
-			runningSubAgentTracker.register({
-				instanceId: toolCall.id,
-				agentId,
-				agentName,
-				prompt: subAgentPrompt,
-				startedAt: new Date(),
-			});
+			// Check if this is a team tool
+			if (toolCall.function.name.startsWith('team-')) {
+				const teamToolName = toolCall.function.name.substring('team-'.length);
+				const teamArgs = args as Record<string, any>;
 
-			// Create a tool confirmation adapter for sub-agent
-			const subAgentToolConfirmation = requestToolConfirmation
-				? async (toolName: string, toolArgs: any) => {
-						// Create a fake tool call for confirmation
-						const fakeToolCall: ToolCall = {
-							id: 'subagent-tool',
-							type: 'function',
-							function: {
-								name: toolName,
-								arguments: JSON.stringify(toolArgs),
-							},
-						};
-						return await requestToolConfirmation(fakeToolCall);
-				  }
-				: undefined;
+				try {
+					const teamResult = await teamService.execute({
+						toolName: teamToolName,
+						args: teamArgs,
+						onMessage: onSubAgentMessage,
+						abortSignal,
+						requestToolConfirmation: requestToolConfirmation
+							? async (toolName: string, toolArgs: any) => {
+									const fakeToolCall = {
+										id: 'team-tool',
+										type: 'function' as const,
+										function: {
+											name: toolName,
+											arguments: JSON.stringify(toolArgs),
+										},
+									};
+									return await requestToolConfirmation(fakeToolCall);
+							  }
+							: undefined,
+						isToolAutoApproved,
+						yoloMode,
+						addToAlwaysApproved: addToAlwaysApproved
+							? (name: string) => addToAlwaysApproved(name)
+							: undefined,
+						requestUserQuestion: onUserInteractionNeeded
+							? async (q: string, opts: string[], multi?: boolean) => {
+									const r = await onUserInteractionNeeded(q, opts, multi);
+									return {selected: r.selected, customInput: r.customInput};
+							  }
+							: undefined,
+					});
 
-			try {
-				// Create an abortable wrapper for sub-agent execution
-				const subAgentPromise = subAgentService.execute({
-					agentId,
-					prompt: subAgentPrompt,
+					result = {
+						tool_call_id: toolCall.id,
+						role: 'tool',
+						content: JSON.stringify(teamResult),
+					};
+				} catch (error: any) {
+					result = {
+						tool_call_id: toolCall.id,
+						role: 'tool',
+						content: JSON.stringify({success: false, error: error.message}),
+					};
+				}
+			}
+			// Check if this is a sub-agent tool
+			else if (toolCall.function.name.startsWith('subagent-')) {
+				const agentId = toolCall.function.name.substring('subagent-'.length);
+				const subAgentPrompt = (args['prompt'] as string) || '';
+
+				// Look up agent name from config for tracking
+				let agentName = agentId;
+				try {
+					const {getSubAgent} = await import('../config/subAgentConfig.js');
+					const agentConfig = getSubAgent(agentId);
+					if (agentConfig) {
+						agentName = agentConfig.name;
+					}
+				} catch {
+					// Fallback to agentId if lookup fails
+				}
+
+				// Register this sub-agent as running
+				runningSubAgentTracker.register({
 					instanceId: toolCall.id,
-					onMessage: onSubAgentMessage,
-					abortSignal,
-					requestToolConfirmation: subAgentToolConfirmation
-						? async (toolCall: ToolCall) => {
-								// Use the adapter to convert to the expected signature
-								const args = safeParseToolArguments(
-									toolCall.function.arguments,
-								);
-								return await subAgentToolConfirmation(
-									toolCall.function.name,
-									args,
-								);
-						  }
-						: undefined,
-					isToolAutoApproved,
-					yoloMode,
-					addToAlwaysApproved,
-					requestUserQuestion: onUserInteractionNeeded,
+					agentId,
+					agentName,
+					prompt: subAgentPrompt,
+					startedAt: new Date(),
 				});
 
-				// Race with abort signal
-				const subAgentResult = abortSignal
-					? await Promise.race([
+				// Create a tool confirmation adapter for sub-agent
+				const subAgentToolConfirmation = requestToolConfirmation
+					? async (toolName: string, toolArgs: any) => {
+							// Create a fake tool call for confirmation
+							const fakeToolCall: ToolCall = {
+								id: 'subagent-tool',
+								type: 'function',
+								function: {
+									name: toolName,
+									arguments: JSON.stringify(toolArgs),
+								},
+							};
+							return await requestToolConfirmation(fakeToolCall);
+					  }
+					: undefined;
+
+				try {
+					// Create an abortable wrapper for sub-agent execution
+					const subAgentPromise = subAgentService.execute({
+						agentId,
+						prompt: subAgentPrompt,
+						instanceId: toolCall.id,
+						onMessage: onSubAgentMessage,
+						abortSignal,
+						requestToolConfirmation: subAgentToolConfirmation
+							? async (toolCall: ToolCall) => {
+									// Use the adapter to convert to the expected signature
+									const args = safeParseToolArguments(
+										toolCall.function.arguments,
+									);
+									return await subAgentToolConfirmation(
+										toolCall.function.name,
+										args,
+									);
+							  }
+							: undefined,
+						isToolAutoApproved,
+						yoloMode,
+						addToAlwaysApproved,
+						requestUserQuestion: onUserInteractionNeeded,
+					});
+
+					// Race with abort signal. Keep a const reference so TypeScript
+					// preserves narrowing inside the nested Promise callback.
+					const activeAbortSignal = abortSignal;
+					let subAgentResult: Awaited<typeof subAgentPromise>;
+					if (activeAbortSignal) {
+						subAgentResult = await Promise.race([
 							subAgentPromise,
 							new Promise<never>((_, reject) => {
 								const onAbort = () =>
 									reject(new Error('Sub-agent execution aborted'));
-								if (abortSignal.aborted) {
+								if (activeAbortSignal.aborted) {
 									onAbort();
 								} else {
-									abortSignal.addEventListener('abort', onAbort, {once: true});
+									activeAbortSignal.addEventListener('abort', onAbort, {
+										once: true,
+									});
 								}
 							}),
-					  ])
-					: await subAgentPromise;
+						]);
+					} else {
+						subAgentResult = await subAgentPromise;
+					}
 
-				// Build sub-agent result content.
-				// If the user injected messages to this sub-agent during execution,
-				// append a summary so the main-flow AI is aware of the user–sub-agent
-				// communication and can avoid information gaps.
-				let subAgentContent: string;
-				if (
-					subAgentResult.injectedUserMessages &&
-					subAgentResult.injectedUserMessages.length > 0
-				) {
-					const injectedSummary = subAgentResult.injectedUserMessages
-						.map((msg: string, i: number) => `  ${i + 1}. ${msg}`)
-						.join('\n');
-					subAgentContent = JSON.stringify({
-						...subAgentResult,
-						_userMessagesNote: `During execution, the user sent ${subAgentResult.injectedUserMessages.length} message(s) directly to this sub-agent:\n${injectedSummary}`,
-					});
-				} else {
-					subAgentContent = JSON.stringify(subAgentResult);
-				}
+					// Build sub-agent result content.
+					// If the user injected messages to this sub-agent during execution,
+					// append a summary so the main-flow AI is aware of the user–sub-agent
+					// communication and can avoid information gaps.
+					let subAgentContent: string;
+					if (
+						subAgentResult.injectedUserMessages &&
+						subAgentResult.injectedUserMessages.length > 0
+					) {
+						const injectedSummary = subAgentResult.injectedUserMessages
+							.map((msg: string, i: number) => `  ${i + 1}. ${msg}`)
+							.join('\n');
+						subAgentContent = JSON.stringify({
+							...subAgentResult,
+							_userMessagesNote: `During execution, the user sent ${subAgentResult.injectedUserMessages.length} message(s) directly to this sub-agent:\n${injectedSummary}`,
+						});
+					} else {
+						subAgentContent = JSON.stringify(subAgentResult);
+					}
 
-				result = {
-					tool_call_id: toolCall.id,
-					role: 'tool',
-					content: subAgentContent,
-				};
-			} finally {
-				// Always unregister the sub-agent when it completes (success or error)
-				runningSubAgentTracker.unregister(toolCall.id);
-			}
-		} else {
-			// Regular tool execution
-			const toolResult = await executeMCPTool(
-				toolCall.function.name,
-				args,
-				abortSignal,
-				onTokenUpdate,
-			);
-
-			// Diff metadata is captured before token truncation inside executeMCPTool
-			const {extractFilesystemEditDiffFromRawResult} = await import(
-				'../config/toolDisplayConfig.js'
-			);
-			let editDiffData: Record<string, any> | undefined;
-			let contentSource: unknown = toolResult;
-			if (
-				toolResult &&
-				typeof toolResult === 'object' &&
-				'editDiffData' in toolResult &&
-				(toolResult as {editDiffData?: Record<string, any>}).editDiffData
-			) {
-				editDiffData = (toolResult as {editDiffData: Record<string, any>})
-					.editDiffData;
-				if ('__toolResultContent' in toolResult) {
-					contentSource = (toolResult as {__toolResultContent: unknown})
-						.__toolResultContent;
+					result = {
+						tool_call_id: toolCall.id,
+						role: 'tool',
+						content: subAgentContent,
+					};
+				} finally {
+					// Always unregister the sub-agent when it completes (success or error)
+					runningSubAgentTracker.unregister(toolCall.id);
 				}
 			} else {
-				editDiffData = extractFilesystemEditDiffFromRawResult(
+				// Regular tool execution
+				const toolResult = await executeMCPTool(
 					toolCall.function.name,
-					toolResult,
+					args,
+					abortSignal,
+					onTokenUpdate,
 				);
+
+				// Diff metadata is captured before token truncation inside executeMCPTool
+				const {extractFilesystemEditDiffFromRawResult} = await import(
+					'../config/toolDisplayConfig.js'
+				);
+				let editDiffData: Record<string, any> | undefined;
+				let contentSource: unknown = toolResult;
 				if (
-					editDiffData &&
-					!editDiffData['filename'] &&
-					typeof args['filePath'] === 'string'
+					toolResult &&
+					typeof toolResult === 'object' &&
+					'editDiffData' in toolResult &&
+					(toolResult as {editDiffData?: Record<string, any>}).editDiffData
 				) {
-					editDiffData['filename'] = args['filePath'];
-				}
-			}
-
-			// Extract multimodal content (text + images)
-			const {textContent, images} = extractMultimodalContent(contentSource);
-
-			result = {
-				tool_call_id: toolCall.id,
-				role: 'tool',
-				content: textContent,
-				images,
-				editDiffData,
-			};
-		}
-	} catch (error) {
-		executionError = error instanceof Error ? error : new Error(String(error));
-
-		// Check if this is a user interaction needed error
-		const {UserInteractionNeededError} = await import(
-			'../ui/userInteractionError.js'
-		);
-
-		if (error instanceof UserInteractionNeededError) {
-			// Call the user interaction callback if provided
-			if (onUserInteractionNeeded) {
-				// Check abort before calling user interaction
-				if (abortSignal?.aborted) {
-					result = {
-						tool_call_id: toolCall.id,
-						role: 'tool',
-						content: 'Error: User question interaction aborted',
-						messageStatus: 'error' as const,
-					};
-					return result;
+					editDiffData = (toolResult as {editDiffData: Record<string, any>})
+						.editDiffData;
+					if ('__toolResultContent' in toolResult) {
+						contentSource = (toolResult as {__toolResultContent: unknown})
+							.__toolResultContent;
+					}
+				} else {
+					editDiffData = extractFilesystemEditDiffFromRawResult(
+						toolCall.function.name,
+						toolResult,
+					);
+					if (
+						editDiffData &&
+						!editDiffData['filename'] &&
+						typeof args['filePath'] === 'string'
+					) {
+						editDiffData['filename'] = args['filePath'];
+					}
 				}
 
-				const response = await onUserInteractionNeeded(
-					error.question,
-					error.options,
-					error.multiSelect,
-				);
-
-				// Check abort after getting response
-				if (abortSignal?.aborted) {
-					result = {
-						tool_call_id: toolCall.id,
-						role: 'tool',
-						content: 'Error: User question interaction aborted',
-						messageStatus: 'error' as const,
-					};
-					return result;
-				}
-
-				// 检查用户是否取消
-				if (response.cancelled) {
-					// 用户取消时，返回拒绝结果而不是抛出错误
-					// 这样工具记录会保留在 session 中
-					result = {
-						tool_call_id: toolCall.id,
-						role: 'tool',
-						content: 'Error: User cancelled the question interaction',
-						messageStatus: 'error' as const,
-					};
-					return result;
-				}
-
-				//返回用户的响应作为工具结果
-				const answerText = response.customInput
-					? `${
-							Array.isArray(response.selected)
-								? response.selected.join(', ')
-								: response.selected
-					  }: ${response.customInput}`
-					: Array.isArray(response.selected)
-					? response.selected.join(', ')
-					: response.selected;
+				// Extract multimodal content (text + images)
+				const {textContent, images} = extractMultimodalContent(contentSource);
 
 				result = {
 					tool_call_id: toolCall.id,
 					role: 'tool',
-					content: JSON.stringify({
-						answer: answerText,
-						selected: response.selected,
-						customInput: response.customInput,
-					}),
+					content: textContent,
+					images,
+					editDiffData,
 				};
-			} else {
-				// No callback provided, return error
-				result = {
-					tool_call_id: toolCall.id,
-					role: 'tool',
-					content: 'Error: User interaction needed but no callback provided',
-				};
-			}
-		} else {
-			// Regular error handling
-			result = {
-				tool_call_id: toolCall.id,
-				role: 'tool',
-				content: `Error: ${
-					error instanceof Error ? error.message : 'Tool execution failed'
-				}`,
-			};
-		}
-	} finally {
-		// Execute afterToolCall hook
-		try {
-			const {unifiedHooksExecutor} = await import(
-				'../execution/unifiedHooksExecutor.js'
-			);
-			const {interpretHookResult} = await import('./hookResultInterpreter.js');
-			const hookResult = await unifiedHooksExecutor.executeHooks(
-				'afterToolCall',
-				{
-					toolName: toolCall.function.name,
-					args: safeParseToolArguments(toolCall.function.arguments),
-					result,
-					error: executionError,
-				},
-			);
-			const interpreted = interpretHookResult('afterToolCall', hookResult);
-			if (result) {
-				if (interpreted.action === 'replace') {
-					result.content = interpreted.replacedContent || result.content;
-				} else if (interpreted.action === 'block') {
-					result.hookFailed = interpreted.hookFailed;
-					result.hookErrorDetails = interpreted.errorDetails;
-				}
 			}
 		} catch (error) {
-			console.warn('Failed to execute afterToolCall hook:', error);
-		}
+			executionError =
+				error instanceof Error ? error : new Error(String(error));
 
-		const telemetryStatus =
-			result?.messageStatus === 'error' || result?.hookFailed
-				? 'error'
-				: 'success';
-		const telemetryAttributes = {
-			...telemetry.metricAttributes,
-			'snow.tool.status': telemetryStatus,
-			...(result?.content
-				? {'snow.tool.output.length': result.content.length}
-				: {}),
-		};
-		if (result) {
-			recordToolContent(
+			// Check if this is a user interaction needed error
+			const {UserInteractionNeededError} = await import(
+				'../ui/userInteractionError.js'
+			);
+
+			if (error instanceof UserInteractionNeededError) {
+				// Call the user interaction callback if provided
+				if (onUserInteractionNeeded) {
+					// Check abort before calling user interaction
+					if (abortSignal?.aborted) {
+						result = {
+							tool_call_id: toolCall.id,
+							role: 'tool',
+							content: 'Error: User question interaction aborted',
+							messageStatus: 'error' as const,
+						};
+						return result;
+					}
+
+					const response = await onUserInteractionNeeded(
+						error.question,
+						error.options,
+						error.multiSelect,
+					);
+
+					// Check abort after getting response
+					if (abortSignal?.aborted) {
+						result = {
+							tool_call_id: toolCall.id,
+							role: 'tool',
+							content: 'Error: User question interaction aborted',
+							messageStatus: 'error' as const,
+						};
+						return result;
+					}
+
+					// 检查用户是否取消
+					if (response.cancelled) {
+						// 用户取消时，返回拒绝结果而不是抛出错误
+						// 这样工具记录会保留在 session 中
+						result = {
+							tool_call_id: toolCall.id,
+							role: 'tool',
+							content: 'Error: User cancelled the question interaction',
+							messageStatus: 'error' as const,
+						};
+						return result;
+					}
+
+					//返回用户的响应作为工具结果
+					const answerText = response.customInput
+						? `${
+								Array.isArray(response.selected)
+									? response.selected.join(', ')
+									: response.selected
+						  }: ${response.customInput}`
+						: Array.isArray(response.selected)
+						? response.selected.join(', ')
+						: response.selected;
+
+					result = {
+						tool_call_id: toolCall.id,
+						role: 'tool',
+						content: JSON.stringify({
+							answer: answerText,
+							selected: response.selected,
+							customInput: response.customInput,
+						}),
+					};
+				} else {
+					// No callback provided, return error
+					result = {
+						tool_call_id: toolCall.id,
+						role: 'tool',
+						content: 'Error: User interaction needed but no callback provided',
+					};
+				}
+			} else {
+				// Regular error handling
+				result = {
+					tool_call_id: toolCall.id,
+					role: 'tool',
+					content: `Error: ${
+						error instanceof Error ? error.message : 'Tool execution failed'
+					}`,
+				};
+			}
+		} finally {
+			// Execute afterToolCall hook
+			try {
+				const {unifiedHooksExecutor} = await import(
+					'../execution/unifiedHooksExecutor.js'
+				);
+				const {interpretHookResult} = await import(
+					'./hookResultInterpreter.js'
+				);
+				const hookResult = await unifiedHooksExecutor.executeHooks(
+					'afterToolCall',
+					{
+						toolName: toolCall.function.name,
+						args: safeParseToolArguments(toolCall.function.arguments),
+						result,
+						error: executionError,
+					},
+				);
+				const interpreted = interpretHookResult('afterToolCall', hookResult);
+				if (result) {
+					if (interpreted.action === 'replace') {
+						result.content = interpreted.replacedContent || result.content;
+					} else if (interpreted.action === 'block') {
+						result.hookFailed = interpreted.hookFailed;
+						result.hookErrorDetails = interpreted.errorDetails;
+					}
+				}
+			} catch (error) {
+				console.warn('Failed to execute afterToolCall hook:', error);
+			}
+
+			const telemetryStatus =
+				result?.messageStatus === 'error' || result?.hookFailed
+					? 'error'
+					: 'success';
+			const telemetryAttributes = {
+				...telemetry.metricAttributes,
+				'snow.tool.status': telemetryStatus,
+				...(result?.content
+					? {'snow.tool.output.length': result.content.length}
+					: {}),
+			};
+			if (result) {
+				recordToolContent(
+					telemetry.span,
+					'tool.output',
+					result.content,
+					telemetryAttributes,
+				);
+			}
+			endToolSpan(
 				telemetry.span,
-				'tool.output',
-				result.content,
+				telemetry.startTime,
 				telemetryAttributes,
+				executionError ??
+					(telemetryStatus === 'error'
+						? new Error(result?.content || 'Tool execution failed')
+						: undefined),
 			);
 		}
-		endToolSpan(
-			telemetry.span,
-			telemetry.startTime,
-			telemetryAttributes,
-			executionError ??
-				(telemetryStatus === 'error'
-					? new Error(result?.content || 'Tool execution failed')
-					: undefined),
-		);
-	}
 
-	// Cleanup ESC key listener
-	if (escKeyListener) {
-		if (process.stdin.isTTY && process.stdin.setRawMode) {
-			process.stdin.setRawMode(false);
-			process.stdin.off('data', escKeyListener);
+		// Cleanup ESC key listener
+		if (escKeyListener) {
+			if (process.stdin.isTTY && process.stdin.setRawMode) {
+				process.stdin.setRawMode(false);
+				process.stdin.off('data', escKeyListener);
+			}
 		}
-	}
 
-	return result!;
+		return result!;
+	});
 }
 
 /**

--- a/source/utils/telemetry/otel.ts
+++ b/source/utils/telemetry/otel.ts
@@ -1,9 +1,11 @@
 import {
+	SpanKind,
 	SpanStatusCode,
 	context,
 	metrics,
 	trace,
 	type Attributes,
+	type Context,
 	type Span,
 } from '@opentelemetry/api';
 import {Metadata} from '@grpc/grpc-js';
@@ -33,6 +35,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import {ATTR_SERVICE_NAME} from '@opentelemetry/semantic-conventions';
 import {
+	DEFAULT_TELEMETRY_SERVICE_NAME,
 	getTelemetryConfig,
 	isTelemetryEnabled,
 	type TelemetryConfig,
@@ -44,7 +47,7 @@ let shutdownRegistered = false;
 
 const METER_NAME = 'snow.telemetry';
 const TRACER_NAME = 'snow.telemetry';
-const SERVICE_NAME = 'snow-cli';
+const DEFAULT_WORKFLOW_NAME = 'snow.cli.workflow';
 const OTLP_SIGNAL_PATHS = {
 	logs: '/v1/logs',
 	metrics: '/v1/metrics',
@@ -91,12 +94,45 @@ export type TelemetryChatAttributes = {
 	streaming?: boolean;
 	conversationId?: string;
 	sessionId?: string;
+	parentContext?: Context;
 };
 
 export type TelemetryToolAttributes = {
 	toolName: string;
 	toolCallId?: string;
 	sessionId?: string;
+	conversationId?: string;
+	parentContext?: Context;
+};
+
+export type TelemetryTurnAttributes = {
+	sessionId?: string;
+	conversationId?: string;
+	turnId?: string;
+	model?: string;
+	requestMethod?: string;
+	planMode?: boolean;
+	vulnerabilityHuntingMode?: boolean;
+	teamMode?: boolean;
+	parentContext?: Context;
+};
+
+export type TelemetryWorkflowAttributes = {
+	name?: string;
+	sessionId?: string;
+	conversationId?: string;
+	userId?: string;
+	parentContext?: Context;
+};
+
+export type TelemetryAgentAttributes = {
+	agentId?: string;
+	agentName: string;
+	instanceId?: string;
+	sessionId?: string;
+	conversationId?: string;
+	spawnDepth?: number;
+	parentContext?: Context;
 };
 
 export type TelemetryContentPhase =
@@ -184,6 +220,7 @@ function getEffectiveTelemetryConfig(): TelemetryConfig {
 	return {
 		...settings,
 		enabled: isTelemetryEnabled(),
+		serviceName: settings.serviceName?.trim() || DEFAULT_TELEMETRY_SERVICE_NAME,
 		tracesExporter: normalizeTraceExporter(settings.tracesExporter, 'otlp'),
 		metricsExporter: normalizeMetricExporter(settings.metricsExporter, 'otlp'),
 		logsExporter: normalizeLogExporter(settings.logsExporter, 'none'),
@@ -394,8 +431,12 @@ export function initializeTelemetry(sessionId?: string): boolean {
 
 	try {
 		telemetrySdk = new NodeSDK({
+			// Keep resource attributes minimal. The default process detector records
+			// process.command_args, which can include full headless --ask prompts.
+			autoDetectResources: false,
 			resource: resourceFromAttributes({
-				[ATTR_SERVICE_NAME]: SERVICE_NAME,
+				[ATTR_SERVICE_NAME]:
+					config.serviceName ?? DEFAULT_TELEMETRY_SERVICE_NAME,
 			}),
 			spanProcessors: createTraceProcessors(config, sessionId),
 			metricReaders: createMetricReaders(config, sessionId),
@@ -434,42 +475,178 @@ export async function shutdownTelemetry(): Promise<void> {
 	}
 }
 
-function toSpanAttributes(attributes: TelemetryChatAttributes): Attributes {
-	const conversationId = attributes.conversationId ?? attributes.sessionId;
+function getConversationId(attributes: {
+	conversationId?: string;
+	sessionId?: string;
+}): string | undefined {
+	return attributes.conversationId ?? attributes.sessionId;
+}
+
+function getSessionId(attributes: {
+	conversationId?: string;
+	sessionId?: string;
+}): string | undefined {
+	return attributes.sessionId ?? attributes.conversationId;
+}
+
+function getParentContext(parentContext?: Context): Context {
+	return parentContext ?? context.active();
+}
+
+function toSessionAttributes(attributes: {
+	conversationId?: string;
+	sessionId?: string;
+}): Attributes {
+	const conversationId = getConversationId(attributes);
+	const sessionId = getSessionId(attributes);
+
 	return {
+		...(sessionId
+			? {
+					'snow.session_id': sessionId,
+					'session.id': sessionId,
+					'langfuse.session.id': sessionId,
+			  }
+			: {}),
+		...(conversationId
+			? {
+					'snow.conversation_id': conversationId,
+					'gen_ai.conversation.id': conversationId,
+					'langfuse.trace.metadata.conversation_id': conversationId,
+			  }
+			: {}),
+	};
+}
+
+function toSpanAttributes(attributes: TelemetryChatAttributes): Attributes {
+	return {
+		...toSessionAttributes(attributes),
 		'snow.provider': attributes.provider,
 		'snow.streaming': attributes.streaming ?? true,
 		...(attributes.model ? {'snow.model': attributes.model} : {}),
-		...(attributes.sessionId ? {'snow.session_id': attributes.sessionId} : {}),
-		...(conversationId ? {'snow.conversation_id': conversationId} : {}),
-		'gen_ai.system': attributes.provider,
+		'gen_ai.provider.name': attributes.provider,
 		'gen_ai.operation.name': 'chat',
-		'gen_ai.request.streaming': attributes.streaming ?? true,
-		...(attributes.model ? {'gen_ai.request.model': attributes.model} : {}),
-		...(conversationId ? {'gen_ai.conversation.id': conversationId} : {}),
+		'gen_ai.request.stream': attributes.streaming ?? true,
+		...(attributes.model
+			? {
+					'gen_ai.request.model': attributes.model,
+					'gen_ai.response.model': attributes.model,
+					'langfuse.observation.model.name': attributes.model,
+			  }
+			: {}),
+		'langfuse.observation.type': 'generation',
+		'langfuse.observation.metadata.provider': attributes.provider,
 	};
 }
 
 function toToolSpanAttributes(attributes: TelemetryToolAttributes): Attributes {
 	return {
+		...toSessionAttributes(attributes),
 		'snow.tool.name': attributes.toolName,
 		'gen_ai.operation.name': 'execute_tool',
 		'gen_ai.tool.name': attributes.toolName,
+		'gen_ai.tool.type': 'function',
+		'langfuse.observation.type': 'span',
+		'langfuse.observation.metadata.snow_observation_type': 'tool',
+		'langfuse.observation.metadata.tool_name': attributes.toolName,
 		...(attributes.toolCallId
 			? {
 					'snow.tool.call_id': attributes.toolCallId,
 					'gen_ai.tool.call.id': attributes.toolCallId,
-			  }
-			: {}),
-		...(attributes.sessionId
-			? {
-					'snow.session_id': attributes.sessionId,
-					'snow.conversation_id': attributes.sessionId,
-					'gen_ai.conversation.id': attributes.sessionId,
+					'langfuse.observation.metadata.tool_call_id': attributes.toolCallId,
 			  }
 			: {}),
 	};
 }
+
+function toTurnSpanAttributes(attributes: TelemetryTurnAttributes): Attributes {
+	return {
+		...toSessionAttributes(attributes),
+		'langfuse.trace.name': 'snow.cli.turn',
+		'langfuse.trace.tags': ['snow-cli', 'interactive'],
+		'snow.trace.schema_version': '2026-06-04',
+		'snow.turn.id': attributes.turnId ?? 'unknown',
+		'snow.mode.plan': attributes.planMode ?? false,
+		'snow.mode.vulnerability_hunting':
+			attributes.vulnerabilityHuntingMode ?? false,
+		'snow.mode.team': attributes.teamMode ?? false,
+		...(attributes.turnId
+			? {'langfuse.trace.metadata.turn_id': attributes.turnId}
+			: {}),
+		...(attributes.model
+			? {
+					'snow.model': attributes.model,
+					'langfuse.trace.metadata.model': attributes.model,
+			  }
+			: {}),
+		...(attributes.requestMethod
+			? {
+					'snow.request_method': attributes.requestMethod,
+					'langfuse.trace.metadata.request_method': attributes.requestMethod,
+			  }
+			: {}),
+	};
+}
+
+function toWorkflowSpanAttributes(
+	attributes: TelemetryWorkflowAttributes,
+): Attributes {
+	const workflowName = attributes.name ?? DEFAULT_WORKFLOW_NAME;
+
+	return {
+		...toSessionAttributes(attributes),
+		'langfuse.trace.name': workflowName,
+		'langfuse.trace.tags': ['snow-cli', 'workflow', 'compact'],
+		'snow.workflow.name': workflowName,
+		'snow.workflow.type': 'compact',
+		'snow.trace.schema_version': '2026-06-04',
+		...(attributes.userId
+			? {
+					'snow.user.id': attributes.userId,
+					'langfuse.user.id': attributes.userId,
+					'langfuse.trace.metadata.user_id': attributes.userId,
+			  }
+			: {}),
+	};
+}
+
+function toAgentSpanAttributes(
+	attributes: TelemetryAgentAttributes,
+): Attributes {
+	return {
+		...toSessionAttributes(attributes),
+		'snow.agent.name': attributes.agentName,
+		'gen_ai.operation.name': 'invoke_agent',
+		'gen_ai.agent.name': attributes.agentName,
+		'langfuse.observation.type': 'span',
+		'langfuse.observation.metadata.snow_observation_type': 'agent',
+		'langfuse.observation.metadata.agent_name': attributes.agentName,
+		'langfuse.observation.metadata.is_subagent': true,
+		...(attributes.agentId
+			? {
+					'snow.agent.id': attributes.agentId,
+					'gen_ai.agent.id': attributes.agentId,
+					'langfuse.observation.metadata.agent_id': attributes.agentId,
+			  }
+			: {}),
+		...(attributes.instanceId
+			? {
+					'snow.agent.instance_id': attributes.instanceId,
+					'langfuse.observation.metadata.agent_instance_id':
+						attributes.instanceId,
+			  }
+			: {}),
+		...(attributes.spawnDepth !== undefined
+			? {
+					'snow.agent.spawn_depth': attributes.spawnDepth,
+					'langfuse.observation.metadata.agent_spawn_depth':
+						attributes.spawnDepth,
+			  }
+			: {}),
+	};
+}
+
+const DEFAULT_CONTENT_MAX_LENGTH = 4096;
 
 function stringifyTelemetryContent(content: unknown): string {
 	if (typeof content === 'string') {
@@ -483,6 +660,96 @@ function stringifyTelemetryContent(content: unknown): string {
 	}
 }
 
+function normalizeContentMaxLength(value: number | undefined): number {
+	if (typeof value !== 'number' || !Number.isFinite(value)) {
+		return DEFAULT_CONTENT_MAX_LENGTH;
+	}
+
+	return Math.max(0, Math.floor(value));
+}
+
+function getContentCaptureConfig(): {
+	captureContent: boolean;
+	contentMaxLength: number;
+} {
+	const config = getEffectiveTelemetryConfig();
+	return {
+		captureContent: config.captureContent !== false,
+		contentMaxLength: normalizeContentMaxLength(config.contentMaxLength),
+	};
+}
+
+function captureTelemetryContent(content: unknown): {
+	contentText: string;
+	truncatedContent: string;
+	contentMaxLength: number;
+	truncated: boolean;
+} {
+	const {contentMaxLength} = getContentCaptureConfig();
+	const contentText = stringifyTelemetryContent(content);
+	const truncatedContent =
+		contentMaxLength > 0 ? contentText.slice(0, contentMaxLength) : '';
+
+	return {
+		contentText,
+		truncatedContent,
+		contentMaxLength,
+		truncated: truncatedContent.length < contentText.length,
+	};
+}
+
+function toContentEventAttributes(
+	phase: TelemetryContentPhase,
+	content: unknown,
+	attributes: Attributes,
+): Attributes {
+	const {captureContent} = getContentCaptureConfig();
+	if (!captureContent) {
+		return {
+			...attributes,
+			'snow.content.phase': phase,
+			'snow.content.capture_enabled': false,
+		};
+	}
+
+	const captured = captureTelemetryContent(content);
+
+	return {
+		...attributes,
+		'snow.content.phase': phase,
+		'snow.content.capture_enabled': true,
+		'snow.content': captured.truncatedContent,
+		'snow.content.length': captured.contentText.length,
+		'snow.content.max_length': captured.contentMaxLength,
+		'snow.content.truncated': captured.truncated,
+	};
+}
+
+function setLangfuseContentAttribute(
+	span: Span,
+	langfuseKey:
+		| 'langfuse.trace.input'
+		| 'langfuse.trace.output'
+		| 'langfuse.observation.input'
+		| 'langfuse.observation.output',
+	phase: TelemetryContentPhase,
+	content: unknown,
+): void {
+	const {captureContent} = getContentCaptureConfig();
+	if (!captureContent) {
+		return;
+	}
+
+	const captured = captureTelemetryContent(content);
+	span.setAttributes({
+		[langfuseKey]: captured.truncatedContent,
+		'snow.content.capture_enabled': true,
+		[`snow.content.${phase}.length`]: captured.contentText.length,
+		[`snow.content.${phase}.max_length`]: captured.contentMaxLength,
+		[`snow.content.${phase}.truncated`]: captured.truncated,
+	});
+}
+
 export function startChatSpan(attributes: TelemetryChatAttributes): {
 	span: Span | null;
 	startTime: number;
@@ -493,10 +760,16 @@ export function startChatSpan(attributes: TelemetryChatAttributes): {
 	}
 
 	const metricAttributes = toSpanAttributes(attributes);
+	const spanName = attributes.model ? `chat ${attributes.model}` : 'chat';
 	requestCounter.add(1, metricAttributes);
-	const span = trace
-		.getTracer(TRACER_NAME)
-		.startSpan('snow.chat.completion', {attributes: metricAttributes});
+	const span = trace.getTracer(TRACER_NAME).startSpan(
+		spanName,
+		{
+			kind: SpanKind.CLIENT,
+			attributes: metricAttributes,
+		},
+		getParentContext(attributes.parentContext),
+	);
 	return {span, startTime: Date.now(), metricAttributes};
 }
 
@@ -510,13 +783,44 @@ export function recordChatContent(
 		return;
 	}
 
-	const contentText = stringifyTelemetryContent(content);
-	span.addEvent(`snow.chat.${phase}`, {
-		...attributes,
-		'snow.content.phase': phase,
-		'snow.content': contentText,
-		'snow.content.length': contentText.length,
-	});
+	span.addEvent(
+		`snow.chat.${phase}`,
+		toContentEventAttributes(phase, content, attributes),
+	);
+	setLangfuseContentAttribute(
+		span,
+		phase === 'request'
+			? 'langfuse.observation.input'
+			: 'langfuse.observation.output',
+		phase,
+		content,
+	);
+}
+
+export function recordTurnContent(
+	phase: Extract<TelemetryContentPhase, 'request' | 'response'>,
+	content: unknown,
+	attributes: Attributes = {},
+): void {
+	if (!initializeTelemetry()) {
+		return;
+	}
+
+	const span = trace.getSpan(context.active());
+	if (!span) {
+		return;
+	}
+
+	span.addEvent(
+		`snow.turn.${phase}`,
+		toContentEventAttributes(phase, content, attributes),
+	);
+	setLangfuseContentAttribute(
+		span,
+		phase === 'request' ? 'langfuse.trace.input' : 'langfuse.trace.output',
+		phase,
+		content,
+	);
 }
 
 export function startToolSpan(attributes: TelemetryToolAttributes): {
@@ -530,10 +834,143 @@ export function startToolSpan(attributes: TelemetryToolAttributes): {
 
 	const metricAttributes = toToolSpanAttributes(attributes);
 	toolCounter.add(1, metricAttributes);
-	const span = trace
-		.getTracer(TRACER_NAME)
-		.startSpan('snow.tool.execution', {attributes: metricAttributes});
+	const span = trace.getTracer(TRACER_NAME).startSpan(
+		`execute_tool ${attributes.toolName}`,
+		{
+			kind: SpanKind.INTERNAL,
+			attributes: metricAttributes,
+		},
+		getParentContext(attributes.parentContext),
+	);
 	return {span, startTime: Date.now(), metricAttributes};
+}
+
+function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error));
+}
+
+export async function withActiveTelemetrySpan<T>(
+	span: Span | null | undefined,
+	fn: () => Promise<T>,
+): Promise<T> {
+	if (!span || !initializeTelemetry()) {
+		return fn();
+	}
+
+	return context.with(trace.setSpan(context.active(), span), fn);
+}
+
+export async function withTurnSpan<T>(
+	attributes: TelemetryTurnAttributes,
+	fn: () => Promise<T>,
+): Promise<T> {
+	if (!initializeTelemetry(attributes.sessionId)) {
+		return fn();
+	}
+
+	const spanAttributes = toTurnSpanAttributes(attributes);
+	return trace.getTracer(TRACER_NAME).startActiveSpan(
+		'snow.cli.turn',
+		{
+			kind: SpanKind.INTERNAL,
+			attributes: spanAttributes,
+		},
+		getParentContext(attributes.parentContext),
+		async span => {
+			try {
+				const result = await fn();
+				span.setStatus({code: SpanStatusCode.OK});
+				return result;
+			} catch (error) {
+				const normalizedError = toError(error);
+				span.recordException(normalizedError);
+				span.setStatus({
+					code: SpanStatusCode.ERROR,
+					message: normalizedError.message,
+				});
+				throw error;
+			} finally {
+				span.end();
+			}
+		},
+	);
+}
+
+export async function withAgentSpan<T>(
+	attributes: TelemetryAgentAttributes,
+	fn: () => Promise<T>,
+): Promise<T> {
+	if (!initializeTelemetry(attributes.sessionId)) {
+		return fn();
+	}
+
+	const spanAttributes = toAgentSpanAttributes(attributes);
+	return trace.getTracer(TRACER_NAME).startActiveSpan(
+		`invoke_agent ${attributes.agentName}`,
+		{
+			kind: SpanKind.INTERNAL,
+			attributes: spanAttributes,
+		},
+		getParentContext(attributes.parentContext),
+		async span => {
+			try {
+				const result = await fn();
+				span.setStatus({code: SpanStatusCode.OK});
+				return result;
+			} catch (error) {
+				const normalizedError = toError(error);
+				span.recordException(normalizedError);
+				span.setStatus({
+					code: SpanStatusCode.ERROR,
+					message: normalizedError.message,
+				});
+				throw error;
+			} finally {
+				span.end();
+			}
+		},
+	);
+}
+
+export async function withCompactSpan<T>(
+	attributes: TelemetryWorkflowAttributes,
+	fn: () => Promise<T>,
+): Promise<T> {
+	if (!initializeTelemetry(attributes.sessionId)) {
+		return fn();
+	}
+
+	const spanName = attributes.name ?? 'snow.cli.compact';
+	const spanAttributes = toWorkflowSpanAttributes({
+		...attributes,
+		name: spanName,
+	});
+
+	return trace.getTracer(TRACER_NAME).startActiveSpan(
+		spanName,
+		{
+			kind: SpanKind.INTERNAL,
+			attributes: spanAttributes,
+		},
+		getParentContext(attributes.parentContext),
+		async span => {
+			try {
+				const result = await fn();
+				span.setStatus({code: SpanStatusCode.OK});
+				return result;
+			} catch (error) {
+				const normalizedError = toError(error);
+				span.recordException(normalizedError);
+				span.setStatus({
+					code: SpanStatusCode.ERROR,
+					message: normalizedError.message,
+				});
+				throw error;
+			} finally {
+				span.end();
+			}
+		},
+	);
 }
 
 export function recordToolContent(
@@ -546,13 +983,18 @@ export function recordToolContent(
 		return;
 	}
 
-	const contentText = stringifyTelemetryContent(content);
-	span.addEvent(`snow.${phase}`, {
-		...attributes,
-		'snow.content.phase': phase,
-		'snow.content': contentText,
-		'snow.content.length': contentText.length,
-	});
+	span.addEvent(
+		`snow.${phase}`,
+		toContentEventAttributes(phase, content, attributes),
+	);
+	setLangfuseContentAttribute(
+		span,
+		phase === 'tool.input'
+			? 'langfuse.observation.input'
+			: 'langfuse.observation.output',
+		phase,
+		content,
+	);
 }
 
 export function recordChatUsage(
@@ -564,6 +1006,8 @@ export function recordChatUsage(
 		return;
 	}
 
+	const cacheReadInputTokens =
+		usage.cache_read_input_tokens ?? usage.cached_tokens;
 	const usageAttributes: Attributes = {
 		...attributes,
 		...(usage.prompt_tokens !== undefined
@@ -579,10 +1023,15 @@ export function recordChatUsage(
 			? {
 					'snow.usage.cache_creation_input_tokens':
 						usage.cache_creation_input_tokens,
+					'gen_ai.usage.cache_creation.input_tokens':
+						usage.cache_creation_input_tokens,
 			  }
 			: {}),
-		...(usage.cache_read_input_tokens !== undefined
-			? {'snow.usage.cache_read_input_tokens': usage.cache_read_input_tokens}
+		...(cacheReadInputTokens !== undefined
+			? {
+					'snow.usage.cache_read_input_tokens': cacheReadInputTokens,
+					'gen_ai.usage.cache_read.input_tokens': cacheReadInputTokens,
+			  }
 			: {}),
 		...(usage.cached_tokens !== undefined
 			? {'snow.usage.cached_tokens': usage.cached_tokens}


### PR DESCRIPTION
## Summary
- Add configurable OpenTelemetry tracing settings for Snow CLI, including OTLP exporter/protocol/headers controls.
- Capture session/message/tool/subagent spans with parent-child relationships suitable for trace backends such as Langfuse/AxonHub.
- Add privacy controls for captured content and resource attributes.

Closes #166

## Verification
- npm run build
- Verified docs/telemetry/llm-trace-langfuse-audit.md is not included in the commit.