### PR TITLE
feat(commands): support $ARGUMENTS placeholder substitution in custom commands

### DIFF
--- a/docs/usage/en/09.5.Custom Extension Commands.md
+++ b/docs/usage/en/09.5.Custom Extension Commands.md
@@ -18,13 +18,13 @@ Create custom commands.
     - **prompt**: Send prompt to AI
     - **panel**: Load AnyPanel plugin to display a panel
   - Supports global and project level
-  - **Supports additional input**: You can add extra arguments after the command, which will be automatically appended to the command or prompt
+  - **Supports additional input**: You can add extra arguments after the command. If the template contains a `$ARGUMENTS` placeholder it is replaced in-place; otherwise arguments are appended to the command or prompt (see below)
 - **Storage Location**:
   - Global: `~/.snow/commands/`
   - Project: `.snow/commands/`
 - **Examples**:
   - Type `/custom` to open configuration interface
-  - Using additional input: `/mycommand extra args` - arguments will be appended to the original command or prompt
+  - Using additional input: `/mycommand extra args` - arguments replace the `$ARGUMENTS` placeholder in the template, or are appended to the end
 
 ### Panel Type and AnyPanel Plugin
 
@@ -289,6 +289,34 @@ Custom command JSON supports an optional `description` field. It is shown in the
 	"description": "Summarize this chat"
 }
 ```
+
+### `$ARGUMENTS` Placeholder
+
+By default, arguments typed after a command are **appended to the end of the command or prompt**. To insert arguments at a specific position in the template, use the `$ARGUMENTS` placeholder in the `command` field:
+
+- **Template contains `$ARGUMENTS`**: arguments replace the placeholder in-place (all occurrences are replaced), letting the command author control exactly where user input lands
+- **Template has no `$ARGUMENTS`**: arguments are appended to the end (legacy behavior preserved; existing commands keep working)
+- **Empty arguments**: the template is returned as-is, with `$ARGUMENTS` left in the text
+
+This placeholder convention matches Snow CLI's Skills path and Claude Code's slash commands, easing cross-tool migration. Both `execute` and `prompt` types support it.
+
+**Example command file** (`~/.snow/commands/fix-issue.json`):
+
+```json
+{
+	"type": "prompt",
+	"command": "Fix GitHub issue $ARGUMENTS following our coding standards.",
+	"description": "Fix GitHub issue per our standards"
+}
+```
+
+After running `/fix-issue 123`, the content sent to the AI is:
+
+```
+Fix GitHub issue 123 following our coding standards.
+```
+
+If the template has no placeholder (e.g. the "Summarize this chat" example above), running `/summary extra note` appends the arguments to the end: `Summarize the current conversation extra note`.
 
 ### Namespaced custom commands
 

--- a/docs/usage/zh/09.5.自定义扩展指令.md
+++ b/docs/usage/zh/09.5.自定义扩展指令.md
@@ -18,13 +18,13 @@
     - **prompt**: 发送提示词给 AI
     - **panel**: 加载 AnyPanel 插件显示面板
   - 支持全局和项目级别
-  - **支持补充输入**: 可以在指令后面添加额外参数，会自动叠加到命令或提示词后面
+  - **支持补充输入**: 可以在指令后面添加额外参数。若模板含 `$ARGUMENTS` 占位符则原地替换，否则追加到命令或提示词末尾（详见下文）
 - **存储位置**:
   - 全局: `~/.snow/commands/`
   - 项目: `.snow/commands/`
 - **示例**:
   - 输入 `/custom` 打开配置界面
-  - 使用补充输入: `/mycommand 额外参数` - 参数会叠加到原命令或提示词后面
+  - 使用补充输入: `/mycommand 额外参数` - 参数会替换模板中的 `$ARGUMENTS` 占位符，或追加到末尾
 
 ### Panel 类型与 AnyPanel 插件
 
@@ -289,6 +289,34 @@ AnyPanel 插件可以实现可选的生命周期钩子，用于资源管理：
 	"description": "总结当前对话"
 }
 ```
