### PR TITLE
fix: preserve image tool results as structured multimodal content

### DIFF
--- a/source/test/tool-result-normalizer.test.ts
+++ b/source/test/tool-result-normalizer.test.ts
@@ -1,0 +1,75 @@
+import anyTest, {type TestFn} from 'ava';
+
+import {extractMultimodalContent} from '../utils/execution/toolResultNormalizer.js';
+
+const test = anyTest as unknown as TestFn;
+
+const sampleBase64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+test('extractMultimodalContent handles direct multimodal array', t => {
+	const result = extractMultimodalContent([
+		{type: 'text', text: 'hello image'},
+		{type: 'image', data: sampleBase64, mimeType: 'image/png'},
+	]);
+
+	t.is(result.textContent, 'hello image');
+	t.false(result.textContent.includes(sampleBase64));
+	t.deepEqual(result.images, [
+		{type: 'image', data: sampleBase64, mimeType: 'image/png'},
+	]);
+});
+
+test('extractMultimodalContent unwraps pure {content} wrapper', t => {
+	const result = extractMultimodalContent({
+		content: [
+			{type: 'text', text: 'wrapped text'},
+			{type: 'image', data: sampleBase64, mimeType: 'image/jpeg'},
+		],
+	});
+
+	t.is(result.textContent, 'wrapped text');
+	t.false(result.textContent.includes(sampleBase64));
+	t.deepEqual(result.images, [
+		{type: 'image', data: sampleBase64, mimeType: 'image/jpeg'},
+	]);
+});
+
+test('extractMultimodalContent preserves wrapper metadata fields', t => {
+	const result = extractMultimodalContent({
+		content: [
+			{type: 'text', text: 'metadata text'},
+			{type: 'image', data: sampleBase64, mimeType: 'image/png'},
+		],
+		files: [{path: 'shot.png', isImage: true, mimeType: 'image/png'}],
+		totalFiles: 1,
+		isImage: true,
+		mimeType: 'image/png',
+	});
+
+	const parsed = JSON.parse(result.textContent);
+	t.is(parsed.content, 'metadata text');
+	t.deepEqual(parsed.files, [
+		{path: 'shot.png', isImage: true, mimeType: 'image/png'},
+	]);
+	t.is(parsed.totalFiles, 1);
+	t.true(parsed.isImage);
+	t.is(parsed.mimeType, 'image/png');
+	t.false(result.textContent.includes(sampleBase64));
+	t.deepEqual(result.images, [
+		{type: 'image', data: sampleBase64, mimeType: 'image/png'},
+	]);
+});
+
+test('extractMultimodalContent keeps plain string results', t => {
+	const result = extractMultimodalContent('plain tool output');
+	t.is(result.textContent, 'plain tool output');
+	t.is(result.images, undefined);
+});
+
+test('extractMultimodalContent stringifies plain objects', t => {
+	const payload = {success: true, value: 42};
+	const result = extractMultimodalContent(payload);
+	t.is(result.textContent, JSON.stringify(payload));
+	t.is(result.images, undefined);
+});

--- a/source/utils/execution/subAgentToolApproval.ts
+++ b/source/utils/execution/subAgentToolApproval.ts
@@ -5,6 +5,7 @@ import {checkYoloPermission} from './yoloPermissionChecker.js';
 import {emitSubAgentMessage} from './subAgentTypes.js';
 import {extractFilesystemEditDiffFromRawResult} from '../config/toolDisplayConfig.js';
 import {sessionManager} from '../session/sessionManager.js';
