### PR TITLE
feat(commands): custom command argsHint/argsOptions + namespace + loader hardening

### DIFF
--- a/source/hooks/input/keyboard/handlers/pickers/argsPicker.ts
+++ b/source/hooks/input/keyboard/handlers/pickers/argsPicker.ts
@@ -43,7 +43,7 @@ export function argsPickerHandler(ctx: HandlerContext): boolean {
 			if (selected) {
 				const value = getCommandArgOptionValue(selected);
 				const text = buffer.text;
-				const hasTrailingSpace = /^\/[a-zA-Z0-9_-]+(?:\s+\S+)*\s+$/.test(text);
+				const hasTrailingSpace = /^\/[a-zA-Z0-9_:-]+(?:\s+\S+)*\s+$/.test(text);
 				const suffix = hasTrailingSpace ? value : ' ' + value;
 				buffer.insert(suffix);
 				buffer.setCursorPosition(buffer.text.length);

--- a/source/hooks/input/keyboard/handlers/tabArgsPicker.ts
+++ b/source/hooks/input/keyboard/handlers/tabArgsPicker.ts
@@ -15,7 +15,7 @@ export function tabArgsPickerHandler(ctx: HandlerContext): boolean {
 	// Tab to open command args picker when hints are visible
 	if (key.tab && !showCommands && !showFilePicker && !showArgsPicker) {
 		const text = buffer.text;
-		const rootMatch = text.match(/^\/([a-zA-Z0-9_-]+)\s*$/);
+		const rootMatch = text.match(/^\/([a-zA-Z0-9_:-]+)\s*$/);
 		const buddyProfileMatch = text.match(/^\/(buddy)\s+profile\s*$/);
 		const inlineTrigger = findInlineCommandTrigger(
 			text,

--- a/source/hooks/ui/useCommandPanel.ts
+++ b/source/hooks/ui/useCommandPanel.ts
@@ -129,7 +129,32 @@ export function getCommandArgsOptions(
 		return getBuddyProfileArgOptions();
 	}
 
-	return COMMAND_ARGS_OPTIONS[commandName] ?? [];
+	// Check static dictionary first
+	const staticOptions = COMMAND_ARGS_OPTIONS[commandName];
+	if (staticOptions) {
+		return staticOptions;
+	}
+
+	// Fall back to custom commands cache for namespaced commands (e.g., oms:auto)
+	const customCmd = getCustomCommands().find(cmd => cmd.name === commandName);
+	if (customCmd?.argsOptions && customCmd.argsOptions.length > 0) {
+		return customCmd.argsOptions;
+	}
+
+	return [];
+}
+
+// 查询命令参数提示文本：先查静态字典，再查自定义命令缓存
+export function getCommandArgsHint(commandName: string): string {
+	// Check static dictionary first
+	const staticHint = COMMAND_ARGS_HINTS[commandName];
+	if (staticHint) {
+		return staticHint;
+	}
+
+	// Fall back to custom commands cache for namespaced commands (e.g., oms:auto)
+	const customCmd = getCustomCommands().find(cmd => cmd.name === commandName);
+	return customCmd?.argsHint ?? '';
 }
 
 export function useCommandPanel(buffer: TextBuffer, isProcessing = false) {

--- a/source/ui/components/chat/ChatInput.tsx
+++ b/source/ui/components/chat/ChatInput.tsx
@@ -20,8 +20,8 @@ const CommandArgsPanel = lazy(() => import('../panels/CommandArgsPanel.js'));
 import {useInputBuffer} from '../../../hooks/input/useInputBuffer.js';
 import {
 	useCommandPanel,
-	COMMAND_ARGS_HINTS,
 	getCommandArgsOptions,
+	getCommandArgsHint,
 	type CommandArgOption,
 } from '../../../hooks/ui/useCommandPanel.js';
 import {
@@ -366,7 +366,7 @@ export default function ChatInput({
 		options: CommandArgOption[];
 	}>(() => {
 		const text = buffer.text;
-		const rootMatch = text.match(/^\/([a-zA-Z0-9_-]+)(?:\s+\S+)*\s*$/);
+		const rootMatch = text.match(/^\/([a-zA-Z0-9_:-]+)(?:\s+\S+)*\s*$/);
 		const inlineTrigger = findInlineCommandTrigger(
 			text,
 			buffer.getCursorPosition(),
@@ -861,10 +861,10 @@ export default function ChatInput({
 	const commandArgsHint = useMemo(() => {
 		const text = buffer.text;
 		if (!text.startsWith('/')) return '';
-		const match = text.match(/^\/([a-zA-Z0-9_-]+)(\s*)$/);
+		const match = text.match(/^\/([a-zA-Z0-9_:-]+)(\s*)$/);
 		if (!match) return '';
 		const cmd = match[1] ?? '';
-		const hint = COMMAND_ARGS_HINTS[cmd];
+		const hint = getCommandArgsHint(cmd);
 		if (!hint) return '';
 		// 若已经有尾随空格则直接拼接，否则前置空格将 cmd 与提示分隔
 		return match[2] && match[2].length > 0 ? hint : ` ${hint}`;

--- a/source/utils/commands/custom.ts
+++ b/source/utils/commands/custom.ts
@@ -17,6 +17,8 @@ export interface CustomCommand {
 	type: 'execute' | 'prompt' | 'panel'; // execute: run in terminal, prompt: send to AI, panel: show AnyPanel plugin
 	description?: string;
 	location?: CommandLocation; // 新增，可选以兼容旧数据
+	argsHint?: string; // 参数提示文本，在输入框中显示可用参数组合
+	argsOptions?: string[]; // 参数可选值列表，用于 Tab 弹出参数选择面板
 }
 
 type CommandFileEntry = {
@@ -123,6 +125,14 @@ async function listJsonCommandsRecursively(
 		const entryPath = join(dir, entry.name);
 
 		if (entry.isDirectory()) {
+			// Skip hidden directories (e.g., `.omc/`, `.git/`) so runtime state
+			// files written under them are never treated as commands. Aligns
+			// behavior with skills.ts loader; without this, `.json` state
+			// files under `~/.snow/commands/<ns>/.omc/state/sessions/` get loaded
+			// as commands with undefined name/description and crash the panel.
+			if (entry.name.startsWith('.')) {
+				continue;
+			}
 			const childPrefix = prefixPath
 				? `${prefixPath}/${entry.name}`
 				: entry.name;
@@ -162,9 +172,30 @@ async function loadCustomCommandFromFile(
 		const content = await readFile(entry.filePath, 'utf-8');
 		const cmd = JSON.parse(content) as CustomCommand;
 
+		// Reject non-command JSON files (e.g., runtime state files accidentally
+		// written under the commands directory). A valid command needs a string
+		// `command` field and a known `type`; without these, loading it would
+		// inject an object with undefined name/description into the panel and
+		// crash `command.description.toLowerCase()` during render.
+		if (typeof cmd.command !== 'string' || cmd.command.length === 0) {
+			return null;
+		}
+		if (
+			cmd.type !== 'execute' &&
+			cmd.type !== 'prompt' &&
+			cmd.type !== 'panel'
+		) {
+			return null;
+		}
+
 		// Use file path to infer command name for stability and namespace support
 		cmd.name = entry.inferredCommandName;
-		cmd.description = cmd.description || cmd.command;
+		// Coerce description to a string: fallback to `command` (the prompt/
+		// terminal text), then empty string, so callers can always call
+		// `.toLowerCase()` / `.includes()` safely.
+		const rawDesc = cmd.description ?? cmd.command;
+		cmd.description =
+			typeof rawDesc === 'string' ? rawDesc : '';
 
 		// Fill default location for backward compatibility
 		if (!cmd.location) {
@@ -295,6 +326,8 @@ export async function saveCustomCommand(
 	description?: string,
 	location: CommandLocation = 'global',
 	projectRoot?: string,
+	argsHint?: string,
+	argsOptions?: string[],
 ): Promise<void> {
 	// Check for command name conflicts with built-in commands
 	if (isCommandNameConflict(name)) {
@@ -310,7 +343,15 @@ export async function saveCustomCommand(
 	// Ensure parent directory exists (for namespaced commands)
 	await mkdir(dirname(filePath), {recursive: true});
 
-	const data: CustomCommand = {name, command, type, description, location};
+	const data: CustomCommand = {
+		name,
+		command,
+		type,
+		description,
+		location,
+		...(argsHint !== undefined ? {argsHint} : {}),
+		...(argsOptions !== undefined ? {argsOptions} : {}),
+	};
 	await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
 }
 
@@ -347,7 +388,7 @@ function normalizeImportedCustomCommand(
 		return null;
 	}
 
-	const {name, command, type, description} = value;
+	const {name, command, type, description, argsHint, argsOptions} = value;
 	if (
 		typeof name !== 'string' ||
 		typeof command !== 'string' ||
@@ -366,6 +407,14 @@ function normalizeImportedCustomCommand(
 		command,
 		type,
 		...(typeof description === 'string' ? {description} : {}),
+		...(typeof argsHint === 'string' ? {argsHint} : {}),
+		...(Array.isArray(argsOptions)
+			? {
+					argsOptions: argsOptions.filter(
+						(v): v is string => typeof v === 'string',
+					),
+			  }
+			: {}),
 		location,
 	};
 }


### PR DESCRIPTION
## 背景

自定义命令（custom commands）目前只支持 `name + command + type + description` 四个字段，无法声明参数提示和可选值。同时命令名正则只允许 `[a-zA-Z0-9_-]`，不支持命名空间（如 `oms:auto`）。此外 custom 命令加载器对非命令 JSON 文件没有校验，运行时状态文件被误当命令加载会导致面板渲染崩溃。

## 改动

**1. 命名空间命令支持**
- 扩展 `argsPicker` / `tabArgsPicker` / `ChatInput` 中命令名正则，允许 `:` 字符，支持 `/oms:auto` 这类命名空间命令触发参数选择面板。

**2. 自定义命令参数提示**
- `CustomCommand` 接口新增可选字段 `argsHint`（参数提示文本）和 `argsOptions`（参数可选值列表）。
- 新增 `getCommandArgsHint()`：先查静态字典 `COMMAND_ARGS_HINTS`，再查自定义命令缓存，让命名空间命令也能拿到 hint。
- `saveCustomCommand` 和 `normalizeImportedCustomCommand` 全链路打通这两个字段。

**3. 加载器防崩溃加固**
- 递归扫描时跳过隐藏目录（`.omc/`、`.git/` 等），避免运行时状态文件被当命令加载。
- 拒绝缺少有效 `command` 字符串或未知 `type` 的 JSON 文件——此前这类文件会被注入 `name/description` 为 undefined 的对象，在渲染时 `command.description.toLowerCase()` 直接崩溃。
- `description` 强制转为字符串并带安全兜底。

## 验证
- `tsc --noEmit` 零类型错误
- 基于最新 `main`（v0.8.10）开分支，无冲突
- 仅 5 个文件改动，`+84 / -10`

## 不在范围内
- 不含 `.gitignore` 改动（本地 `.omc/` 忽略属于本地环境配置）
- 不含 codebaseIndexAgent 相关的 batch 优化及其 revert（与本次功能无关）