+
+### 参数占位符 `$ARGUMENTS`
+
+默认情况下，命令后输入的参数会被**追加到命令或提示词末尾**。若想让参数插入到模板的指定位置，可以在 `command` 字段中使用 `$ARGUMENTS` 占位符：
+
+- **模板含 `$ARGUMENTS`**：参数原地替换占位符（所有出现处均被替换），命令作者可精确控制参数落点
+- **模板不含 `$ARGUMENTS`**：参数追加到末尾（保留旧行为，已有命令无需改动）
+- **参数为空**：模板原样返回，`$ARGUMENTS` 保留在文本中
+
+该占位符约定与 Snow CLI 的 Skills 路径及 Claude Code 的 slash 命令一致，便于跨工具迁移。`execute` 与 `prompt` 两种类型均适用。
+
+**示例命令文件**（`~/.snow/commands/fix-issue.json`）：
+
+```json
+{
+	"type": "prompt",
+	"command": "Fix GitHub issue $ARGUMENTS following our coding standards.",
+	"description": "按规范修复 GitHub issue"
+}
+```
+
+执行 `/fix-issue 123` 后，发给 AI 的内容为：
+
+```
+Fix GitHub issue 123 following our coding standards.
+```
+
+若模板不含占位符（如上文「总结当前对话」示例），执行 `/summary 额外说明` 时参数会追加到末尾：`请根据当前对话生成一份简短总结 额外说明`。
 
 ### 命名空间自定义指令
 

--- a/source/utils/commands/custom.ts
+++ b/source/utils/commands/custom.ts
@@ -467,6 +467,24 @@ export async function deleteCustomCommand(
 	customCommandsCache = customCommandsCache.filter(cmd => cmd.name !== name);
 }
 
+// Substitute user-supplied args into a command template. If the template
+// contains a `$ARGUMENTS` placeholder, the args replace it in-place — this
+// matches the convention used by the skill path in useSkillsPicker.ts and
+// Claude Code's slash commands, letting command authors control exactly
+// where user input lands. When no placeholder is present, fall back to the
+// legacy behavior of appending args to the end, so existing commands that
+// don't use `$ARGUMENTS` keep working unchanged.
+function applyArgsToCommand(command: string, args?: string): string {
+	const trimmedArgs = args?.trim();
+	if (!trimmedArgs) {
+		return command;
+	}
+	if (command.includes('$ARGUMENTS')) {
+		return command.split('$ARGUMENTS').join(trimmedArgs);
+	}
+	return `${command} ${trimmedArgs}`;
+}
+
 // Register dynamic custom commands
 export async function registerCustomCommands(
 	projectRoot?: string,
@@ -489,8 +507,7 @@ export async function registerCustomCommands(
 				}
 
 				if (cmd.type === 'execute') {
-					// 支持补充输入：将args叠加到命令后面
-					const finalCommand = args ? `${cmd.command} ${args}` : cmd.command;
+					const finalCommand = applyArgsToCommand(cmd.command, args);
 					return {
 						success: true,
 						message: `Executing: ${finalCommand}`,
@@ -510,8 +527,8 @@ export async function registerCustomCommands(
 					};
 				}
 
-				// 支持补充输入：将args叠加到prompt后面
-				const finalPrompt = args ? `${cmd.command} ${args}` : cmd.command;
+				// 支持补充输入：有 $ARGUMENTS 占位符则原地替换，否则追加到末尾
+				const finalPrompt = applyArgsToCommand(cmd.command, args);
 				return {
 					success: true,
 					message: `Sending to AI: ${finalPrompt}`,


### PR DESCRIPTION
## 背景

自定义命令（custom commands）的模板里如果写了占位符，用户输入的参数不会被替换到占位符位置，而是被硬拼到命令文本末尾。

例如某个 prompt 命令模板为：

```
## Task
$ARGUMENTS
## Instructions
...
```

用户执行 `/cmd 优化性能` 时，最终发给 LLM 的内容里占位符原样残留为 `$ARGUMENTS`，而「优化性能」被追加到了整段 prompt 最末尾，与命令作者的意图不符。

## 原因

`registerCustomCommands` 里对 execute 和 prompt 两种类型都用 `${cmd.command} ${args}` 拼接，只支持「追加到末尾」这一种行为，不认任何占位符。

snow-cli 的 skill 路径（`useSkillsPicker.ts`）已经实现了「有 `$ARGUMENTS` 占位符就替换、没有就追加」的成熟模式，且与 Claude Code slash 命令的 `$ARGUMENTS` 约定一致；本 PR 把同样的能力补到 custom command 路径上。

## 改动

新增辅助函数 `applyArgsToCommand(command, args)`，execute 与 prompt 两处调用换成它：

- 模板包含 `$ARGUMENTS` → 参数原地替换占位符（全部出现处，与 skill 路径一致）
- 模板不含占位符 → 参数追加到末尾（保留旧行为，已有命令无需改动）
- 参数为空 → 模板原样返回

## 兼容性

纯增强，向后兼容。不带 `$ARGUMENTS` 的现有命令行为完全不变。

## 验证

- `tsc --noEmit` 通过
- 手工验证四档行为：有占位符替换、无占位符追加、空参数原样、多占位符全替换