+import {extractMultimodalContent} from './toolResultNormalizer.js';
 import {
 	endToolSpan,
 	recordToolContent,
@@ -285,11 +286,13 @@ export async function executeMcpTools(
 				editDiffData['filename'] = args['filePath'];
 			}
 
-			const resultContent = JSON.stringify(contentSource);
+			const {textContent: resultContent, images} =
+				extractMultimodalContent(contentSource);
 			toolResults.push({
 				role: 'tool' as const,
 				tool_call_id: toolCall.id,
 				content: resultContent,
+				...(images ? {images} : {}),
 				...(editDiffData ? {editDiffData} : {}),
 			} as ChatMessage);
 			emitSubAgentMessage(ctx, {
@@ -327,6 +330,7 @@ export async function executeMcpTools(
 							tool_call_id: toolCall.id,
 							role: 'tool',
 							content: resultContent,
+							...(images ? {images} : {}),
 						},
 						error: null,
 					},

--- a/source/utils/execution/teamExecutor.ts
+++ b/source/utils/execution/teamExecutor.ts
@@ -17,6 +17,7 @@ import {unifiedHooksExecutor} from './unifiedHooksExecutor.js';
 import {interpretHookResult} from './hookResultInterpreter.js';
 import {compressionCoordinator} from '../core/compressionCoordinator.js';
 import {extractFilesystemEditDiffFromRawResult} from '../config/toolDisplayConfig.js';
+import {extractMultimodalContent} from './toolResultNormalizer.js';
 
 export interface TeammateExecutionOptions {
 	onMessage?: (message: SubAgentMessage) => void;
@@ -345,7 +346,11 @@ ${role ? `Your role: ${role}` : ''}
 			toolName: string,
 			result: unknown,
 			args: any,
-		): {resultContent: string; editDiffData?: Record<string, any>} => {
+		): {
+			resultContent: string;
+			editDiffData?: Record<string, any>;
+			images?: import('../../api/types.js').ImageContent[];
+		} => {
 			let contentSource: unknown = result;
 			let editDiffData: Record<string, any> | undefined;
 
@@ -374,12 +379,9 @@ ${role ? `Your role: ${role}` : ''}
 				editDiffData['filename'] = args['filePath'];
 			}
 
-			const serializedContent =
-				typeof contentSource === 'string'
-					? contentSource
-					: JSON.stringify(contentSource) ?? String(contentSource);
+			const {textContent, images} = extractMultimodalContent(contentSource);
 
-			return {resultContent: serializedContent, editDiffData};
+			return {resultContent: textContent, editDiffData, images};
 		};
 
 		// eslint-disable-next-line no-constant-condition
@@ -1018,12 +1020,15 @@ ${role ? `Your role: ${role}` : ''}
 									toolArgs,
 									abortSignal,
 								);
-								const {resultContent: rawResultContent, editDiffData} =
-									normalizeToolResultPayload(
-										tc.function.name,
-										result,
-										toolArgs,
-									);
+								const {
+									resultContent: rawResultContent,
+									editDiffData,
+									images,
+								} = normalizeToolResultPayload(
+									tc.function.name,
+									result,
+									toolArgs,
+								);
 								let resultContent = rawResultContent;
 
 								// afterToolCall hook
@@ -1037,6 +1042,7 @@ ${role ? `Your role: ${role}` : ''}
 												tool_call_id: tc.id,
 												role: 'tool',
 												content: resultContent,
+												...(images ? {images} : {}),
 											},
 											error: null,
 										},
@@ -1053,6 +1059,7 @@ ${role ? `Your role: ${role}` : ''}
 									role: 'tool' as const,
 									tool_call_id: tc.id,
 									content: resultContent,
+									...(images ? {images} : {}),
 									...(editDiffData ? {editDiffData} : {}),
 								} as ChatMessage);
 								emitToolResultEvent(
@@ -1181,8 +1188,11 @@ ${role ? `Your role: ${role}` : ''}
 								toolArgs,
 								abortSignal,
 							);
-							const {resultContent: rawResultContent, editDiffData} =
-								normalizeToolResultPayload(toolName, result, toolArgs);
+							const {
+								resultContent: rawResultContent,
+								editDiffData,
+								images,
+							} = normalizeToolResultPayload(toolName, result, toolArgs);
 							let resultContent = rawResultContent;
 
 							// afterToolCall hook
@@ -1196,6 +1206,7 @@ ${role ? `Your role: ${role}` : ''}
 											tool_call_id: tc.id,
 											role: 'tool',
 											content: resultContent,
+											...(images ? {images} : {}),
 										},
 										error: null,
 									},
@@ -1212,6 +1223,7 @@ ${role ? `Your role: ${role}` : ''}
 								role: 'tool' as const,
 								tool_call_id: tc.id,
 								content: resultContent,
+								...(images ? {images} : {}),
 								...(editDiffData ? {editDiffData} : {}),
 							} as ChatMessage);
 							emitToolResultEvent(tc.id, toolName, resultContent, editDiffData);

--- a/source/utils/execution/toolExecutor.ts
+++ b/source/utils/execution/toolExecutor.ts
@@ -13,8 +13,8 @@ import {
 import type {SubAgentMessage} from './subAgentExecutor.js';
 import type {ConfirmationResult} from '../../ui/components/tools/ToolConfirmation.js';
 import type {ImageContent} from '../../api/types.js';
-import type {MultimodalContent} from '../../mcp/types/filesystem.types.js';
 import type {UnifiedHookExecutionResult} from './unifiedHooksExecutor.js';
+import {extractMultimodalContent} from './toolResultNormalizer.js';
 
 //安全解析JSON，处理可能被拼接的多个JSON对象
 function safeParseToolArguments(argsString: string): Record<string, any> {
@@ -129,93 +129,6 @@ export interface UserInteractionCallback {
 		customInput?: string;
 		cancelled?: boolean;
 	}>;
-}
-
-/**
- * Check if a value is a multimodal content array
- */
-function isMultimodalContent(value: any): value is MultimodalContent {
-	return (
-		Array.isArray(value) &&
-		value.length > 0 &&
-		value.every(
-			(item: any) =>
-				item &&
-				typeof item === 'object' &&
-				(item.type === 'text' || item.type === 'image'),
-		)
-	);
-}
-
-/**
- * Extract images and text content from a result that may be multimodal
- */
-function extractMultimodalContent(result: any): {
-	textContent: string;
-	images?: ImageContent[];
-} {
-	// Check if result has multimodal content array
-	let contentToCheck = result;
-
-	// Handle wrapped results (e.g., {content: [...], files: [...], totalFiles: n})
-	if (result && typeof result === 'object' && result.content) {
-		contentToCheck = result.content;
-	}
-
-	if (isMultimodalContent(contentToCheck)) {
-		const textParts: string[] = [];
-		const images: ImageContent[] = [];
-
-		for (const item of contentToCheck) {
-			if (item.type === 'text') {
-				textParts.push(item.text);
-			} else if (item.type === 'image') {
-				images.push({
-					type: 'image',
-					data: item.data,
-					mimeType: item.mimeType,
-				});
-			}
-		}
-
-		// If we extracted the content, we need to rebuild the result
-		if (
-			result &&
-			typeof result === 'object' &&
-			result.content === contentToCheck
-		) {
-			// Check if result has only 'content' field (pure MCP response)
-			// In this case, return the extracted text directly without wrapping
-			const resultKeys = Object.keys(result);
-			if (resultKeys.length === 1 && resultKeys[0] === 'content') {
-				// Pure MCP response - return extracted text directly
-				return {
-					textContent: textParts.join('\n\n'),
-					images: images.length > 0 ? images : undefined,
-				};
-			}
-
-			// Result has additional fields (e.g., files, totalFiles) - preserve them
-			const newResult = {...result, content: textParts.join('\n\n')};
-			return {
-				textContent: JSON.stringify(newResult),
-				images: images.length > 0 ? images : undefined,
-			};
-		}
-
-		return {
-			textContent: textParts.join('\n\n'),
-			images: images.length > 0 ? images : undefined,
-		};
-	}
-
-	// Not multimodal — convert to string for tool result content
-	if (typeof result === 'string') {
-		return {textContent: result};
-	}
-	return {
-		textContent: JSON.stringify(result),
-	};
 }
 
 /**

--- a/source/utils/execution/toolResultNormalizer.ts
+++ b/source/utils/execution/toolResultNormalizer.ts
@@ -1,0 +1,75 @@
+import type {ImageContent} from '../../api/types.js';
+import type {MultimodalContent} from '../../mcp/types/filesystem.types.js';
+
+export function isMultimodalContent(value: any): value is MultimodalContent {
+	return (
+		Array.isArray(value) &&
+		value.length > 0 &&
+		value.every(
+			(item: any) =>
+				item &&
+				typeof item === 'object' &&
+				(item.type === 'text' || item.type === 'image'),
+		)
+	);
+}
+
+export function extractMultimodalContent(result: any): {
+	textContent: string;
+	images?: ImageContent[];
+} {
+	let contentToCheck = result;
+
+	if (result && typeof result === 'object' && result.content) {
+		contentToCheck = result.content;
+	}
+
+	if (isMultimodalContent(contentToCheck)) {
+		const textParts: string[] = [];
+		const images: ImageContent[] = [];
+
+		for (const item of contentToCheck) {
+			if (item.type === 'text') {
+				textParts.push(item.text);
+			} else if (item.type === 'image') {
+				images.push({
+					type: 'image',
+					data: item.data,
+					mimeType: item.mimeType,
+				});
+			}
+		}
+
+		if (
+			result &&
+			typeof result === 'object' &&
+			result.content === contentToCheck
+		) {
+			const resultKeys = Object.keys(result);
+			if (resultKeys.length === 1 && resultKeys[0] === 'content') {
+				return {
+					textContent: textParts.join('\n\n'),
+					images: images.length > 0 ? images : undefined,
+				};
+			}
+
+			const newResult = {...result, content: textParts.join('\n\n')};
+			return {
+				textContent: JSON.stringify(newResult),
+				images: images.length > 0 ? images : undefined,
+			};
+		}
+
+		return {
+			textContent: textParts.join('\n\n'),
+			images: images.length > 0 ? images : undefined,
+		};
+	}
+
+	if (typeof result === 'string') {
+		return {textContent: result};
+	}
+	return {
+		textContent: JSON.stringify(result),
+	};
+}


### PR DESCRIPTION
Fixes #185
Sub-agents and Team Mode previously JSON.stringified multimodal filesystem-read results, turning image Base64 into ordinary text and inflating prompts past the model context limit. Extract shared multimodal normalization, keep Base64 in ChatMessage.images, leave tool content as readable metadata, 和 add regression coverage for single/batch image and plain tool results.