### PR TITLE
fix: harden session control plane after #191 review

### DIFF
--- a/docs/usage/en/08.Theme Settings.md
+++ b/docs/usage/en/08.Theme Settings.md
@@ -684,6 +684,7 @@ Chat tool titles use the technical tool id by default (e.g. `websearch-search`).
 /tool-names                              # list overrides
 /tool-names websearch-search:Web Search  # set one
 /tool-names a:A b:B c:C                  # batch set (prefer over editing the file)
+/tool-names a:Alpha Name, b:Beta Name    # multi-word batch uses commas
 /tool-names websearch-search:            # clear one
 /tool-names clear                        # clear all
 ```
@@ -696,7 +697,7 @@ snow cmd theme set toolDisplayNames=websearch-search:
 snow cmd theme status   # includes toolDisplayNames
 ```
 
-For batch updates prefer `/tool-names t1:Name1 t2:Name2 …` (single merge write).
+For batch updates prefer `/tool-names t1:Name1 t2:Name2 …` (single merge write). Use commas when any display name contains spaces.
 
 **theme.json field** (result shape only; write via commands):
 

--- a/docs/usage/en/09.2.Mode Switching Commands.md
+++ b/docs/usage/en/09.2.Mode Switching Commands.md
@@ -125,13 +125,14 @@ Customize chat tool title labels (**no built-in default translations**; unset to
   - none or `status`: list overrides
   - `<tool>:<display>`: set one
   - `<tool>:`: clear one
-  - space/comma-separated pairs: batch set (single write)
+  - space-separated single-word pairs, or comma-separated multi-word pairs: batch set (single write)
   - `clear` / `reset`: clear all overrides
 - **Persistence**: via theme API → `toolDisplayNames`; **new** tool titles only
 - **Examples**:
   - `/tool-names` or `/tool-name`
   - `/tool-names websearch-search:Web Search`
   - `/tool-names filesystem-read:Read terminal-execute:Shell`
+  - `/tool-names filesystem-read:Read File, terminal-execute:Run Shell`
   - `/tool-names clear`
 
 Session-command: `snow cmd theme set toolDisplayNames=websearch-search:Web Search` (single; batch prefer `/tool-names a:A b:B`).

--- a/docs/usage/en/20.SSE Service Mode.md
+++ b/docs/usage/en/20.SSE Service Mode.md
@@ -8,7 +8,23 @@ Want to quickly experience the SSE client? We provide a complete browser test cl
 
 **Location**: `source/test/sse-client/index.html`
 
-Simply open this file in your browser and connect to the SSE server to start testing.
+Serve this file from a local web origin, add that exact origin to
+`SNOW_SSE_ALLOWED_ORIGINS`, and configure the client to send the SSE token.
+
+## Security
+
+The SSE server binds to `127.0.0.1`. Browser origins are denied by default.
+For browser integration, explicitly configure comma-separated trusted origins:
+
+```bash
+SNOW_SSE_TOKEN="replace-with-a-long-random-token" \
+SNOW_SSE_ALLOWED_ORIGINS="http://localhost:5173" \
+snow --sse
+```
+
+Send `Authorization: Bearer <token>` on HTTP requests. Browser `EventSource`
+cannot set custom headers, so only the event stream accepts
+`/events?token=<token>`. Keep the token out of source control and browser logs.
 
 ## What is SSE Service Mode
 

--- a/docs/usage/en/29.Session Command Control Plane.md
+++ b/docs/usage/en/29.Session Command Control Plane.md
@@ -72,18 +72,20 @@ Built-in service: **session-command**
 ```json
 {
 	"command": "buddy.hatch",
-	"args": "小雪 --species=fox --personality=calm",
-	"confirm": false
+	"args": "小雪 --species=fox --personality=calm"
 }
 ```
 
-Medium/high risk writes need `"confirm": true`.
+Agent tools may run read and low-write commands. Medium/high-risk writes return
+`CONFIRMATION_REQUIRED` because model arguments are not trusted user approval;
+use the TUI, CLI `--yes`, or authenticated SSE for those operations.
 
 ## SSE
 
 ```http
 POST /session/command
 Content-Type: application/json
+Authorization: Bearer <SNOW_SSE_TOKEN>
 
 {
   "command": "tool-display",
@@ -92,14 +94,20 @@ Content-Type: application/json
 }
 ```
 
+The server binds to `127.0.0.1`. Set `SNOW_SSE_TOKEN` to authenticate all
+control endpoints. Browser origins are rejected by default; explicitly list
+trusted origins with comma-separated `SNOW_SSE_ALLOWED_ORIGINS`. Browser
+`EventSource` clients pass the token only on `/events?token=...` because that
+API cannot set an Authorization header.
+
 ## Risk model
 
-| Risk           | Default                        | Examples                                                                          |
-| -------------- | ------------------------------ | --------------------------------------------------------------------------------- |
-| `read`         | Allowed                        | buddy status, mcp status, profiles list, session list, goal status                |
-| `low_write`    | Allowed                        | buddy hatch/pet/mute/say, simple, tool-display, export, goal create               |
-| `medium_write` | Needs `--yes` / `confirm:true` | yolo on, plan on, profile switch, codebase on, mcp enable/disable, session resume |
-| `high_risk`    | Needs confirm                  | buddy reset, permissions clear                                                    |
+| Risk           | Default                    | Examples                                                                         |
+| -------------- | -------------------------- | -------------------------------------------------------------------------------- |
+| `read`         | Allowed                    | buddy status, mcp status, profiles list, session list, goal status               |
+| `low_write`    | Allowed                    | buddy hatch/pet/mute/say, simple, tool-display, goal create                      |
+| `medium_write` | Needs trusted confirmation | yolo on, export, profile switch, codebase on, mcp enable/disable, session resume |
+| `high_risk`    | Needs confirm              | buddy reset, permissions clear                                                   |
 
 **Status queries** (`status` / bare / `list` / `current`) are treated as read even when the command also supports writes.
 
@@ -197,7 +205,7 @@ Columns: **Command ID** | **CLI form** | **Risk** | **Confirm** | **Notes**
 | Command ID           | CLI form                                                   | Risk         | Confirm | Notes                            |
 | -------------------- | ---------------------------------------------------------- | ------------ | ------- | -------------------------------- |
 | `compact`            | `snow cmd compact [sessionId] --yes`                       | medium_write | yes     | Needs active/target session      |
-| `export`             | `snow cmd export <txt\|md\|html\|json> [sessionId] [path]` | low_write    | no      | Formats: txt, md, html, json     |
+| `export`             | `snow cmd export <txt\|md\|html\|json> [sessionId] [path]` | medium_write | yes     | Formats: txt, md, html, json     |
 | `permissions.status` | `snow cmd permissions status`                              | read         | no      | Bare `permissions`               |
 | `permissions.allow`  | `snow cmd permissions allow <tool> --yes`                  | medium_write | yes     | Always-approve tool              |
 | `permissions.revoke` | `snow cmd permissions revoke <tool> --yes`                 | medium_write | yes     |                                  |
@@ -242,18 +250,18 @@ Columns: **Command ID** | **CLI form** | **Risk** | **Confirm** | **Notes**
 
 ## Error codes
 
-| Code                    | Meaning                                        |
-| ----------------------- | ---------------------------------------------- |
-| `UNKNOWN_COMMAND`       | Not in allowlist                               |
-| `COMMAND_NOT_ALLOWED`   | Policy blocked                                 |
-| `CONFIRMATION_REQUIRED` | Need `--yes` / `confirm:true`                  |
-| `INVALID_ARGS`          | Bad arguments                                  |
-| `HEADLESS_UNSUPPORTED`  | Not available outside TUI (e.g. `home`)        |
-| `EXECUTION_FAILED`      | Runtime failure                                |
-| `NOT_FOUND`             | Missing resource (buddy/profile/session/skill) |
-| `ALREADY_EXISTS`        | e.g. buddy already hatched                     |
-| `NOT_CONFIGURED`        | e.g. codebase embedding missing                |
-| `SESSION_REQUIRED`      | Active/target session required (e.g. compact)  |
+| Code                    | Meaning                                              |
+| ----------------------- | ---------------------------------------------------- |
+| `UNKNOWN_COMMAND`       | Not in allowlist                                     |
+| `COMMAND_NOT_ALLOWED`   | Policy blocked                                       |
+| `CONFIRMATION_REQUIRED` | Need CLI `--yes` or authenticated SSE `confirm:true` |
+| `INVALID_ARGS`          | Bad arguments                                        |
+| `HEADLESS_UNSUPPORTED`  | Not available outside TUI (e.g. `home`)              |
+| `EXECUTION_FAILED`      | Runtime failure                                      |
+| `NOT_FOUND`             | Missing resource (buddy/profile/session/skill)       |
+| `ALREADY_EXISTS`        | e.g. buddy already hatched                           |
+| `NOT_CONFIGURED`        | e.g. codebase embedding missing                      |
+| `SESSION_REQUIRED`      | Active/target session required (e.g. compact)        |
 
 ## Success shape
 
@@ -302,7 +310,7 @@ Still **do not** document or automate silent API key mutation through this plane
 - `usage` returns session `contextUsage` (legacy-compatible) plus rolling-window `history`; optional `--period`/`-p`/bare token, default `week` (last_30d). Data source: `~/.snow/usage`.
 - `reindex` needs codebase configured or returns `NOT_CONFIGURED` / `EXECUTION_FAILED`.
 - `reindex` headless path **awaits the full rebuild** (not a fire-and-forget job queue).
-- Medium/high writes need `--yes` / `confirm:true` unless the call is a status-only query.
+- Medium/high writes need CLI `--yes` or authenticated SSE `confirm:true`; Agent tool calls cannot self-confirm them. Status-only queries remain read-only.
 - `config snapshot` includes non-secret fields such as modes, theme, `speedometerEnabled`, `hybridCompressEnabled`, `autoFormatEnabled`, `subAgentMaxSpawnDepth`, `fileListDisplayMode`, `language`, `showThinking`, `privacy:{enabled,mode}`, and `codebaseFlags`.
 - Destructive git / arbitrary shell / silent API-key changes remain **out of allowlist**.
 
@@ -328,7 +336,7 @@ Snow currently has two execution surfaces for many slash-like features:
 
 ## Hardening / testing notes
 
-- Medium/high risk commands require `confirm:true` / `--yes`; status/list/current queries stay free.
+- Medium/high risk commands require CLI `--yes` or authenticated SSE `confirm:true`; status/list/current queries stay free and Agent calls cannot self-confirm writes.
 - Contract tests in `source/test/session-command-plane.test.ts` cover:
   - confirmation matrix for write commands
   - stable failure codes (`INVALID_ARGS`, `NOT_FOUND`, `SESSION_REQUIRED`, …)

--- a/docs/usage/zh/08.主题设置.md
+++ b/docs/usage/zh/08.主题设置.md
@@ -684,6 +684,7 @@ snow cmd theme set toolIcons=websearch-search:
 /tool-names                              # 查看覆盖
 /tool-names websearch-search:网页搜索    # 设置一项
 /tool-names a:甲 b:乙 c:丙               # 批量设置（优先于改文件）
+/tool-names a:甲 名, b:乙 名             # 多词显示名批量时使用逗号
 /tool-names websearch-search:            # 清除一项
 /tool-names clear                        # 清除全部
 ```
@@ -696,7 +697,7 @@ snow cmd theme set toolDisplayNames=websearch-search:
 snow cmd theme status   # 含 toolDisplayNames
 ```
 
-批量场景请优先 `/tool-names t1:名1 t2:名2 …`（一次合并写入）。
+批量场景请优先 `/tool-names t1:名1 t2:名2 …`（一次合并写入）；任一显示名含空格时请用逗号分隔各项。
 
 **theme.json 字段**（仅作结果参考；写入请走命令）：
 

--- a/docs/usage/zh/09.2.模式切换指令.md
+++ b/docs/usage/zh/09.2.模式切换指令.md
@@ -125,13 +125,14 @@
   - 无参数或 `status`：列出当前覆盖
   - `<tool>:<显示名>`：设置一项
   - `<tool>:`：清除一项
-  - 多项空格/逗号分隔：批量设置（一次写入）
+  - 单词显示名可用空格分隔，多词显示名用逗号分隔：批量设置（一次写入）
   - `clear` / `reset`：清除全部覆盖
 - **状态**: 经 theme API 写入 `toolDisplayNames`；仅影响**新**工具标题
 - **示例**:
   - `/tool-names` 或 `/tool-name`
   - `/tool-names websearch-search:网页搜索`
   - `/tool-names filesystem-read:阅读文件 terminal-execute:终端`
+  - `/tool-names filesystem-read:阅读 File, terminal-execute:运行 Shell`
   - `/tool-names clear`
 
 session-command：`snow cmd theme set toolDisplayNames=websearch-search:网页搜索`（单项；批量优先 `/tool-names a:甲 b:乙`）。

--- a/docs/usage/zh/20.SSE服务模式.md
+++ b/docs/usage/zh/20.SSE服务模式.md
@@ -8,7 +8,23 @@
 
 **位置**：`source/test/sse-client/index.html`
 
-直接在浏览器中打开该文件，连接到 SSE 服务器即可开始测试。
+请通过本地 Web Origin 提供该文件，将这个精确 Origin 加入
+`SNOW_SSE_ALLOWED_ORIGINS`，并让客户端携带 SSE token。
+
+## 安全配置
+
+SSE 服务仅监听 `127.0.0.1`，默认拒绝所有浏览器 Origin。浏览器集成必须
+显式配置逗号分隔的可信来源：
+
+```bash
+SNOW_SSE_TOKEN="请替换为足够长的随机令牌" \
+SNOW_SSE_ALLOWED_ORIGINS="http://localhost:5173" \
+snow --sse
+```
+
+普通 HTTP 请求使用 `Authorization: Bearer <token>`。浏览器 `EventSource`
+无法设置自定义 header，因此只有事件流支持 `/events?token=<token>`。
+不要将 token 写入源码仓库或浏览器日志。
 
 ## 什么是 SSE 服务模式
 

--- a/docs/usage/zh/29.会话控制面session-command.md
+++ b/docs/usage/zh/29.会话控制面session-command.md
@@ -72,18 +72,20 @@ snow cmd buddy reset --yes --json
 ```json
 {
 	"command": "buddy.hatch",
-	"args": "小雪 --species=fox --personality=calm",
-	"confirm": false
+	"args": "小雪 --species=fox --personality=calm"
 }
 ```
 
-中高风险写操作必须 `confirm: true`。
+Agent 工具只可直接执行只读与低风险写操作。中高风险写操作会返回
+`CONFIRMATION_REQUIRED`，因为模型参数不能代表用户确认；请改用 TUI、CLI
+`--yes` 或经过认证的 SSE。
 
 ## SSE
 
 ```http
 POST /session/command
 Content-Type: application/json
+Authorization: Bearer <SNOW_SSE_TOKEN>
 
 {
   "command": "tool-display",
@@ -92,14 +94,19 @@ Content-Type: application/json
 }
 ```
 
+服务默认仅监听 `127.0.0.1`。设置 `SNOW_SSE_TOKEN` 后，所有控制端点都要求
+认证。浏览器 Origin 默认拒绝；需要浏览器客户端时，通过逗号分隔的
+`SNOW_SSE_ALLOWED_ORIGINS` 显式配置可信来源。由于 `EventSource` 不能设置
+Authorization header，仅 `/events?token=...` 支持查询参数 token。
+
 ## 风险分级
 
-| 风险           | 默认策略                    | 示例                                                             |
-| -------------- | --------------------------- | ---------------------------------------------------------------- |
-| `read`         | 允许                        | buddy status、mcp status、session list、goal status              |
-| `low_write`    | 允许                        | buddy hatch/say、simple、tool-display、export、goal create       |
-| `medium_write` | 需 `--yes` / `confirm:true` | yolo on、profile switch、codebase on、mcp enable、session resume |
-| `high_risk`    | 需确认                      | buddy reset、permissions clear                                   |
+| 风险           | 默认策略   | 示例                                                                     |
+| -------------- | ---------- | ------------------------------------------------------------------------ |
+| `read`         | 允许       | buddy status、mcp status、session list、goal status                      |
+| `low_write`    | 允许       | buddy hatch/say、simple、tool-display、goal create                       |
+| `medium_write` | 需可信确认 | yolo on、export、profile switch、codebase on、mcp enable、session resume |
+| `high_risk`    | 需确认     | buddy reset、permissions clear                                           |
 
 `status` / `list` / `current` / 空参数查询按 **只读** 处理，无需确认。
 
@@ -196,7 +203,7 @@ Content-Type: application/json
 | 命令 ID              | CLI 形式                                                   | 风险         | 确认 | 说明                   |
 | -------------------- | ---------------------------------------------------------- | ------------ | ---- | ---------------------- |
 | `compact`            | `snow cmd compact [sessionId] --yes`                       | medium_write | 是   | 需要活跃/目标会话      |
-| `export`             | `snow cmd export <txt\|md\|html\|json> [sessionId] [path]` | low_write    | 否   | 格式：txt/md/html/json |
+| `export`             | `snow cmd export <txt\|md\|html\|json> [sessionId] [path]` | medium_write | 是   | 格式：txt/md/html/json |
 | `permissions.status` | `snow cmd permissions status`                              | read         | 否   | 裸 `permissions`       |
 | `permissions.allow`  | `snow cmd permissions allow <tool> --yes`                  | medium_write | 是   | 永久放行工具           |
 | `permissions.revoke` | `snow cmd permissions revoke <tool> --yes`                 | medium_write | 是   |                        |
@@ -243,18 +250,18 @@ Content-Type: application/json
 
 ## 错误码
 
-| 错误码                  | 含义                                      |
-| ----------------------- | ----------------------------------------- |
-| `UNKNOWN_COMMAND`       | 不在 allowlist                            |
-| `COMMAND_NOT_ALLOWED`   | 策略拦截                                  |
-| `CONFIRMATION_REQUIRED` | 需要 `--yes` / `confirm:true`             |
-| `INVALID_ARGS`          | 参数非法                                  |
-| `HEADLESS_UNSUPPORTED`  | 无头/非 TUI 不可用（如 `home`）           |
-| `EXECUTION_FAILED`      | 运行时失败                                |
-| `NOT_FOUND`             | 资源不存在（buddy/profile/session/skill） |
-| `ALREADY_EXISTS`        | 例如 buddy 已孵化                         |
-| `NOT_CONFIGURED`        | 例如 codebase 嵌入未配置                  |
-| `SESSION_REQUIRED`      | 需要活跃/目标会话（如 compact）           |
+| 错误码                  | 含义                                         |
+| ----------------------- | -------------------------------------------- |
+| `UNKNOWN_COMMAND`       | 不在 allowlist                               |
+| `COMMAND_NOT_ALLOWED`   | 策略拦截                                     |
+| `CONFIRMATION_REQUIRED` | 需要 CLI `--yes` 或已认证 SSE `confirm:true` |
+| `INVALID_ARGS`          | 参数非法                                     |
+| `HEADLESS_UNSUPPORTED`  | 无头/非 TUI 不可用（如 `home`）              |
+| `EXECUTION_FAILED`      | 运行时失败                                   |
+| `NOT_FOUND`             | 资源不存在（buddy/profile/session/skill）    |
+| `ALREADY_EXISTS`        | 例如 buddy 已孵化                            |
+| `NOT_CONFIGURED`        | 例如 codebase 嵌入未配置                     |
+| `SESSION_REQUIRED`      | 需要活跃/目标会话（如 compact）              |
 
 ## 成功响应形状
 
@@ -303,7 +310,7 @@ Content-Type: application/json
 - `usage` 返回会话 `contextUsage`（兼容旧字段）+ `history` 滚动窗统计；`--period`/`-p`/裸参数可选，默认 `week`（last_30d）。数据源 `~/.snow/usage`。
 - `reindex` 需要已配置 codebase，否则 `NOT_CONFIGURED` / `EXECUTION_FAILED`。
 - `reindex` 无头路径会**等待完整重建完成**（不是异步 job 队列）。
-- 中/高风险写操作需要 `--yes` / `confirm:true`（status 类查询除外）。
+- 中/高风险写操作需要 CLI `--yes` 或已认证 SSE `confirm:true`；Agent 工具不能自行确认。status 类查询除外。
 - `config snapshot` 包含非密钥字段：modes、theme、`api:{advancedModel,basicModel,requestMethod,maxContextTokens,maxTokens}`、`speedometerEnabled`、`hybridCompressEnabled`、`autoFormatEnabled`、`subAgentMaxSpawnDepth`、`fileListDisplayMode`、`language`、`showThinking`、`privacy:{enabled,mode}`、`codebaseFlags` 等。
 - `config set` 会写 `~/.snow/config.json` + 当前 active profile，并 emit `apiConfig`；同进程 TUI（含 StatusLine）热刷新。外部强写 `config.json` 也会被 `fs.watch` 拾取。
 - 破坏性 git / 任意 shell / 静默改密钥仍**不在** allowlist。
@@ -330,7 +337,7 @@ Content-Type: application/json
 
 ## 硬化 / 测试说明
 
-- 中/高风险命令需要 `confirm:true` / `--yes`；status/list/current 查询仍免确认。
+- 中/高风险命令需要 CLI `--yes` 或已认证 SSE `confirm:true`；status/list/current 查询仍免确认，Agent 不能自行确认写操作。
 - `source/test/session-command-plane.test.ts` 覆盖：
   - 写命令确认门闩矩阵
   - 稳定失败码（`INVALID_ARGS` / `NOT_FOUND` / `SESSION_REQUIRED` 等）

--- a/package.json
+++ b/package.json
@@ -159,6 +159,9 @@
 		"tough-cookie": "^6.0.0"
 	},
 	"ava": {
+		"files": [
+			"source/test/**/*.test.ts"
+		],
 		"extensions": {
 			"ts": "module",
 			"tsx": "module"

--- a/source/api/sse-server.ts
+++ b/source/api/sse-server.ts
@@ -64,7 +64,11 @@ class SSEConnection {
 	private response: ServerResponse;
 	private connectionId: string;
 
-	constructor(response: ServerResponse, connectionId: string) {
+	constructor(
+		response: ServerResponse,
+		connectionId: string,
+		allowedOrigin: string,
+	) {
 		this.response = response;
 		this.connectionId = connectionId;
 
@@ -73,7 +77,7 @@ class SSEConnection {
 			'Content-Type': 'text/event-stream',
 			'Cache-Control': 'no-cache',
 			Connection: 'keep-alive',
-			'Access-Control-Allow-Origin': '*',
+			'Access-Control-Allow-Origin': allowedOrigin,
 		});
 
 		// 发送初始连接事件
@@ -112,6 +116,28 @@ export class SSEServer {
 	private connections: Map<string, SSEConnection> = new Map();
 	private sessionConnections: Map<string, string> = new Map(); // sessionId -> connectionId 映射
 	private port: number;
+	private readonly authToken = process.env['SNOW_SSE_TOKEN']?.trim();
+	private readonly allowedOrigins = new Set(
+		(process.env['SNOW_SSE_ALLOWED_ORIGINS'] ?? '')
+			.split(',')
+			.map(origin => origin.trim())
+			.filter(Boolean),
+	);
+	private isAllowedOrigin(origin: string | undefined): boolean {
+		if (!origin) return true;
+		return this.allowedOrigins.has(origin);
+	}
+	private isAuthorizedRequest(
+		req: IncomingMessage,
+		pathname: string | null,
+		query: Record<string, unknown>,
+	): boolean {
+		if (!this.authToken) return true;
+		if (req.headers.authorization === `Bearer ${this.authToken}`) return true;
+		// Browser EventSource cannot set Authorization headers. Restrict the query
+		// token fallback to the read-only event stream endpoint.
+		return pathname === '/events' && query['token'] === this.authToken;
+	}
 	private messageHandler?: (
 		message: ClientMessage,
 		sendEvent: (event: SSEEvent) => void,
@@ -177,8 +203,13 @@ export class SSEServer {
 				reject(error);
 			});
 
-			this.server.listen(this.port, () => {
-				this.log(`SSE 服务器已启动，监听端口 ${this.port}`, 'success');
+			// The SSE daemon is a local control plane. Do not expose it on all
+			// interfaces unless a future authenticated transport explicitly opts in.
+			this.server.listen(this.port, '127.0.0.1', () => {
+				this.log(
+					`SSE 服务器已启动，监听端口 ${this.getListeningPort()}`,
+					'success',
+				);
 				resolve();
 			});
 		});
@@ -244,10 +275,23 @@ export class SSEServer {
 	private async readJsonBody<T = any>(req: IncomingMessage): Promise<T> {
 		return new Promise((resolve, reject) => {
 			let body = '';
+			let rejected = false;
+			const maxBytes = 1024 * 1024;
 			req.on('data', chunk => {
+				if (rejected) return;
 				body += chunk.toString();
+				if (Buffer.byteLength(body, 'utf8') > maxBytes) {
+					rejected = true;
+					body = '';
+					reject(
+						Object.assign(new Error('Request body too large'), {
+							statusCode: 413,
+						}),
+					);
+				}
 			});
 			req.on('end', () => {
+				if (rejected) return;
 				try {
 					resolve(body ? (JSON.parse(body) as T) : ({} as T));
 				} catch (error) {
@@ -276,15 +320,57 @@ export class SSEServer {
 	private handleRequest(req: IncomingMessage, res: ServerResponse): void {
 		const parsedUrl = parseUrl(req.url || '', true);
 		const pathname = parsedUrl.pathname;
+		const query = parsedUrl.query as Record<string, unknown>;
 
 		// 处理 CORS 预检请求
 		if (req.method === 'OPTIONS') {
+			if (!this.isAllowedOrigin(req.headers.origin)) {
+				res.writeHead(403);
+				res.end();
+				return;
+			}
 			res.writeHead(200, {
-				'Access-Control-Allow-Origin': '*',
+				'Access-Control-Allow-Origin': req.headers.origin ?? 'http://localhost',
 				'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
-				'Access-Control-Allow-Headers': 'Content-Type',
+				'Access-Control-Allow-Headers': 'Content-Type, Authorization',
 			});
 			res.end();
+			return;
+		}
+
+		// Health stays public so local supervisors can probe startup without
+		// handling the optional SSE auth token.
+		if (pathname === '/health' && req.method === 'GET') {
+			res.writeHead(200, {'Content-Type': 'application/json'});
+			res.end(
+				JSON.stringify({
+					status: 'ok',
+					connections: this.connections.size,
+				}),
+			);
+			return;
+		}
+
+		// Apply the same browser-origin and optional token boundary to the entire
+		// control plane, not just /session/command. Several legacy endpoints can
+		// read/delete sessions or inject messages into an active connection.
+		if (!this.isAllowedOrigin(req.headers.origin)) {
+			res.writeHead(403, {'Content-Type': 'application/json'});
+			res.end(JSON.stringify({ok: false, code: 'ORIGIN_FORBIDDEN'}));
+			return;
+		}
+		if (!this.isAuthorizedRequest(req, pathname, query)) {
+			res.writeHead(401, {
+				'Content-Type': 'application/json',
+				'Access-Control-Allow-Origin': req.headers.origin ?? 'http://localhost',
+			});
+			res.end(
+				JSON.stringify({
+					ok: false,
+					code: 'UNAUTHORIZED',
+					message: 'Bearer token required',
+				}),
+			);
 			return;
 		}
 
@@ -308,20 +394,13 @@ export class SSEServer {
 
 		// 回滚点列表端点（demo 使用）
 		if (pathname === '/session/rollback-points' && req.method === 'GET') {
-			this.handleSessionRollbackPoints(
-				res,
-				parsedUrl.query as Record<string, unknown>,
-			);
+			this.handleSessionRollbackPoints(res, query);
 			return;
 		}
 
 		// 会话列表端点
 		if (pathname === '/session/list' && req.method === 'GET') {
-			this.handleSessionList(
-				req,
-				res,
-				parsedUrl.query as Record<string, unknown>,
-			);
+			this.handleSessionList(req, res, query);
 			return;
 		}
 
@@ -334,18 +413,6 @@ export class SSEServer {
 		// 消息发送端点
 		if (pathname === '/message' && req.method === 'POST') {
 			this.handleMessage(req, res);
-			return;
-		}
-
-		// 健康检查端点
-		if (pathname === '/health' && req.method === 'GET') {
-			res.writeHead(200, {'Content-Type': 'application/json'});
-			res.end(
-				JSON.stringify({
-					status: 'ok',
-					connections: this.connections.size,
-				}),
-			);
 			return;
 		}
 
@@ -405,6 +472,7 @@ export class SSEServer {
 					args: body.args,
 					mode: 'sse',
 					confirm: Boolean(body.confirm),
+					trustedConfirm: Boolean(body.confirm) && Boolean(this.authToken),
 				});
 
 				res.writeHead(result.ok ? 200 : 400, {
@@ -413,14 +481,21 @@ export class SSEServer {
 				});
 				res.end(JSON.stringify(result));
 			} catch (error) {
-				res.writeHead(500, {
+				const statusCode =
+					typeof error === 'object' &&
+					error !== null &&
+					'statusCode' in error &&
+					error.statusCode === 413
+						? 413
+						: 500;
+				res.writeHead(statusCode, {
 					'Content-Type': 'application/json',
 					'Access-Control-Allow-Origin': '*',
 				});
 				res.end(
 					JSON.stringify({
 						ok: false,
-						code: 'EXECUTION_FAILED',
+						code: statusCode === 413 ? 'PAYLOAD_TOO_LARGE' : 'EXECUTION_FAILED',
 						message:
 							error instanceof Error ? error.message : 'Session command failed',
 					}),
@@ -859,7 +934,11 @@ export class SSEServer {
 		const connectionId = `conn_${Date.now()}_${Math.random()
 			.toString(36)
 			.substring(7)}`;
-		const connection = new SSEConnection(res, connectionId);
+		const connection = new SSEConnection(
+			res,
+			connectionId,
+			req.headers.origin ?? 'http://localhost',
+		);
 
 		this.connections.set(connectionId, connection);
 
@@ -876,15 +955,9 @@ export class SSEServer {
 	 * 处理客户端消息
 	 */
 	private handleMessage(req: IncomingMessage, res: ServerResponse): void {
-		let body = '';
-
-		req.on('data', chunk => {
-			body += chunk.toString();
-		});
-
-		req.on('end', async () => {
+		void (async () => {
 			try {
-				const message: ClientMessage = JSON.parse(body);
+				const message = await this.readJsonBody<ClientMessage>(req);
 
 				// 验证消息格式
 				if (!message.type || (!message.content && message.type === 'chat')) {
@@ -934,14 +1007,23 @@ export class SSEServer {
 				});
 				res.end(JSON.stringify({success: true}));
 			} catch (error) {
-				res.writeHead(500, {'Content-Type': 'application/json'});
+				const statusCode =
+					typeof error === 'object' &&
+					error !== null &&
+					'statusCode' in error &&
+					error.statusCode === 413
+						? 413
+						: error instanceof SyntaxError
+						? 400
+						: 500;
+				res.writeHead(statusCode, {'Content-Type': 'application/json'});
 				res.end(
 					JSON.stringify({
 						error: error instanceof Error ? error.message : 'Unknown error',
 					}),
 				);
 			}
-		});
+		})();
 	}
 
 	/**
@@ -958,5 +1040,11 @@ export class SSEServer {
 	 */
 	getConnectionCount(): number {
 		return this.connections.size;
+	}
+
+	/** Actual bound port (useful when constructed with port 0). */
+	getListeningPort(): number {
+		const address = this.server?.address();
+		return typeof address === 'object' && address ? address.port : this.port;
 	}
 }

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -150,20 +150,22 @@ process.on('unhandledRejection', (reason: unknown) => {
 
 // Check if this is a quick command that doesn't need loading indicator
 const args = process.argv.slice(2);
-const isQuickCommand = args.some(
-	arg =>
-		arg === '--version' ||
-		arg === '-v' ||
-		arg === '--help' ||
-		arg === '-h' ||
-		arg === '--doctor' ||
-		arg === '--update-check' ||
-		arg === '--acp' ||
-		arg === '--sse' ||
-		arg === '--sse-daemon' ||
-		arg === '--loop-daemon-execute' ||
-		arg === '--snow-agent-child-worker',
-);
+const isQuickCommand =
+	args[0] === 'cmd' ||
+	args.some(
+		arg =>
+			arg === '--version' ||
+			arg === '-v' ||
+			arg === '--help' ||
+			arg === '-h' ||
+			arg === '--doctor' ||
+			arg === '--update-check' ||
+			arg === '--acp' ||
+			arg === '--sse' ||
+			arg === '--sse-daemon' ||
+			arg === '--loop-daemon-execute' ||
+			arg === '--snow-agent-child-worker',
+	);
 
 // Show loading indicator only for non-quick commands
 if (!isQuickCommand) {

--- a/source/hooks/conversation/chatLogic/useMessageProcessing.ts
+++ b/source/hooks/conversation/chatLogic/useMessageProcessing.ts
@@ -23,7 +23,6 @@ import {
 	notifyAgentTurnComplete,
 	shouldNotifyAgentTurnCompletion,
 } from '../../../utils/platform/notification.js';
-import {hasEnabledHookActions} from '../../../utils/config/hooksConfig.js';
 
 interface MessageTarget {
 	instanceId: string;
@@ -272,23 +271,37 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 		);
 		// AI path: may include onUserMessage inject tags (snow-mode / workflow-state).
 		const aiSource = message;
-		const aiCleanContent =
+		const aiParsed =
 			aiSource === uiSource
-				? cleanContent
-				: (await parseAndValidateFileReferences(aiSource)).cleanContent;
+				? {cleanContent, validFiles}
+				: await parseAndValidateFileReferences(aiSource);
+		const aiCleanContent =
+			aiSource === uiSource ? cleanContent : aiParsed.cleanContent;
 
-		const imageFiles = validFiles.filter(
+		const uiImageFiles = validFiles.filter(
 			f => f.isImage && f.imageData && f.mimeType,
 		);
-		const regularFiles = validFiles.filter(f => !f.isImage);
+		const aiImageFiles = aiParsed.validFiles.filter(
+			f => f.isImage && f.imageData && f.mimeType,
+		);
+		const regularFiles = aiParsed.validFiles.filter(f => !f.isImage);
 
-		const imageContents = [
-			...(images || []).map(img => ({
+		const explicitImages = (images || []).map(img => ({
+			type: 'image' as const,
+			data: img.data,
+			mimeType: img.mimeType,
+		}));
+		const uiImageContents = [
+			...explicitImages,
+			...uiImageFiles.map(f => ({
 				type: 'image' as const,
-				data: img.data,
-				mimeType: img.mimeType,
+				data: f.imageData!,
+				mimeType: f.mimeType!,
 			})),
-			...imageFiles.map(f => ({
+		];
+		const imageContents = [
+			...explicitImages,
+			...aiImageFiles.map(f => ({
 				type: 'image' as const,
 				data: f.imageData!,
 				mimeType: f.mimeType!,
@@ -300,7 +313,7 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 				role: 'user',
 				content: cleanContent,
 				files: validFiles.length > 0 ? validFiles : undefined,
-				images: imageContents.length > 0 ? imageContents : undefined,
+				images: uiImageContents.length > 0 ? uiImageContents : undefined,
 			};
 			setMessages(prev => [...prev, userMessage]);
 		}
@@ -579,7 +592,6 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 							wasUserInterrupted,
 							willAutoContinue,
 							pendingMessageCount: pendingMessagesRef.current.length,
-							hasOnStopHook: hasEnabledHookActions('onStop'),
 						})
 					) {
 						notifyAgentTurnWaitingForInput();
@@ -864,28 +876,45 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 		const {cleanContent, validFiles} = await parseAndValidateFileReferences(
 			typedPending,
 		);
-		const aiCleanPending =
+		const aiParsed =
 			messageToSend === typedPending
-				? cleanContent
-				: (await parseAndValidateFileReferences(messageToSend)).cleanContent;
+				? {cleanContent, validFiles}
+				: await parseAndValidateFileReferences(messageToSend);
+		const aiCleanPending = aiParsed.cleanContent;
 
-		const imageFiles = validFiles.filter(
+		const uiImageFiles = validFiles.filter(
 			f => f.isImage && f.imageData && f.mimeType,
 		);
-		const regularFiles = validFiles.filter(f => !f.isImage);
+		const aiImageFiles = aiParsed.validFiles.filter(
+			f => f.isImage && f.imageData && f.mimeType,
+		);
+		const regularFiles = aiParsed.validFiles.filter(f => !f.isImage);
 
-		const allImages = messagesToProcess
-			.flatMap(m => m.images || [])
-			.concat(
-				imageFiles.map(f => ({
-					data: f.imageData!,
-					mimeType: f.mimeType!,
-				})),
-			);
+		const explicitImages = messagesToProcess.flatMap(m => m.images || []);
+		const uiImages = explicitImages.concat(
+			uiImageFiles.map(f => ({
+				data: f.imageData!,
+				mimeType: f.mimeType!,
+			})),
+		);
+		const aiImages = explicitImages.concat(
+			aiImageFiles.map(f => ({
+				data: f.imageData!,
+				mimeType: f.mimeType!,
+			})),
+		);
 
 		const imageContents =
-			allImages.length > 0
-				? allImages.map(img => ({
+			aiImages.length > 0
+				? aiImages.map(img => ({
+						type: 'image' as const,
+						data: img.data,
+						mimeType: img.mimeType,
+				  }))
+				: undefined;
+		const uiImageContents =
+			uiImages.length > 0
+				? uiImages.map(img => ({
 						type: 'image' as const,
 						data: img.data,
 						mimeType: img.mimeType,
@@ -896,7 +925,7 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 			role: 'user',
 			content: cleanContent,
 			files: validFiles.length > 0 ? validFiles : undefined,
-			images: imageContents,
+			images: uiImageContents,
 		};
 		setMessages(prev => [...prev, userMessage]);
 
@@ -911,6 +940,16 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 				regularFiles,
 				vscodeState.vscodeConnected ? vscodeState.editorContext : undefined,
 			);
+			const saveMessageWithOriginal = async (msg: any) => {
+				await saveMessage({
+					...msg,
+					...(msg.role === 'user' && messageToSend !== typedPending
+						? {originalContent: typedPending}
+						: {}),
+					editorContext:
+						msg.role === 'user' ? messageForAI.editorContext : undefined,
+				});
+			};
 
 			try {
 				await handleConversationWithTools({
@@ -919,7 +958,7 @@ export function useMessageProcessing(props: UseChatLogicProps) {
 					imageContents,
 					controller,
 					messages,
-					saveMessage,
+					saveMessage: saveMessageWithOriginal,
 					setMessages,
 					setStreamTokenCount: streamingState.setStreamTokenCount,
 					requestToolConfirmation,

--- a/source/hooks/conversation/core/toolCallProcessor.ts
+++ b/source/hooks/conversation/core/toolCallProcessor.ts
@@ -115,6 +115,7 @@ export async function processToolCallsAfterStream(
 			);
 			pendingDisplayMessages.push({
 				role: 'assistant',
+				toolName: toolCall.function.name,
 				content: formatToolTitleLine(toolCall.function.name, 'pending'),
 				streaming: false,
 				toolCall: {

--- a/source/hooks/conversation/core/toolResultDisplay.ts
+++ b/source/hooks/conversation/core/toolResultDisplay.ts
@@ -43,6 +43,7 @@ export function buildToolResultMessages(
 
 			resultMessages.push({
 				role: 'assistant',
+				toolName: toolCall.function.name,
 				content: formatToolTitleLine(toolCall.function.name, statusKey),
 				streaming: false,
 				messageStatus: isError ? 'error' : 'success',
@@ -62,6 +63,7 @@ export function buildToolResultMessages(
 
 		resultMessages.push({
 			role: 'assistant',
+			toolName: toolCall.function.name,
 			content: formatToolTitleLine(toolCall.function.name, statusKey),
 			streaming: false,
 			messageStatus: isError ? 'error' : 'success',

--- a/source/hooks/ui/usePanelState.ts
+++ b/source/hooks/ui/usePanelState.ts
@@ -1,5 +1,6 @@
-import {useState, type Dispatch, type SetStateAction} from 'react';
+import {useEffect, useState, type Dispatch, type SetStateAction} from 'react';
 import {reloadConfig} from '../../utils/config/apiConfig.js';
+import {configEvents} from '../../utils/config/configEvents.js';
 import {
 	getAllProfiles,
 	getActiveProfileName,
@@ -157,6 +158,17 @@ export function usePanelState(): PanelState & PanelActions {
 		const profile = profiles.find(p => p.name === activeName);
 		return profile?.displayName || activeName;
 	});
+
+	useEffect(() => {
+		const handleConfigChange = (event: {type: string; value: unknown}) => {
+			if (event.type !== 'profile' || typeof event.value !== 'string') return;
+			const profiles = getAllProfiles();
+			const profile = profiles.find(item => item.name === event.value);
+			setCurrentProfileName(profile?.displayName || event.value);
+		};
+		configEvents.onConfigChange(handleConfigChange);
+		return () => configEvents.removeConfigChangeListener(handleConfigChange);
+	}, []);
 
 	const handleSwitchProfile = (options: {
 		isStreaming: boolean;

--- a/source/mcp/aceCodeSearch.ts
+++ b/source/mcp/aceCodeSearch.ts
@@ -329,13 +329,18 @@ export class ACECodeSearchService {
 		}
 	}
 
-	dispose(): void {
+	/** Clear restartable caches without disabling the process-lifetime service. */
+	clearSessionCaches(): void {
 		if (this.idleCleanupTimer) {
 			clearTimeout(this.idleCleanupTimer);
 			this.idleCleanupTimer = undefined;
 		}
 
 		this.clearCaches();
+	}
+
+	dispose(): void {
+		this.clearSessionCaches();
 		this.isDisposed = true;
 	}
 
@@ -1294,7 +1299,9 @@ export class ACECodeSearchService {
 
 			child.once('error', err => {
 				finalize(() => {
-					reject(new Error(`Failed to start ${displayCommand}: ${err.message}`));
+					reject(
+						new Error(`Failed to start ${displayCommand}: ${err.message}`),
+					);
 				});
 			});
 

--- a/source/mcp/engines/websearch/index.ts
+++ b/source/mcp/engines/websearch/index.ts
@@ -28,9 +28,9 @@ import {
 	type FSWatcher,
 } from 'node:fs';
 import {extname, join} from 'node:path';
-import {pathToFileURL} from 'node:url';
 
 import {SEARCH_ENGINES_DIR} from '../../../utils/config/apiConfig.js';
+import {importFreshPluginModule} from '../../../utils/plugins/importFresh.js';
 import {DuckDuckGoEngine} from './duckduckgo.engine.js';
 import {BingEngine} from './bing.engine.js';
 import type {SearchEngine, SearchEngineId} from './types.js';
@@ -51,9 +51,7 @@ const BUILT_IN_ENGINES: SearchEngine[] = [
  * `ensureSearchEnginesLoaded()`. Engines explicitly setting `enable: false`
  * are NOT registered.
  */
-const ENGINES: Map<string, SearchEngine> = new Map(
-	BUILT_IN_ENGINES.filter(isEngineEnabled).map(e => [e.id, e] as const),
-);
+const ENGINES: Map<string, SearchEngine> = buildBuiltinEngineMap();
 
 let externalLoadPromise: Promise<void> | null = null;
 let externalLoaded = false;
@@ -65,6 +63,7 @@ let reloadInFlight: Promise<void> | null = null;
 let reloadQueued = false;
 let pluginWatcher: FSWatcher | null = null;
 let pluginReloadTimer: ReturnType<typeof setTimeout> | null = null;
+let pluginWatchRetryTimer: ReturnType<typeof setTimeout> | null = null;
 let watcherBootstrapped = false;
 
 type SearchEngineModule = {
@@ -106,21 +105,26 @@ function collectFromModule(mod: SearchEngineModule): SearchEngine[] {
 }
 
 /** Bust ESM import cache so edited plugins reload without process restart. */
-function buildCacheBustedModuleUrl(modulePath: string): string {
-	return `${pathToFileURL(modulePath).href}?t=${Date.now()}`;
-}
-
-function resetEnginesToBuiltins(): void {
-	ENGINES.clear();
+function buildBuiltinEngineMap(): Map<string, SearchEngine> {
+	const engines = new Map<string, SearchEngine>();
 	for (const engine of BUILT_IN_ENGINES) {
 		if (isEngineEnabled(engine)) {
-			ENGINES.set(engine.id, engine);
+			engines.set(engine.id, engine);
 		}
+	}
+	return engines;
+}
+
+function replaceEngines(nextEngines: Map<string, SearchEngine>): void {
+	ENGINES.clear();
+	for (const [id, engine] of nextEngines) {
+		ENGINES.set(id, engine);
 	}
 }
 
-async function loadExternalEngines(): Promise<void> {
-	if (!existsSync(SEARCH_ENGINES_DIR)) return;
+async function loadExternalEngines(): Promise<Map<string, SearchEngine>> {
+	const nextEngines = buildBuiltinEngineMap();
+	if (!existsSync(SEARCH_ENGINES_DIR)) return nextEngines;
 
 	let entries: Array<import('node:fs').Dirent>;
 	try {
@@ -128,7 +132,7 @@ async function loadExternalEngines(): Promise<void> {
 	} catch (error) {
 		// eslint-disable-next-line no-console
 		console.warn('[websearch] failed to read plugin dir', error);
-		return;
+		return nextEngines;
 	}
 
 	const files = entries
@@ -142,8 +146,9 @@ async function loadExternalEngines(): Promise<void> {
 	for (const file of files) {
 		const modulePath = join(SEARCH_ENGINES_DIR, file.name);
 		try {
-			const moduleUrl = buildCacheBustedModuleUrl(modulePath);
-			const mod = (await import(moduleUrl)) as SearchEngineModule;
+			const mod = (await importFreshPluginModule(
+				modulePath,
+			)) as SearchEngineModule;
 			const engines = collectFromModule(mod);
 			if (engines.length === 0) {
 				// eslint-disable-next-line no-console
@@ -157,10 +162,10 @@ async function loadExternalEngines(): Promise<void> {
 					// Plugin author explicitly disabled this engine — ensure it is
 					// not registered AND drop any same-id built-in so the user can
 					// also use `enable: false` as a way to mask built-ins.
-					ENGINES.delete(engine.id);
+					nextEngines.delete(engine.id);
 					continue;
 				}
-				ENGINES.set(engine.id, engine);
+				nextEngines.set(engine.id, engine);
 			}
 		} catch (error) {
 			// eslint-disable-next-line no-console
@@ -170,15 +175,31 @@ async function loadExternalEngines(): Promise<void> {
 			);
 		}
 	}
+
+	return nextEngines;
 }
 
 function ensurePluginWatcher(): void {
 	if (watcherBootstrapped) return;
 	watcherBootstrapped = true;
+	let shouldReloadAfterAttach = false;
+
+	const scheduleWatchRetry = (delayMs: number) => {
+		if (pluginWatcher || pluginWatchRetryTimer) return;
+		pluginWatchRetryTimer = setTimeout(() => {
+			pluginWatchRetryTimer = null;
+			startWatch();
+		}, delayMs);
+		pluginWatchRetryTimer.unref?.();
+	};
 
 	const startWatch = () => {
 		if (pluginWatcher) return;
-		if (!existsSync(SEARCH_ENGINES_DIR)) return;
+		if (!existsSync(SEARCH_ENGINES_DIR)) {
+			shouldReloadAfterAttach = true;
+			scheduleWatchRetry(800);
+			return;
+		}
 		try {
 			pluginWatcher = watchDir(
 				SEARCH_ENGINES_DIR,
@@ -205,16 +226,20 @@ function ensurePluginWatcher(): void {
 					// ignore
 				}
 				pluginWatcher = null;
-				setTimeout(startWatch, 300);
+				shouldReloadAfterAttach = true;
+				scheduleWatchRetry(300);
 			});
+			if (shouldReloadAfterAttach) {
+				shouldReloadAfterAttach = false;
+				void reloadSearchEngines();
+			}
 		} catch {
-			setTimeout(startWatch, 400);
+			shouldReloadAfterAttach = true;
+			scheduleWatchRetry(400);
 		}
 	};
 
 	startWatch();
-	// Directory may appear later after first plugin is created.
-	setTimeout(startWatch, 800);
 }
 
 /**
@@ -229,9 +254,10 @@ export function ensureSearchEnginesLoaded(): Promise<void> {
 	if (externalLoaded) return Promise.resolve();
 	if (externalLoadPromise) return externalLoadPromise;
 	const gen = loadGeneration;
-	externalLoadPromise = loadExternalEngines().then(() => {
+	externalLoadPromise = loadExternalEngines().then(nextEngines => {
 		// Only mark loaded if no reload superseded this load.
 		if (gen === loadGeneration) {
+			replaceEngines(nextEngines);
 			externalLoaded = true;
 		}
 	});
@@ -259,10 +285,9 @@ export async function reloadSearchEngines(): Promise<void> {
 			const gen = loadGeneration;
 			externalLoaded = false;
 			externalLoadPromise = null;
-			// Reset only after claiming the generation so concurrent ensure waits on us.
-			resetEnginesToBuiltins();
-			const loadPromise = loadExternalEngines().then(() => {
+			const loadPromise = loadExternalEngines().then(nextEngines => {
 				if (gen === loadGeneration) {
+					replaceEngines(nextEngines);
 					externalLoaded = true;
 				}
 			});

--- a/source/mcp/sessionCommand.ts
+++ b/source/mcp/sessionCommand.ts
@@ -28,7 +28,7 @@ export const mcpTools = [
 	{
 		name: 'session-command-run',
 		description:
-			'Execute an allowlisted Snow session/slash control command without requiring the user to type /slash in the TUI. Examples: command="buddy.hatch" args with name/species; command="buddy" args="status"; command="tool-display" args="compact"; command="mcp" args="status". Medium/high risk writes require confirm=true. Returns stable JSON {ok, command, data, code, message}.',
+			'Execute an allowlisted Snow session/slash control command without requiring the user to type /slash in the TUI. Examples: command="buddy.hatch" args with name/species; command="buddy" args="status"; command="tool-display" args="compact"; command="mcp" args="status". Agent calls may execute read/low-write commands; medium/high-risk writes return CONFIRMATION_REQUIRED because this tool has no trusted user-confirmation channel. Returns stable JSON {ok, command, data, code, message}.',
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -41,11 +41,6 @@ export const mcpTools = [
 					type: 'string',
 					description:
 						'Optional args string, e.g. "hatch 小雪 --species=fox", "on", "compact", "status".',
-				},
-				confirm: {
-					type: 'boolean',
-					description:
-						'Set true to confirm medium_write/high_risk commands (yolo on, profile switch, buddy reset, etc.).',
 				},
 			},
 			required: ['command'],
@@ -103,7 +98,7 @@ export async function executeSessionCommandTool(
 						? undefined
 						: String(args.args),
 				mode: 'agent',
-				confirm: Boolean(args?.confirm),
+				confirm: false,
 			});
 			return JSON.stringify(result, null, 2);
 		}

--- a/source/test/ace-code-search-lifecycle.test.ts
+++ b/source/test/ace-code-search-lifecycle.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import anyTest, {type TestFn} from 'ava';
+import {ACECodeSearchService} from '../mcp/aceCodeSearch.js';
+
+const test = anyTest as unknown as TestFn;
+
+test('session cache cleanup keeps ACE code search usable', async t => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), 'snow-ace-lifecycle-'));
+	await fs.writeFile(
+		path.join(root, 'sample.ts'),
+		'export function sample(): number { return 1; }\n',
+	);
+	const service = new ACECodeSearchService(root, {idleCleanupMs: 0});
+
+	try {
+		service.clearSessionCaches();
+		await t.notThrowsAsync(service.getFileOutline('sample.ts'));
+	} finally {
+		service.dispose();
+		await fs.rm(root, {recursive: true, force: true});
+	}
+});

--- a/source/test/config-watchers.test.ts
+++ b/source/test/config-watchers.test.ts
@@ -1,0 +1,124 @@
+import {execFile} from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {promisify} from 'node:util';
+import anyTest, {type TestFn} from 'ava';
+
+const test = anyTest as unknown as TestFn;
+const execFileAsync = promisify(execFile);
+
+async function runIsolatedWatcherScenario(
+	homeDirectory: string,
+	script: string,
+): Promise<string> {
+	const {stdout} = await execFileAsync(
+		process.execPath,
+		['--loader=ts-node/esm', '--input-type=module', '--eval', script],
+		{
+			cwd: process.cwd(),
+			env: {
+				...process.env,
+				HOME: homeDirectory,
+				USERPROFILE: homeDirectory,
+			},
+			timeout: 10_000,
+			windowsHide: true,
+		},
+	);
+	return stdout;
+}
+
+test('api config watcher survives an atomic replacement during save suppression', async t => {
+	const homeDirectory = await fs.mkdtemp(
+		path.join(os.tmpdir(), 'snow-api-watch-'),
+	);
+	const script = String.raw`
+		const fs = await import('node:fs/promises');
+		const path = await import('node:path');
+		const {pathToFileURL} = await import('node:url');
+		const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+		const snowDir = path.join(process.env.USERPROFILE, '.snow');
+		const configPath = path.join(snowDir, 'config.json');
+		const backupPath = path.join(snowDir, 'config.backup.json');
+		await fs.mkdir(snowDir, {recursive: true});
+		await fs.writeFile(configPath, JSON.stringify({snowcfg: {advancedModel: 'initial'}}));
+		const root = pathToFileURL(process.cwd() + path.sep).href;
+		const api = await import(new URL('source/utils/config/apiConfig.ts', root));
+		const {configEvents} = await import(new URL('source/utils/config/configEvents.ts', root));
+		const initial = api.loadConfig();
+		const waitForModel = model => new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => reject(new Error('Timed out waiting for ' + model)), 4000);
+			const listener = event => {
+				if (event.type === 'apiConfig' && event.value?.advancedModel === model) {
+					clearTimeout(timeout);
+					configEvents.removeConfigChangeListener(listener);
+					resolve();
+				}
+			};
+			configEvents.onConfigChange(listener);
+		});
+		const replacementSeen = waitForModel('replacement');
+		api.saveConfig({...initial, snowcfg: {...initial.snowcfg, advancedModel: 'internal'}});
+		await fs.rename(configPath, backupPath);
+		await delay(25);
+		await fs.writeFile(configPath, JSON.stringify({snowcfg: {advancedModel: 'replacement'}}));
+		await replacementSeen;
+		await delay(350);
+		const followupSeen = waitForModel('followup');
+		await fs.writeFile(configPath, JSON.stringify({snowcfg: {advancedModel: 'followup'}}));
+		await followupSeen;
+		console.log('WATCHER_OK');
+	`;
+
+	try {
+		const output = await runIsolatedWatcherScenario(homeDirectory, script);
+		t.true(output.includes('WATCHER_OK'));
+	} finally {
+		await fs.rm(homeDirectory, {recursive: true, force: true});
+	}
+});
+
+test('theme watcher reloads a file created after its watch target disappears', async t => {
+	const homeDirectory = await fs.mkdtemp(
+		path.join(os.tmpdir(), 'snow-theme-watch-'),
+	);
+	const script = String.raw`
+		const fs = await import('node:fs/promises');
+		const path = await import('node:path');
+		const {pathToFileURL} = await import('node:url');
+		const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+		const snowDir = path.join(process.env.USERPROFILE, '.snow');
+		const themePath = path.join(snowDir, 'theme.json');
+		const backupPath = path.join(snowDir, 'theme.backup.json');
+		await fs.mkdir(snowDir, {recursive: true});
+		await fs.writeFile(themePath, JSON.stringify({theme: 'tiffany', diffOpacity: 1}));
+		const root = pathToFileURL(process.cwd() + path.sep).href;
+		const {watchThemeConfigFile} = await import(new URL('source/ui/contexts/ThemeContext.tsx', root));
+		let resolveReload;
+		const reloaded = new Promise(resolve => { resolveReload = resolve; });
+		const stopWatching = watchThemeConfigFile(async () => {
+			try {
+				const config = JSON.parse(await fs.readFile(themePath, 'utf8'));
+				if (config.theme === 'dark' && config.diffOpacity === 0.5) resolveReload();
+			} catch {}
+		});
+		await delay(100);
+		await fs.rename(themePath, backupPath);
+		await delay(250);
+		await fs.writeFile(themePath, JSON.stringify({theme: 'dark', diffOpacity: 0.5}));
+		await Promise.race([
+			reloaded,
+			delay(4000).then(() => { throw new Error('Theme watcher did not reload recreated file'); }),
+		]);
+		stopWatching();
+		console.log('THEME_OK');
+	`;
+
+	try {
+		const output = await runIsolatedWatcherScenario(homeDirectory, script);
+		t.true(output.includes('THEME_OK'));
+	} finally {
+		await fs.rm(homeDirectory, {recursive: true, force: true});
+	}
+});

--- a/source/test/notification.test.ts
+++ b/source/test/notification.test.ts
@@ -1,9 +1,11 @@
 import anyTest, {type TestFn} from 'ava';
 
 import {
+	buildWindowsNotificationArguments,
 	buildToastScript,
 	escapeXml,
 	formatAgentTurnCompletionNotification,
+	shouldNotifyAgentTurnCompletion,
 } from '../utils/platform/notification.js';
 
 const test = anyTest as unknown as TestFn;
@@ -15,6 +17,8 @@ test('buildToastScript registers Snow CLI AppUserModelID for WinRT toast', t => 
 	t.true(script.includes("$displayName = 'Snow CLI'"));
 	t.true(script.includes('AppUserModelId\\$appUserModelId'));
 	t.true(script.includes("DisplayName' -Value $displayName"));
+	t.false(script.includes("Name 'Enabled'"));
+	t.false(script.includes("Name 'ShowInActionCenter'"));
 	t.true(script.includes('CreateToastNotifier($appUserModelId)'));
 	t.true(script.includes('<text>Snow agent waiting for input</text>'));
 	t.true(script.includes('<text>snow-cli</text>'));
@@ -33,6 +37,24 @@ test('buildToastScript escapes XML special characters in toast content', t => {
 	t.false(script.includes('<text>A & B <C></text>'));
 });
 
+test('Windows toast launcher relies on windowsHide instead of PowerShell hidden mode', t => {
+	const args = buildWindowsNotificationArguments('Snow test', 'Notification');
+	const encodedIndex = args.indexOf('-EncodedCommand');
+
+	t.deepEqual(args.slice(0, encodedIndex), [
+		'-NoProfile',
+		'-ExecutionPolicy',
+		'Bypass',
+	]);
+	t.false(args.includes('-WindowStyle'));
+	t.true(encodedIndex >= 0);
+	const decoded = Buffer.from(args[encodedIndex + 1]!, 'base64').toString(
+		'utf16le',
+	);
+	t.true(decoded.includes("$appUserModelId = 'Snow.CLI'"));
+	t.true(decoded.includes('<text>Snow test</text>'));
+});
+
 test('formatAgentTurnCompletionNotification uses project name as body', t => {
 	const payload = formatAgentTurnCompletionNotification({
 		projectName: 'snow-cli',
@@ -40,4 +62,21 @@ test('formatAgentTurnCompletionNotification uses project name as body', t => {
 
 	t.is(payload.body, 'snow-cli');
 	t.true(payload.title.length > 0);
+});
+
+test('completed turns notify when unfocused and no continuation is pending', t => {
+	t.true(
+		shouldNotifyAgentTurnCompletion({
+			terminalFocused: false,
+			wasUserInterrupted: false,
+			willAutoContinue: false,
+			pendingMessageCount: 0,
+		}),
+	);
+	t.false(
+		shouldNotifyAgentTurnCompletion({
+			terminalFocused: false,
+			willAutoContinue: true,
+		}),
+	);
 });

--- a/source/test/plugin-import-fresh.test.ts
+++ b/source/test/plugin-import-fresh.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import anyTest, {type TestFn} from 'ava';
+
+import {importFreshPluginModule} from '../utils/plugins/importFresh.js';
+
+const test = anyTest as unknown as TestFn;
+
+test('fresh plugin loader invalidates CommonJS cache', async t => {
+	const directory = await fs.mkdtemp(
+		path.join(os.tmpdir(), 'snow-plugin-fresh-'),
+	);
+	const pluginPath = path.join(directory, 'plugin.cjs');
+
+	try {
+		await fs.writeFile(pluginPath, 'module.exports = {value: 1};\n', 'utf8');
+		const first = await importFreshPluginModule(pluginPath);
+		t.is((first['default'] as {value?: number})?.value, 1);
+
+		await fs.writeFile(pluginPath, 'module.exports = {value: 2};\n', 'utf8');
+		const second = await importFreshPluginModule(pluginPath);
+		t.is((second['default'] as {value?: number})?.value, 2);
+	} finally {
+		await fs.rm(directory, {recursive: true, force: true});
+	}
+});
+
+test('fresh plugin loader handles cyclic CommonJS dependencies', async t => {
+	const directory = await fs.mkdtemp(
+		path.join(os.tmpdir(), 'snow-plugin-cycle-'),
+	);
+	const pluginPath = path.join(directory, 'plugin.cjs');
+	const dependencyPath = path.join(directory, 'dependency.cjs');
+	const cyclePath = path.join(directory, 'cycle.cjs');
+
+	try {
+		await fs.writeFile(
+			pluginPath,
+			"module.exports = require('./dependency.cjs');\n",
+			'utf8',
+		);
+		await fs.writeFile(
+			dependencyPath,
+			"exports.value = 1; exports.fromCycle = require('./cycle.cjs').value;\n",
+			'utf8',
+		);
+		await fs.writeFile(
+			cyclePath,
+			"module.exports = {value: require('./dependency.cjs').value};\n",
+			'utf8',
+		);
+
+		const first = await importFreshPluginModule(pluginPath);
+		t.deepEqual(first['default'], {value: 1, fromCycle: 1});
+
+		await fs.writeFile(
+			dependencyPath,
+			"exports.value = 2; exports.fromCycle = require('./cycle.cjs').value;\n",
+			'utf8',
+		);
+		const second = await importFreshPluginModule(pluginPath);
+		t.deepEqual(second['default'], {value: 2, fromCycle: 2});
+	} finally {
+		await fs.rm(directory, {recursive: true, force: true});
+	}
+});

--- a/source/test/profile-name-validation.test.ts
+++ b/source/test/profile-name-validation.test.ts
@@ -1,0 +1,65 @@
+import {execFile} from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {promisify} from 'node:util';
+import anyTest, {type TestFn} from 'ava';
+
+const test = anyTest as unknown as TestFn;
+const execFileAsync = promisify(execFile);
+
+test('profile names remain portable across Windows and POSIX filesystems', async t => {
+	const homeDirectory = await fs.mkdtemp(
+		path.join(os.tmpdir(), 'snow-profile-names-'),
+	);
+	const script = String.raw`
+		const path = await import('node:path');
+		const {pathToFileURL} = await import('node:url');
+		const root = pathToFileURL(process.cwd() + path.sep).href;
+		const {createProfile, getAllProfiles} = await import(
+			new URL('source/utils/config/configManager.ts', root)
+		);
+		const invalid = [
+			'a:b', 'a*b', 'a?b', 'a"b', 'a<b', 'a>b', 'a|b',
+			'CON', 'con.prod', 'PRN', 'AUX', 'NUL', 'COM1', 'LPT9', 'trailing.'
+		];
+		for (const name of invalid) {
+			try {
+				createProfile(name);
+				throw new Error('Accepted invalid profile name: ' + name);
+			} catch (error) {
+				if (error?.message !== 'Invalid profile name') throw error;
+			}
+		}
+		const valid = [
+			'work prod', '研发', 'café', '.hidden', 'foo.bar',
+			'CONSOLE', 'COM10', 'LPT0', 'auxiliary'
+		];
+		for (const name of valid) createProfile(name);
+		const profiles = new Set(getAllProfiles().map(profile => profile.name));
+		for (const name of valid) {
+			if (!profiles.has(name)) throw new Error('Missing valid profile: ' + name);
+		}
+		console.log('PROFILE_NAMES_OK');
+	`;
+
+	try {
+		const {stdout} = await execFileAsync(
+			process.execPath,
+			['--loader=ts-node/esm', '--input-type=module', '--eval', script],
+			{
+				cwd: process.cwd(),
+				env: {
+					...process.env,
+					HOME: homeDirectory,
+					USERPROFILE: homeDirectory,
+				},
+				timeout: 15_000,
+				windowsHide: true,
+			},
+		);
+		t.true(stdout.includes('PROFILE_NAMES_OK'));
+	} finally {
+		await fs.rm(homeDirectory, {recursive: true, force: true});
+	}
+});

--- a/source/test/session-command-plane.test.ts
+++ b/source/test/session-command-plane.test.ts
@@ -96,6 +96,48 @@ test('parseCmdArgv extracts json and yes flags', t => {
 	t.true(parsed.request.confirm);
 	t.is(parsed.request.command, 'buddy');
 	t.is(parsed.request.args, 'hatch Pip --species=fox');
+	t.deepEqual(parsed.request.argTokens, ['hatch', 'Pip', '--species=fox']);
+});
+
+test('CLI argv preserves spaces in export paths', async t => {
+	const parsed = parseCmdArgv([
+		'export',
+		'md',
+		'--session',
+		'definitely-missing-session',
+		'--out',
+		'C:/My Exports/chat.md',
+		'--yes',
+	]);
+
+	t.deepEqual(parsed.request.argTokens, [
+		'md',
+		'--session',
+		'definitely-missing-session',
+		'--out',
+		'C:/My Exports/chat.md',
+	]);
+	const result = await runSessionCommand(parsed.request);
+	t.false(result.ok);
+	t.is(result.code, 'NOT_FOUND');
+	t.regex(result.message ?? '', /definitely-missing-session/);
+	t.notRegex(result.message ?? '', /Exports\/chat\.md/);
+});
+
+test('subcommand normalization preserves quoted profile names', async t => {
+	const result = await runSessionCommand({
+		command: 'profiles',
+		args: 'rename "definitely missing profile" "new profile"',
+		mode: 'cli',
+		confirm: true,
+	});
+
+	t.false(result.ok);
+	t.is(result.code, 'NOT_FOUND');
+	t.regex(
+		result.message ?? '',
+		/Profile "definitely missing profile" not found/,
+	);
 });
 
 test('runSessionCommand rejects unknown command', async t => {
@@ -181,7 +223,7 @@ test('runSessionCommand speedometer status/on/off without confirm', async t => {
 		const on = await runSessionCommand({
 			command: 'speedometer',
 			args: 'on',
-			mode: 'agent',
+			mode: 'cli',
 		});
 		t.true(on.ok, on.message);
 		t.is((on.data as {enabled?: boolean})?.enabled, true);
@@ -189,7 +231,7 @@ test('runSessionCommand speedometer status/on/off without confirm', async t => {
 		const mid = await runSessionCommand({
 			command: 'speedometer',
 			args: 'status',
-			mode: 'agent',
+			mode: 'cli',
 		});
 		t.true(mid.ok, mid.message);
 		t.is((mid.data as {enabled?: boolean})?.enabled, true);
@@ -197,7 +239,7 @@ test('runSessionCommand speedometer status/on/off without confirm', async t => {
 		const off = await runSessionCommand({
 			command: 'speedometer',
 			args: 'off',
-			mode: 'agent',
+			mode: 'cli',
 		});
 		t.true(off.ok, off.message);
 		t.is((off.data as {enabled?: boolean})?.enabled, false);
@@ -205,7 +247,7 @@ test('runSessionCommand speedometer status/on/off without confirm', async t => {
 		await runSessionCommand({
 			command: 'speedometer',
 			args: original ? 'on' : 'off',
-			mode: 'agent',
+			mode: 'cli',
 		});
 	}
 });
@@ -223,7 +265,7 @@ test('runSessionCommand hybrid-compress status/toggle without confirm', async t 
 		const flipped = await runSessionCommand({
 			command: 'hybrid-compress',
 			args: original ? 'off' : 'on',
-			mode: 'agent',
+			mode: 'cli',
 		});
 		t.true(flipped.ok, flipped.message);
 		t.is((flipped.data as {enabled?: boolean})?.enabled, !original);
@@ -231,7 +273,7 @@ test('runSessionCommand hybrid-compress status/toggle without confirm', async t 
 		await runSessionCommand({
 			command: 'hybrid-compress',
 			args: original ? 'on' : 'off',
-			mode: 'agent',
+			mode: 'cli',
 		});
 	}
 });
@@ -410,11 +452,11 @@ test('runSessionCommand show-thinking status/toggle without confirm', async t =>
 	}
 });
 
-test('runSessionCommand privacy status/mode with confirm', async t => {
+test('runSessionCommand privacy status/mode with CLI confirmation', async t => {
 	const status = await runSessionCommand({
 		command: 'privacy',
 		args: 'status',
-		mode: 'agent',
+		mode: 'cli',
 		confirm: true,
 	});
 	t.true(status.ok, status.message);
@@ -429,7 +471,7 @@ test('runSessionCommand privacy status/mode with confirm', async t => {
 		const modeResult = await runSessionCommand({
 			command: 'privacy',
 			args: `mode ${targetMode}`,
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		t.true(modeResult.ok, modeResult.message);
@@ -438,7 +480,7 @@ test('runSessionCommand privacy status/mode with confirm', async t => {
 		const setResult = await runSessionCommand({
 			command: 'privacy',
 			args: originalEnabled ? 'off' : 'on',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		t.true(setResult.ok, setResult.message);
@@ -447,23 +489,23 @@ test('runSessionCommand privacy status/mode with confirm', async t => {
 		await runSessionCommand({
 			command: 'privacy',
 			args: `mode ${originalMode}`,
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		await runSessionCommand({
 			command: 'privacy',
 			args: originalEnabled ? 'on' : 'off',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 	}
 });
 
-test('runSessionCommand codebase agent-review/reranking toggles', async t => {
+test('runSessionCommand codebase agent-review/reranking toggles via CLI', async t => {
 	const status = await runSessionCommand({
 		command: 'codebase',
 		args: 'status',
-		mode: 'agent',
+		mode: 'cli',
 		confirm: true,
 	});
 	t.true(status.ok, status.message);
@@ -478,7 +520,7 @@ test('runSessionCommand codebase agent-review/reranking toggles', async t => {
 		const reviewOff = await runSessionCommand({
 			command: 'codebase',
 			args: 'agent-review off',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		t.true(reviewOff.ok, reviewOff.message);
@@ -490,7 +532,7 @@ test('runSessionCommand codebase agent-review/reranking toggles', async t => {
 		const rerankOn = await runSessionCommand({
 			command: 'codebase',
 			args: 'reranking on',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		t.true(rerankOn.ok, rerankOn.message);
@@ -503,13 +545,13 @@ test('runSessionCommand codebase agent-review/reranking toggles', async t => {
 		await runSessionCommand({
 			command: 'codebase',
 			args: originalReview ? 'agent-review on' : 'agent-review off',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		await runSessionCommand({
 			command: 'codebase',
 			args: originalRerank ? 'reranking on' : 'reranking off',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 	}
@@ -938,6 +980,17 @@ test('runSessionCommand permissions clear without confirm requires confirmation'
 		args: 'clear',
 		mode: 'cli',
 		confirm: false,
+	});
+	t.false(result.ok);
+	t.is(result.code, 'CONFIRMATION_REQUIRED');
+});
+
+test('hardening: agent cannot self-confirm medium/high writes', async t => {
+	const result = await runSessionCommand({
+		command: 'yolo',
+		args: 'on',
+		mode: 'agent',
+		confirm: true,
 	});
 	t.false(result.ok);
 	t.is(result.code, 'CONFIRMATION_REQUIRED');
@@ -1448,11 +1501,87 @@ test('hardening: session.current structured fields', async t => {
 test('hardening: usage returns object data', async t => {
 	const result = await runSessionCommand({
 		command: 'usage',
+		args: '--period=day',
 		mode: 'cli',
 	});
 	t.true(result.ok, result.message);
 	t.is(typeof result.data, 'object');
 	t.truthy(result.data);
+	const data = result.data as {
+		history?: {period?: string; window?: string; models?: unknown[]};
+	};
+	t.is(data.history?.period, 'day');
+	t.is(data.history?.window, 'last_7d');
+	t.true(Array.isArray(data.history?.models));
+});
+
+test('hardening: usage rejects invalid periods', async t => {
+	for (const args of ['--period=century', '--period=']) {
+		const result = await runSessionCommand({
+			command: 'usage',
+			args,
+			mode: 'cli',
+		});
+		t.false(result.ok);
+		t.is(result.code, 'INVALID_ARGS');
+	}
+});
+
+test('hardening: session ids reject traversal attempts', async t => {
+	for (const command of ['session.resume', 'session.load']) {
+		const result = await runSessionCommand({
+			command,
+			args: '../../config',
+			mode: 'cli',
+			confirm: true,
+		});
+		t.false(result.ok);
+		t.is(result.code, 'NOT_FOUND');
+	}
+});
+
+test('hardening: profile paths and default profile invariant are protected', async t => {
+	const traversal = await runSessionCommand({
+		command: 'profiles.delete',
+		args: '../config',
+		mode: 'cli',
+		confirm: true,
+	});
+	t.false(traversal.ok);
+	t.regex(traversal.message ?? '', /invalid profile name/i);
+
+	const renameDefault = await runSessionCommand({
+		command: 'profiles.rename',
+		args: 'default renamed-default',
+		mode: 'cli',
+		confirm: true,
+	});
+	t.false(renameDefault.ok);
+	t.regex(renameDefault.message ?? '', /cannot rename the default profile/i);
+});
+
+test('hardening: export flags require values', async t => {
+	for (const args of ['--out', '--out=', '--session', '--session=']) {
+		const result = await runSessionCommand({
+			command: 'export',
+			args,
+			mode: 'cli',
+			confirm: true,
+		});
+		t.false(result.ok);
+		t.is(result.code, 'INVALID_ARGS');
+	}
+});
+
+test('hardening: unknown MCP services are not persisted as built-ins', async t => {
+	const result = await runSessionCommand({
+		command: 'mcp.disable',
+		args: 'definitely-not-a-service',
+		mode: 'cli',
+		confirm: true,
+	});
+	t.false(result.ok);
+	t.is(result.code, 'NOT_FOUND');
 });
 
 test('hardening: config.snapshot has no secret-like keys (deep)', async t => {
@@ -1615,7 +1744,7 @@ test('hardening: same-process plan/yolo/theme writes emit configEvents', async t
 		const planOn = await runSessionCommand({
 			command: 'plan',
 			args: originalPlan ? 'off' : 'on',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		t.true(planOn.ok, planOn.message);
@@ -1630,7 +1759,7 @@ test('hardening: same-process plan/yolo/theme writes emit configEvents', async t
 		const yoloOn = await runSessionCommand({
 			command: 'yolo',
 			args: originalYolo ? 'off' : 'on',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		t.true(yoloOn.ok, yoloOn.message);
@@ -1657,13 +1786,13 @@ test('hardening: same-process plan/yolo/theme writes emit configEvents', async t
 		await runSessionCommand({
 			command: 'plan',
 			args: originalPlan ? 'on' : 'off',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		await runSessionCommand({
 			command: 'yolo',
 			args: originalYolo ? 'on' : 'off',
-			mode: 'agent',
+			mode: 'cli',
 			confirm: true,
 		});
 		await runSessionCommand({

--- a/source/test/session-command-plane.test.ts
+++ b/source/test/session-command-plane.test.ts
@@ -1558,6 +1558,18 @@ test('hardening: profile paths and default profile invariant are protected', asy
 	});
 	t.false(renameDefault.ok);
 	t.regex(renameDefault.message ?? '', /cannot rename the default profile/i);
+
+	for (const name of ['a:b', 'a*b', 'CON', 'con.prod', 'COM1', 'trailing.']) {
+		const invalidName = await runSessionCommand({
+			command: 'profiles.create',
+			args: name,
+			mode: 'cli',
+			confirm: true,
+		});
+		t.false(invalidName.ok);
+		t.is(invalidName.code, 'INVALID_ARGS');
+		t.regex(invalidName.message ?? '', /invalid profile name/i);
+	}
 });
 
 test('hardening: export flags require values', async t => {

--- a/source/test/session-manager-security.test.ts
+++ b/source/test/session-manager-security.test.ts
@@ -1,0 +1,125 @@
+import anyTest, {type TestFn} from 'ava';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {sessionManager, type Session} from '../utils/session/sessionManager.js';
+
+const test = anyTest as unknown as TestFn;
+
+type SessionManagerInternals = {
+	sessionsDir: string;
+	currentProjectId: string;
+	currentProjectPath: string;
+	currentProjectRoot: string;
+	projectAliasIds: string[];
+	sessionListCache: unknown;
+	cacheTimestamp: number;
+	currentSession: Session | null;
+};
+
+function buildSession(
+	id: string,
+	extra: Record<string, unknown> = {},
+): Session {
+	return {
+		id,
+		title: id,
+		summary: '',
+		createdAt: Date.now(),
+		updatedAt: Date.now(),
+		messages: [],
+		messageCount: 0,
+		...extra,
+	} as Session;
+}
+
+async function writeSession(filePath: string, session: Session): Promise<void> {
+	await fs.mkdir(path.dirname(filePath), {recursive: true});
+	await fs.writeFile(filePath, JSON.stringify(session), 'utf8');
+}
+
+test.serial(
+	'legacy sessions require reliable current-project ownership evidence',
+	async t => {
+		const root = await fs.mkdtemp(
+			path.join(os.tmpdir(), 'snow-session-security-'),
+		);
+		const sessionsDir = path.join(root, 'sessions');
+		const projectPath = path.join(root, 'workspace');
+		const projectId = 'workspace-abc123';
+		const dateFolder = '20260716';
+		await fs.mkdir(projectPath, {recursive: true});
+
+		const internals = sessionManager as unknown as SessionManagerInternals;
+		const original = {
+			sessionsDir: internals.sessionsDir,
+			currentProjectId: internals.currentProjectId,
+			currentProjectPath: internals.currentProjectPath,
+			currentProjectRoot: internals.currentProjectRoot,
+			projectAliasIds: internals.projectAliasIds,
+			sessionListCache: internals.sessionListCache,
+			cacheTimestamp: internals.cacheTimestamp,
+			currentSession: internals.currentSession,
+		};
+
+		Object.assign(internals, {
+			sessionsDir,
+			currentProjectId: projectId,
+			currentProjectPath: projectPath,
+			currentProjectRoot: projectPath,
+			projectAliasIds: [],
+			sessionListCache: null,
+			cacheTimestamp: 0,
+			currentSession: null,
+		});
+
+		const unownedId = 'legacy-unowned';
+		const foreignId = 'legacy-foreign';
+		const inferredId = 'legacy-inferred';
+		const scopedId = 'legacy-scoped';
+		const unownedPath = path.join(sessionsDir, `${unownedId}.json`);
+
+		try {
+			await writeSession(unownedPath, buildSession(unownedId));
+			await writeSession(
+				path.join(sessionsDir, `${foreignId}.json`),
+				buildSession(foreignId, {
+					workingDirectory: path.join(root, 'other-workspace'),
+				}),
+			);
+			await writeSession(
+				path.join(sessionsDir, `${inferredId}.json`),
+				buildSession(inferredId, {workingDirectory: projectPath}),
+			);
+			await writeSession(
+				path.join(sessionsDir, projectId, dateFolder, `${scopedId}.json`),
+				buildSession(scopedId),
+			);
+
+			t.is(await sessionManager.getSessionForExport(unownedId), null);
+			t.is(await sessionManager.getSessionForExport(foreignId), null);
+
+			const inferred = await sessionManager.getSessionForExport(inferredId);
+			t.is(inferred?.projectId, projectId);
+			t.is(inferred?.projectPath, projectPath);
+
+			const scoped = await sessionManager.getSessionForExport(scopedId);
+			t.is(scoped?.projectId, projectId);
+			t.is(scoped?.projectPath, projectPath);
+
+			const listedIds = (await sessionManager.listSessions()).map(
+				item => item.id,
+			);
+			t.false(listedIds.includes(unownedId));
+			t.false(listedIds.includes(foreignId));
+			t.true(listedIds.includes(inferredId));
+			t.true(listedIds.includes(scopedId));
+
+			t.false(await sessionManager.deleteSession(unownedId));
+			t.true(Boolean(await fs.stat(unownedPath)));
+		} finally {
+			Object.assign(internals, original);
+			await fs.rm(root, {recursive: true, force: true});
+		}
+	},
+);

--- a/source/test/sse-client/app.js
+++ b/source/test/sse-client/app.js
@@ -7,8 +7,20 @@
 // ----------------------------------------------------------------------------
 let eventSource = null; // SSE 连接实例
 let serverUrl = 'http://localhost:3000';
+let authToken = '';
 let currentSessionId = null; // 当前会话 ID
 let selectedImages = []; // 待发送的图片（Base64 data URI）数组
+
+const nativeFetch = window.fetch.bind(window);
+window.fetch = (input, init = {}) => {
+	const url = typeof input === 'string' ? input : input.url;
+	if (!authToken || !url.startsWith(serverUrl)) {
+		return nativeFetch(input, init);
+	}
+	const headers = new Headers(init.headers || {});
+	headers.set('Authorization', `Bearer ${authToken}`);
+	return nativeFetch(input, {...init, headers});
+};
 
 // 会话列表 UI 状态
 const sessionListState = {
@@ -1045,8 +1057,12 @@ function updateStatus(connected) {
 // 连接到 SSE 服务器
 function connect() {
 	serverUrl = document.getElementById('serverUrl').value;
+	authToken = document.getElementById('authToken').value.trim();
 
-	eventSource = new EventSource(`${serverUrl}/events`);
+	const eventUrl = authToken
+		? `${serverUrl}/events?token=${encodeURIComponent(authToken)}`
+		: `${serverUrl}/events`;
+	eventSource = new EventSource(eventUrl);
 
 	eventSource.onopen = () => {
 		updateStatus(true);

--- a/source/test/sse-client/index.html
+++ b/source/test/sse-client/index.html
@@ -96,6 +96,15 @@
 								/>
 							</div>
 							<div class="config-section">
+								<label for="authToken">SSE Token</label>
+								<input
+									type="password"
+									id="authToken"
+									autocomplete="off"
+									style="width: 100%"
+								/>
+							</div>
+							<div class="config-section">
 								<label>连接控制</label>
 								<div style="display: flex; gap: 8px">
 									<button onclick="connect()" id="connectBtn">连接</button>

--- a/source/test/sse-server-security.test.ts
+++ b/source/test/sse-server-security.test.ts
@@ -1,0 +1,134 @@
+import anyTest, {type TestFn} from 'ava';
+
+import {SSEServer} from '../api/sse-server.js';
+
+const test = anyTest as unknown as TestFn;
+const jsonHeaders = {'Content-Type': 'application/json'};
+
+test.serial(
+	'SSE protects all control endpoints when a token is configured',
+	async t => {
+		const previousToken = process.env['SNOW_SSE_TOKEN'];
+		const previousOrigins = process.env['SNOW_SSE_ALLOWED_ORIGINS'];
+		process.env['SNOW_SSE_TOKEN'] = 'sse-test-token';
+		process.env['SNOW_SSE_ALLOWED_ORIGINS'] = 'http://localhost:5173';
+		const server = new SSEServer(0);
+
+		try {
+			await server.start();
+			const baseUrl = `http://127.0.0.1:${server.getListeningPort()}`;
+
+			const health = await fetch(`${baseUrl}/health`);
+			t.is(health.status, 200);
+
+			const unauthorized = await fetch(`${baseUrl}/session/list`);
+			t.is(unauthorized.status, 401);
+
+			const forbiddenOrigin = await fetch(`${baseUrl}/session/list`, {
+				headers: {
+					Authorization: 'Bearer sse-test-token',
+					Origin: 'https://evil.example',
+				},
+			});
+			t.is(forbiddenOrigin.status, 403);
+
+			const authorized = await fetch(`${baseUrl}/session/list`, {
+				headers: {
+					Authorization: 'Bearer sse-test-token',
+					Origin: 'http://localhost:5173',
+				},
+			});
+			t.is(authorized.status, 200);
+
+			const oversized = await fetch(`${baseUrl}/message`, {
+				method: 'POST',
+				headers: {
+					...jsonHeaders,
+					Authorization: 'Bearer sse-test-token',
+					Origin: 'http://localhost:5173',
+				},
+				body: JSON.stringify({type: 'chat', content: 'x'.repeat(1024 * 1024)}),
+			});
+			t.is(oversized.status, 413);
+		} finally {
+			await server.stop();
+			if (previousToken === undefined) {
+				delete process.env['SNOW_SSE_TOKEN'];
+			} else {
+				process.env['SNOW_SSE_TOKEN'] = previousToken;
+			}
+			if (previousOrigins === undefined) {
+				delete process.env['SNOW_SSE_ALLOWED_ORIGINS'];
+			} else {
+				process.env['SNOW_SSE_ALLOWED_ORIGINS'] = previousOrigins;
+			}
+		}
+	},
+);
+
+test.serial(
+	'SSE rejects browser origins unless explicitly allowlisted',
+	async t => {
+		const previousToken = process.env['SNOW_SSE_TOKEN'];
+		const previousOrigins = process.env['SNOW_SSE_ALLOWED_ORIGINS'];
+		delete process.env['SNOW_SSE_TOKEN'];
+		delete process.env['SNOW_SSE_ALLOWED_ORIGINS'];
+		const server = new SSEServer(0);
+
+		try {
+			await server.start();
+			const response = await fetch(
+				`http://127.0.0.1:${server.getListeningPort()}/session/list`,
+				{headers: {Origin: 'http://localhost:5173'}},
+			);
+			t.is(response.status, 403);
+		} finally {
+			await server.stop();
+			if (previousToken === undefined) {
+				delete process.env['SNOW_SSE_TOKEN'];
+			} else {
+				process.env['SNOW_SSE_TOKEN'] = previousToken;
+			}
+			if (previousOrigins === undefined) {
+				delete process.env['SNOW_SSE_ALLOWED_ORIGINS'];
+			} else {
+				process.env['SNOW_SSE_ALLOWED_ORIGINS'] = previousOrigins;
+			}
+		}
+	},
+);
+
+test.serial(
+	'SSE request confirm is not trusted without transport auth',
+	async t => {
+		const previousToken = process.env['SNOW_SSE_TOKEN'];
+		delete process.env['SNOW_SSE_TOKEN'];
+		const server = new SSEServer(0);
+
+		try {
+			await server.start();
+			const response = await fetch(
+				`http://127.0.0.1:${server.getListeningPort()}/session/command`,
+				{
+					method: 'POST',
+					headers: jsonHeaders,
+					body: JSON.stringify({
+						command: 'buddy.reset',
+						args: 'status',
+						confirm: true,
+					}),
+				},
+			);
+			t.is(response.status, 400);
+			const result = (await response.json()) as {code?: string};
+			t.is(result.code, 'CONFIRMATION_REQUIRED');
+		} finally {
+			await server.stop();
+			if (previousToken === undefined) {
+				delete process.env['SNOW_SSE_TOKEN'];
+			} else {
+				process.env['SNOW_SSE_TOKEN'] = previousToken;
+			}
+		}
+	},
+);

--- a/source/test/tool-names.test.ts
+++ b/source/test/tool-names.test.ts
@@ -1,0 +1,41 @@
+import anyTest, {type TestFn} from 'ava';
+
+import {parseToolDisplayNamePairs} from '../utils/commands/toolNames.js';
+
+const test = anyTest as unknown as TestFn;
+
+test('tool display names keep spaces in a single English display name', t => {
+	t.deepEqual(parseToolDisplayNamePairs('websearch-search:Web Search'), [
+		{toolName: 'websearch-search', displayName: 'Web Search'},
+	]);
+});
+
+test('tool display names split batches only at the next tool marker', t => {
+	t.deepEqual(
+		parseToolDisplayNamePairs(
+			'filesystem-read:Read File, terminal-execute:Run Shell',
+		),
+		[
+			{toolName: 'filesystem-read', displayName: 'Read File'},
+			{toolName: 'terminal-execute', displayName: 'Run Shell'},
+		],
+	);
+	t.deepEqual(parseToolDisplayNamePairs('a:Alpha Name, b:Beta Name'), [
+		{toolName: 'a', displayName: 'Alpha Name'},
+		{toolName: 'b', displayName: 'Beta Name'},
+	]);
+});
+
+test('tool display names may contain colons without becoming a batch', t => {
+	t.deepEqual(parseToolDisplayNamePairs('websearch-search:Web Search: fast'), [
+		{toolName: 'websearch-search', displayName: 'Web Search: fast'},
+	]);
+});
+
+test('tool display names preserve empty values for clearing overrides', t => {
+	t.deepEqual(parseToolDisplayNamePairs('a: b:Beta'), [
+		{toolName: 'a', displayName: ''},
+		{toolName: 'b', displayName: 'Beta'},
+	]);
+	t.is(parseToolDisplayNamePairs('missing-separator'), null);
+});

--- a/source/test/usage-history.test.ts
+++ b/source/test/usage-history.test.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import anyTest, {type TestFn} from 'ava';
+
+import {
+	aggregateByModel,
+	filterByPeriod,
+	loadUsageData,
+	parseUsagePeriod,
+} from '../utils/core/usageHistory.js';
+
+const test = anyTest as unknown as TestFn;
+
+test('usage history skips invalid identities and normalizes unsafe token counts', async t => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), 'snow-usage-history-'));
+	const dateDir = path.join(root, '2026-07-16');
+	await fs.mkdir(dateDir, {recursive: true});
+	await fs.writeFile(
+		path.join(dateDir, 'usage.jsonl'),
+		[
+			'{"model":" model-a ","profileName":"","inputTokens":10,"outputTokens":5,"timestamp":"2026-07-16T00:00:00.000Z"}',
+			'{"model":"model-a","profileName":"default","inputTokens":-20,"outputTokens":1e999,"cacheReadInputTokens":-1,"timestamp":"2026-07-16T01:00:00.000Z"}',
+			'{"model":"","inputTokens":99,"outputTokens":99,"timestamp":"2026-07-16T02:00:00.000Z"}',
+			'{"model":"model-b","inputTokens":99,"outputTokens":99,"timestamp":"not-a-date"}',
+		].join('\n'),
+		'utf8',
+	);
+
+	try {
+		const entries = await loadUsageData(root);
+		t.is(entries.length, 2);
+		t.deepEqual(entries[0], {
+			model: 'model-a',
+			profileName: 'default',
+			inputTokens: 10,
+			outputTokens: 5,
+			timestamp: '2026-07-16T00:00:00.000Z',
+		});
+		t.is(entries[1]?.inputTokens, 0);
+		t.is(entries[1]?.outputTokens, 0);
+		t.is(entries[1]?.cacheReadInputTokens, 0);
+
+		const totals = aggregateByModel(entries);
+		t.is(totals.grandTotal, 15);
+		t.is(totals.models.get('model-a')?.total, 15);
+	} finally {
+		await fs.rm(root, {recursive: true, force: true});
+	}
+});
+
+test('usage period parser accepts documented aliases', t => {
+	t.deepEqual(parseUsagePeriod('24h'), {ok: true, period: 'hour'});
+	t.deepEqual(parseUsagePeriod('7d'), {ok: true, period: 'day'});
+	t.deepEqual(parseUsagePeriod('30d'), {ok: true, period: 'week'});
+	t.deepEqual(parseUsagePeriod('12m'), {ok: true, period: 'month'});
+	t.false(parseUsagePeriod('century').ok);
+});
+
+test('usage rolling windows exclude future timestamps', t => {
+	const now = new Date('2026-07-16T12:00:00.000Z');
+	const entries = [
+		{
+			model: 'model-a',
+			profileName: 'default',
+			inputTokens: 1,
+			outputTokens: 1,
+			timestamp: '2026-07-16T11:00:00.000Z',
+		},
+		{
+			model: 'model-a',
+			profileName: 'default',
+			inputTokens: 10,
+			outputTokens: 10,
+			timestamp: '2026-07-17T12:00:00.000Z',
+		},
+	];
+
+	t.deepEqual(filterByPeriod(entries, 'hour', now), [entries[0]]);
+});

--- a/source/ui/components/chat/MessageList.tsx
+++ b/source/ui/components/chat/MessageList.tsx
@@ -33,6 +33,8 @@ export interface Message {
 		name: string;
 		arguments: any;
 	};
+	/** Stable technical tool id; display text may be localized/decorated. */
+	toolName?: string;
 	toolDisplay?: {
 		toolName: string;
 		args: Array<{key: string; value: string; isLast: boolean}>;

--- a/source/ui/components/chat/MessageRenderer.tsx
+++ b/source/ui/components/chat/MessageRenderer.tsx
@@ -164,7 +164,9 @@ function MessageRendererImpl({
 		// 先折叠 Skill / GitLine，再剥离 onUserMessage hook 注入（snow-mode 等）。
 		const afterSkill = maskSkillInjectedText(removeAnsiCodes(content || ''));
 		const afterGit = maskGitLineText(afterSkill.displayText).displayText;
-		return maskHookInjectedText(afterGit).displayText;
+		return message.role === 'user'
+			? maskHookInjectedText(afterGit).displayText
+			: afterGit;
 	};
 
 	const wrapTextToVisualWidth = (text: string, maxWidth: number): string[] => {
@@ -562,14 +564,17 @@ function MessageRendererImpl({
 																message.messageStatus === 'success' &&
 																message.toolResult &&
 																(() => {
-																	const toolName = removeAnsiCodes(titleLine)
-																		// Status glyphs + optional tool-type emoji (when toolIcons enabled)
-																		.replace(
-																			/^[✓✗⚡✅❌⚠️⏳]\s*(?:[\p{Emoji_Presentation}\p{Extended_Pictographic}]\uFE0F?\s*)?/u,
-																			'',
-																		)
-																		.replace(/.*⚇✓\s*/, '')
-																		.trim();
+																	const toolName =
+																		message.toolName ??
+																		message.toolCall?.name ??
+																		removeAnsiCodes(titleLine)
+																			// Status glyphs + optional tool-type emoji (when toolIcons enabled)
+																			.replace(
+																				/^[✓✗⚡✅❌⚠️⏳]\s*(?:[\p{Emoji_Presentation}\p{Extended_Pictographic}]\uFE0F?\s*)?/u,
+																				'',
+																			)
+																			.replace(/.*⚇✓\s*/, '')
+																			.trim();
 																	const summary = getToolResultSummary(
 																		toolName,
 																		message.toolResult,
@@ -856,13 +861,16 @@ function MessageRendererImpl({
 										toolDisplayMode === 'full' && (
 											<ToolResultPreview
 												toolName={
-													(message.content || '')
+													message.toolName ??
+													message.toolCall?.name ??
+													((message.content || '')
 														.replace(/^✓\s*/, '') // Remove leading ✓
 														.replace(/^⚇✓\s*/, '') // Remove leading ⚇✓
 														.replace(/.*⚇✓\s*/, '') // Remove any prefix before ⚇✓
 														.replace(/\x1b\[[0-9;]*m/g, '') // Remove ANSI color codes
 														.split('\n')[0]
-														?.trim() || ''
+														?.trim() ||
+														'')
 												}
 												result={message.toolResult}
 												maxLines={5}

--- a/source/ui/components/common/statusline/useStatusLineHooks.ts
+++ b/source/ui/components/common/statusline/useStatusLineHooks.ts
@@ -5,10 +5,10 @@ import {
 	type FSWatcher,
 } from 'node:fs';
 import {extname, join} from 'node:path';
-import {pathToFileURL} from 'node:url';
 import React from 'react';
 import {STATUSLINE_HOOKS_DIR} from '../../../../utils/config/apiConfig.js';
 import {logger} from '../../../../utils/core/logger.js';
+import {importFreshPluginModule} from '../../../../utils/plugins/importFresh.js';
 import {gitBranchStatusLineHook} from './gitBranch.js';
 import type {
 	StatusLineHookContext,
@@ -103,15 +103,6 @@ function normalizeStatusLineHookExports(
 	});
 }
 
-/**
- * Bust ESM module cache so edited statusline plugins reload without restart.
- * Node caches dynamic import() by full URL, so a unique query is enough.
- */
-function buildCacheBustedModuleUrl(modulePath: string): string {
-	const baseUrl = pathToFileURL(modulePath).href;
-	return `${baseUrl}?t=${Date.now()}`;
-}
-
 async function loadExternalStatusLineHooks(): Promise<
 	StatusLineHookDefinition[]
 > {
@@ -142,8 +133,9 @@ async function loadExternalStatusLineHooks(): Promise<
 	for (const moduleFile of moduleFiles) {
 		const modulePath = join(STATUSLINE_HOOKS_DIR, moduleFile.name);
 		try {
-			const moduleUrl = buildCacheBustedModuleUrl(modulePath);
-			const importedModule = (await import(moduleUrl)) as StatusLineHookModule;
+			const importedModule = (await importFreshPluginModule(
+				modulePath,
+			)) as StatusLineHookModule;
 			hooks.push(...normalizeStatusLineHookExports(importedModule, modulePath));
 		} catch (error) {
 			logger.warn('Failed to load status line hook module', {
@@ -236,7 +228,9 @@ export function useStatusLineHookItems(
 	React.useEffect(() => {
 		let watcher: FSWatcher | null = null;
 		let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+		let watchRetryTimer: ReturnType<typeof setTimeout> | null = null;
 		let disposed = false;
+		let shouldReloadAfterAttach = false;
 
 		const scheduleReload = () => {
 			if (disposed) return;
@@ -247,10 +241,20 @@ export function useStatusLineHookItems(
 			}, STATUSLINE_PLUGIN_RELOAD_DEBOUNCE_MS);
 		};
 
+		const scheduleWatchRetry = (delayMs: number) => {
+			if (disposed || watcher || watchRetryTimer) return;
+			watchRetryTimer = setTimeout(() => {
+				watchRetryTimer = null;
+				startWatch();
+			}, delayMs);
+			watchRetryTimer.unref?.();
+		};
+
 		const startWatch = () => {
 			if (disposed || watcher) return;
 			if (!existsSync(STATUSLINE_HOOKS_DIR)) {
-				// Directory may appear later after first plugin is created.
+				shouldReloadAfterAttach = true;
+				scheduleWatchRetry(800);
 				return;
 			}
 			try {
@@ -276,24 +280,28 @@ export function useStatusLineHookItems(
 						// ignore
 					}
 					watcher = null;
+					shouldReloadAfterAttach = true;
 					if (!disposed) {
-						setTimeout(startWatch, 300);
+						scheduleWatchRetry(300);
 					}
 				});
+				if (shouldReloadAfterAttach) {
+					shouldReloadAfterAttach = false;
+					scheduleReload();
+				}
 			} catch {
+				shouldReloadAfterAttach = true;
 				if (!disposed) {
-					setTimeout(startWatch, 400);
+					scheduleWatchRetry(400);
 				}
 			}
 		};
 
 		startWatch();
-		// Retry shortly in case the plugin dir is created after mount.
-		const bootTimer = setTimeout(startWatch, 800);
 
 		return () => {
 			disposed = true;
-			clearTimeout(bootTimer);
+			if (watchRetryTimer) clearTimeout(watchRetryTimer);
 			if (debounceTimer) clearTimeout(debounceTimer);
 			try {
 				watcher?.close();

--- a/source/ui/contexts/ThemeContext.tsx
+++ b/source/ui/contexts/ThemeContext.tsx
@@ -6,7 +6,7 @@ import React, {
 	useEffect,
 	ReactNode,
 } from 'react';
-import {existsSync, watch as watchFile, type FSWatcher} from 'fs';
+import {existsSync, readFileSync, watch as watchFile, type FSWatcher} from 'fs';
 import {homedir} from 'os';
 import {join} from 'path';
 import {ThemeType, themes, Theme, getCustomTheme} from '../themes/index.js';
@@ -36,6 +36,86 @@ interface ThemeProviderProps {
 }
 
 const THEME_CONFIG_PATH = join(homedir(), '.snow', 'theme.json');
+
+/** Watch the theme config across atomic replacement and delayed recreation. */
+export function watchThemeConfigFile(onChange: () => void): () => void {
+	let watcher: FSWatcher | null = null;
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+	let watchRetryTimer: ReturnType<typeof setTimeout> | null = null;
+	let disposed = false;
+	let shouldReloadAfterAttach = false;
+
+	const scheduleReload = () => {
+		if (debounceTimer) clearTimeout(debounceTimer);
+		debounceTimer = setTimeout(() => {
+			debounceTimer = null;
+			if (!disposed) onChange();
+		}, 80);
+	};
+
+	const scheduleWatchRetry = (delayMs: number) => {
+		if (disposed || watcher || watchRetryTimer) return;
+		watchRetryTimer = setTimeout(() => {
+			watchRetryTimer = null;
+			startWatch();
+		}, delayMs);
+		watchRetryTimer.unref?.();
+	};
+
+	const startWatch = () => {
+		if (disposed || watcher) return;
+		if (!existsSync(THEME_CONFIG_PATH)) {
+			shouldReloadAfterAttach = true;
+			scheduleWatchRetry(400);
+			return;
+		}
+		try {
+			watcher = watchFile(THEME_CONFIG_PATH, {persistent: false}, eventType => {
+				scheduleReload();
+				if (eventType === 'rename') {
+					try {
+						watcher?.close();
+					} catch {
+						// ignore
+					}
+					watcher = null;
+					shouldReloadAfterAttach = true;
+					scheduleWatchRetry(150);
+				}
+			});
+			watcher.on('error', () => {
+				try {
+					watcher?.close();
+				} catch {
+					// ignore
+				}
+				watcher = null;
+				shouldReloadAfterAttach = true;
+				scheduleWatchRetry(200);
+			});
+			if (shouldReloadAfterAttach) {
+				shouldReloadAfterAttach = false;
+				scheduleReload();
+			}
+		} catch {
+			shouldReloadAfterAttach = true;
+			scheduleWatchRetry(300);
+		}
+	};
+
+	startWatch();
+
+	return () => {
+		disposed = true;
+		if (watchRetryTimer) clearTimeout(watchRetryTimer);
+		if (debounceTimer) clearTimeout(debounceTimer);
+		try {
+			watcher?.close();
+		} catch {
+			// ignore
+		}
+	};
+}
 
 export function ThemeProvider({children}: ThemeProviderProps) {
 	const [themeType, setThemeTypeState] = useState<ThemeType>(() => {
@@ -90,13 +170,12 @@ export function ThemeProvider({children}: ThemeProviderProps) {
 	// External writes to ~/.snow/theme.json (agent force-write / manual edit)
 	// must hot-refresh without restarting the process.
 	useEffect(() => {
-		let watcher: FSWatcher | null = null;
-		let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-		let disposed = false;
-
 		const applyFromDisk = () => {
-			if (disposed) return;
 			try {
+				// Validate the file before calling helpers that intentionally fall back
+				// to defaults on parse errors. Transient half-writes must keep the
+				// current UI theme instead of flashing back to defaults.
+				JSON.parse(readFileSync(THEME_CONFIG_PATH, 'utf8'));
 				const nextTheme = getCurrentTheme();
 				const nextOpacity = getDiffOpacity();
 				setThemeTypeState(nextTheme);
@@ -109,48 +188,7 @@ export function ThemeProvider({children}: ThemeProviderProps) {
 			}
 		};
 
-		const scheduleReload = () => {
-			if (debounceTimer) clearTimeout(debounceTimer);
-			debounceTimer = setTimeout(applyFromDisk, 80);
-		};
-
-		const startWatch = () => {
-			if (disposed || watcher) return;
-			if (!existsSync(THEME_CONFIG_PATH)) return;
-			try {
-				watcher = watchFile(THEME_CONFIG_PATH, {persistent: false}, () => {
-					scheduleReload();
-				});
-				watcher.on('error', () => {
-					// File may be replaced atomically; re-arm later.
-					try {
-						watcher?.close();
-					} catch {
-						// ignore
-					}
-					watcher = null;
-					setTimeout(startWatch, 200);
-				});
-			} catch {
-				// watch unsupported or race during write — retry
-				setTimeout(startWatch, 300);
-			}
-		};
-
-		startWatch();
-		// If file appears later, poll once shortly after mount.
-		const bootTimer = setTimeout(startWatch, 500);
-
-		return () => {
-			disposed = true;
-			clearTimeout(bootTimer);
-			if (debounceTimer) clearTimeout(debounceTimer);
-			try {
-				watcher?.close();
-			} catch {
-				// ignore
-			}
-		};
+		return watchThemeConfigFile(applyFromDisk);
 	}, []);
 
 	const getTheme = useCallback((): Theme => {

--- a/source/ui/pages/chatScreen/useChatScreenLocalState.ts
+++ b/source/ui/pages/chatScreen/useChatScreenLocalState.ts
@@ -46,9 +46,10 @@ export function useChatScreenLocalState() {
 	const hadBashSensitiveCommandRef = useRef(false);
 	const [hookError, setHookError] = useState<HookErrorDetails | null>(null);
 	const [hookStatus, setHookStatus] = useState<HookStatusEvent | null>(null);
-	const hookStatusClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-		null,
-	);
+	const hookStatusRunsRef = useRef<Map<string, HookStatusEvent>>(new Map());
+	const hookStatusClearTimersRef = useRef<
+		Map<string, ReturnType<typeof setTimeout>>
+	>(new Map());
 	const [pendingUserQuestion, setPendingUserQuestion] =
 		useState<PendingUserQuestionState>(null);
 	const [compressionStatus, setCompressionStatus] =
@@ -69,37 +70,55 @@ export function useChatScreenLocalState() {
 
 	// Live Hook execution status (Unicode icons + spinner in HookStatusDisplay)
 	useEffect(() => {
-		const unsubscribe = onHookStatus(event => {
-			if (hookStatusClearTimerRef.current) {
-				clearTimeout(hookStatusClearTimerRef.current);
-				hookStatusClearTimerRef.current = null;
-			}
+		const refreshVisibleStatus = () => {
+			const events = Array.from(hookStatusRunsRef.current.values());
+			const running = events
+				.toReversed()
+				.find(event => event.phase === 'start' || event.phase === 'action');
+			setHookStatus(running ?? events.at(-1) ?? null);
+		};
 
+		const unsubscribe = onHookStatus(event => {
 			if (!event || event.phase === 'idle') {
+				for (const timer of hookStatusClearTimersRef.current.values()) {
+					clearTimeout(timer);
+				}
+				hookStatusClearTimersRef.current.clear();
+				hookStatusRunsRef.current.clear();
 				setHookStatus(null);
 				return;
 			}
 
-			setHookStatus(event);
+			const existingTimer = hookStatusClearTimersRef.current.get(
+				event.executionId,
+			);
+			if (existingTimer) {
+				clearTimeout(existingTimer);
+				hookStatusClearTimersRef.current.delete(event.executionId);
+			}
+			hookStatusRunsRef.current.delete(event.executionId);
+			hookStatusRunsRef.current.set(event.executionId, event);
+			refreshVisibleStatus();
 
 			// Auto-clear terminal success/failed banner so it does not stick
 			if (event.phase === 'success' || event.phase === 'failed') {
 				const delayMs = event.phase === 'success' ? 1600 : 3200;
-				hookStatusClearTimerRef.current = setTimeout(() => {
-					setHookStatus(current =>
-						current && current.phase === event.phase ? null : current,
-					);
-					hookStatusClearTimerRef.current = null;
+				const timer = setTimeout(() => {
+					hookStatusRunsRef.current.delete(event.executionId);
+					hookStatusClearTimersRef.current.delete(event.executionId);
+					refreshVisibleStatus();
 				}, delayMs);
+				hookStatusClearTimersRef.current.set(event.executionId, timer);
 			}
 		});
 
 		return () => {
 			unsubscribe();
-			if (hookStatusClearTimerRef.current) {
-				clearTimeout(hookStatusClearTimerRef.current);
-				hookStatusClearTimerRef.current = null;
+			for (const timer of hookStatusClearTimersRef.current.values()) {
+				clearTimeout(timer);
 			}
+			hookStatusClearTimersRef.current.clear();
+			hookStatusRunsRef.current.clear();
 		};
 	}, []);
 

--- a/source/utils/commands/toolNames.ts
+++ b/source/utils/commands/toolNames.ts
@@ -18,54 +18,51 @@ function getMessages() {
 type Pair = {toolName: string; displayName: string};
 
 /**
- * Parse one or more `tool:display` tokens.
+ * Parse one or more `tool:display` entries.
  * Supports:
  *   websearch-search:网页搜索
+ *   websearch-search:Web Search
  *   a:甲 b:乙
  *   a:甲, b:乙
- * Display may contain spaces only when a single pair uses the first `:`
- * (legacy single-pair form with spaces after colon).
+ * Without commas, whitespace is treated as a batch separator only when every
+ * token is a complete `tool:value` pair. Commas make multi-word batches
+ * unambiguous and allow display names themselves to contain spaces or colons.
  */
-function parsePairs(raw: string): Pair[] | null {
+export function parseToolDisplayNamePairs(raw: string): Pair[] | null {
 	const trimmed = raw.trim();
 	if (!trimmed) {
 		return [];
 	}
 
-	// Prefer multi-token: split on commas / whitespace that separate pairs.
-	const tokens = trimmed
-		.split(/[\s,]+/)
-		.map(t => t.trim())
-		.filter(Boolean);
+	const parseEntry = (entry: string): Pair | null => {
+		const colon = entry.indexOf(':');
+		if (colon <= 0) return null;
+		return {
+			toolName: entry.slice(0, colon).trim(),
+			displayName: entry.slice(colon + 1).trim(),
+		};
+	};
 
-	if (tokens.length > 1) {
-		const pairs: Pair[] = [];
-		for (const token of tokens) {
+	if (trimmed.includes(',')) {
+		const entries = trimmed.split(',').map(entry => entry.trim());
+		if (entries.some(entry => entry.length === 0)) return null;
+		const pairs = entries.map(parseEntry);
+		return pairs.every((pair): pair is Pair => pair !== null) ? pairs : null;
+	}
+
+	const tokens = trimmed.split(/\s+/);
+	if (
+		tokens.length > 1 &&
+		tokens.every(token => {
 			const colon = token.indexOf(':');
-			if (colon <= 0) {
-				return null;
-			}
-			const toolName = token.slice(0, colon).trim();
-			const displayName = token.slice(colon + 1);
-			if (!toolName) {
-				return null;
-			}
-			pairs.push({toolName, displayName});
-		}
-		return pairs;
+			return colon > 0;
+		})
+	) {
+		return tokens.map(token => parseEntry(token)!);
 	}
 
-	// Single token or single pair with spaces in display name.
-	const colon = trimmed.indexOf(':');
-	if (colon <= 0) {
-		return null;
-	}
-	const toolName = trimmed.slice(0, colon).trim();
-	const displayName = trimmed.slice(colon + 1);
-	if (!toolName) {
-		return null;
-	}
-	return [{toolName, displayName}];
+	const pair = parseEntry(trimmed);
+	return pair ? [pair] : null;
 }
 
 function applyPairs(pairs: Pair[]): {set: number; cleared: number} {
@@ -118,7 +115,7 @@ function executeToolNames(args?: string): CommandResult {
 		};
 	}
 
-	const pairs = parsePairs(raw);
+	const pairs = parseToolDisplayNamePairs(raw);
 	if (!pairs || pairs.length === 0) {
 		return {success: false, message: messages.invalid};
 	}

--- a/source/utils/config/apiConfig.ts
+++ b/source/utils/config/apiConfig.ts
@@ -304,8 +304,9 @@ let configCache: AppConfig | null = null;
 let configFileWatcher: FSWatcher | null = null;
 let configWatchBootstrapped = false;
 let configWatchDebounce: ReturnType<typeof setTimeout> | null = null;
+let configWatchRetry: ReturnType<typeof setTimeout> | null = null;
 /** Suppress re-entrant emit when saveConfig itself triggers fs.watch. */
-let suppressConfigWatchEmit = false;
+let suppressConfigWatchUntil = 0;
 
 function notifyApiConfigChanged(config?: AppConfig): void {
 	const snowcfg = config?.snowcfg ?? configCache?.snowcfg;
@@ -318,31 +319,70 @@ function notifyApiConfigChanged(config?: AppConfig): void {
 function ensureConfigFileWatcher(): void {
 	if (configWatchBootstrapped) return;
 	configWatchBootstrapped = true;
+	let shouldReloadAfterAttach = false;
+
+	const scheduleReload = (delayMs = 100) => {
+		if (configWatchDebounce) clearTimeout(configWatchDebounce);
+		configWatchDebounce = setTimeout(() => {
+			configWatchDebounce = null;
+			const suppressionRemaining = suppressConfigWatchUntil - Date.now();
+			if (suppressionRemaining > 0) {
+				scheduleReload(suppressionRemaining + 10);
+				return;
+			}
+
+			const previous = configCache;
+			// Drop cache so loadConfig re-reads disk. A parse failure leaves the
+			// cache null; restore last-known-good and emit nothing in that case.
+			configCache = null;
+			const next = loadConfig();
+			if (configCache === null) {
+				configCache = previous;
+				return;
+			}
+			if (previous && JSON.stringify(previous) === JSON.stringify(next)) {
+				return;
+			}
+			notifyApiConfigChanged(next);
+			// Best-effort: drop agent caches so model/token limits apply
+			void import('./configManager.js')
+				.then(m => m.clearAllAgentCaches())
+				.catch(() => {
+					// optional during early boot
+				});
+		}, delayMs);
+		configWatchDebounce.unref?.();
+	};
+
+	const scheduleWatchRetry = (delayMs: number) => {
+		if (configFileWatcher || configWatchRetry) return;
+		configWatchRetry = setTimeout(() => {
+			configWatchRetry = null;
+			startWatch();
+		}, delayMs);
+		configWatchRetry.unref?.();
+	};
 
 	const startWatch = () => {
 		if (configFileWatcher) return;
-		if (!existsSync(CONFIG_FILE)) return;
+		if (!existsSync(CONFIG_FILE)) {
+			shouldReloadAfterAttach = true;
+			scheduleWatchRetry(400);
+			return;
+		}
 		try {
-			configFileWatcher = watch(CONFIG_FILE, {persistent: false}, () => {
-				if (suppressConfigWatchEmit) return;
-				if (configWatchDebounce) clearTimeout(configWatchDebounce);
-				configWatchDebounce = setTimeout(() => {
-					if (suppressConfigWatchEmit) return;
-					// Drop cache so next getSnowConfig() re-reads disk
-					configCache = null;
+			configFileWatcher = watch(CONFIG_FILE, {persistent: false}, eventType => {
+				scheduleReload();
+				if (eventType === 'rename') {
 					try {
-						const next = loadConfig();
-						notifyApiConfigChanged(next);
-						// Best-effort: drop agent caches so model/token limits apply
-						void import('./configManager.js')
-							.then(m => m.clearAllAgentCaches())
-							.catch(() => {
-								// optional during early boot
-							});
+						configFileWatcher?.close();
 					} catch {
-						// ignore corrupt transient writes mid-save
+						// ignore
 					}
-				}, 100);
+					configFileWatcher = null;
+					shouldReloadAfterAttach = true;
+					scheduleWatchRetry(150);
+				}
 			});
 			configFileWatcher.on('error', () => {
 				try {
@@ -351,15 +391,20 @@ function ensureConfigFileWatcher(): void {
 					// ignore
 				}
 				configFileWatcher = null;
-				setTimeout(startWatch, 300);
+				shouldReloadAfterAttach = true;
+				scheduleWatchRetry(300);
 			});
+			if (shouldReloadAfterAttach) {
+				shouldReloadAfterAttach = false;
+				scheduleReload();
+			}
 		} catch {
-			setTimeout(startWatch, 400);
+			shouldReloadAfterAttach = true;
+			scheduleWatchRetry(400);
 		}
 	};
 
 	startWatch();
-	setTimeout(startWatch, 800);
 }
 
 export function loadConfig(): AppConfig {
@@ -456,7 +501,7 @@ export function loadConfig(): AppConfig {
 		configCache = mergedConfig;
 		return mergedConfig;
 	} catch (error) {
-		configCache = DEFAULT_CONFIG;
+		// Keep cache unset so a transient half-write is retried on the next read.
 		return DEFAULT_CONFIG;
 	}
 }
@@ -467,21 +512,17 @@ export function saveConfig(config: AppConfig): void {
 	try {
 		const configData = JSON.stringify(config, null, 2);
 		// Avoid double notify from our own write + fs.watch
-		suppressConfigWatchEmit = true;
-		try {
-			writeFileSync(CONFIG_FILE, configData, 'utf8');
-		} finally {
-			// Keep suppress briefly so Windows watch callbacks coalesce
-			setTimeout(() => {
-				suppressConfigWatchEmit = false;
-			}, 150);
-		}
+		suppressConfigWatchUntil = Math.max(
+			suppressConfigWatchUntil,
+			Date.now() + 150,
+		);
+		writeFileSync(CONFIG_FILE, configData, 'utf8');
 		// Keep cache in sync so getSnowConfig() sees new values immediately
 		configCache = config;
 		// Hot-refresh TUI / listeners without process restart
 		notifyApiConfigChanged(config);
 	} catch (error) {
-		suppressConfigWatchEmit = false;
+		suppressConfigWatchUntil = 0;
 		throw new Error(`Failed to save configuration: ${error}`);
 	}
 }

--- a/source/utils/config/configEvents.ts
+++ b/source/utils/config/configEvents.ts
@@ -29,6 +29,7 @@ export type ConfigChangeEvent = {
 		| 'theme'
 		| 'customColors'
 		| 'diffOpacity'
+		| 'profile'
 		/** Active snowcfg / profile API settings (maxContextTokens, models, …) */
 		| 'apiConfig'
 		| 'other';

--- a/source/utils/config/configManager.ts
+++ b/source/utils/config/configManager.ts
@@ -63,6 +63,10 @@ function ensureProfilesDirectory(): void {
 	}
 }
 
+const invalidPortableProfileNameCharacters = /[<>:"/\\|?*\u0000-\u001F\u007F]/u;
+const reservedWindowsProfileName =
+	/^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/iu;
+
 function isValidProfileName(profileName: unknown): profileName is string {
 	return (
 		typeof profileName === 'string' &&
@@ -71,7 +75,9 @@ function isValidProfileName(profileName: unknown): profileName is string {
 		profileName === profileName.trim() &&
 		profileName !== '.' &&
 		profileName !== '..' &&
-		!/[\\/\u0000-\u001F\u007F]/u.test(profileName)
+		!profileName.endsWith('.') &&
+		!invalidPortableProfileNameCharacters.test(profileName) &&
+		!reservedWindowsProfileName.test(profileName)
 	);
 }
 

--- a/source/utils/config/configManager.ts
+++ b/source/utils/config/configManager.ts
@@ -63,6 +63,34 @@ function ensureProfilesDirectory(): void {
 	}
 }
 
+function isValidProfileName(profileName: unknown): profileName is string {
+	return (
+		typeof profileName === 'string' &&
+		profileName.length > 0 &&
+		profileName.length <= 128 &&
+		profileName === profileName.trim() &&
+		profileName !== '.' &&
+		profileName !== '..' &&
+		!/[\\/\u0000-\u001F\u007F]/u.test(profileName)
+	);
+}
+
+function assertValidProfileName(profileName: string): void {
+	if (!isValidProfileName(profileName)) {
+		throw new Error('Invalid profile name');
+	}
+}
+
+function emitActiveProfileChanged(profileName: string): void {
+	void import('./configEvents.js')
+		.then(({configEvents}) => {
+			configEvents.emitConfigChange({type: 'profile', value: profileName});
+		})
+		.catch(() => {
+			// Optional during early startup.
+		});
+}
+
 /**
  * Get the current active profile name
  */
@@ -79,7 +107,9 @@ export function getActiveProfileName(): string {
 				LEGACY_ACTIVE_PROFILE_FILE,
 				'utf8',
 			).trim();
-			const profileName = legacyProfileName || 'default';
+			const profileName = isValidProfileName(legacyProfileName)
+				? legacyProfileName
+				: 'default';
 			// Save in new JSON format
 			setActiveProfileName(profileName);
 			// Delete old .txt file
@@ -97,7 +127,9 @@ export function getActiveProfileName(): string {
 	try {
 		const fileContent = readFileSync(ACTIVE_PROFILE_FILE, 'utf8').trim();
 		const data = JSON.parse(fileContent);
-		return data.activeProfile || 'default';
+		return isValidProfileName(data.activeProfile)
+			? data.activeProfile
+			: 'default';
 	} catch {
 		return 'default';
 	}
@@ -108,6 +140,7 @@ export function getActiveProfileName(): string {
  */
 function setActiveProfileName(profileName: string): void {
 	ensureProfilesDirectory();
+	assertValidProfileName(profileName);
 
 	try {
 		const data = {activeProfile: profileName};
@@ -128,6 +161,7 @@ export function setActiveProfileFromImport(profileName: string): void {
  * Get the path to a profile file
  */
 function getProfilePath(profileName: string): string {
+	assertValidProfileName(profileName);
 	return join(PROFILES_DIR, `${profileName}.json`);
 }
 
@@ -375,6 +409,7 @@ export function switchProfile(profileName: string): void {
 
 	// Update the active profile marker
 	setActiveProfileName(profileName);
+	emitActiveProfileChanged(profileName);
 
 	// Clear all agent caches when switching profiles
 	clearAllAgentCaches();
@@ -401,15 +436,7 @@ export function getNextProfileName(): string {
  */
 export function createProfile(profileName: string, config?: AppConfig): void {
 	ensureProfilesDirectory();
-
-	// Validate profile name
-	if (
-		!profileName.trim() ||
-		profileName.includes('/') ||
-		profileName.includes('\\')
-	) {
-		throw new Error('Invalid profile name');
-	}
+	assertValidProfileName(profileName);
 
 	const profilePath = getProfilePath(profileName);
 
@@ -456,10 +483,10 @@ export function deleteProfile(profileName: string): void {
  */
 export function renameProfile(oldName: string, newName: string): void {
 	ensureProfilesDirectory();
-
-	// Validate new name
-	if (!newName.trim() || newName.includes('/') || newName.includes('\\')) {
-		throw new Error('Invalid profile name');
+	assertValidProfileName(oldName);
+	assertValidProfileName(newName);
+	if (oldName === 'default') {
+		throw new Error('Cannot rename the default profile');
 	}
 
 	if (oldName === newName) {
@@ -489,6 +516,7 @@ export function renameProfile(oldName: string, newName: string): void {
 		// Update active profile if necessary
 		if (getActiveProfileName() === oldName) {
 			setActiveProfileName(newName);
+			emitActiveProfileChanged(newName);
 		}
 
 		// Delete old profile

--- a/source/utils/core/globalCleanup.ts
+++ b/source/utils/core/globalCleanup.ts
@@ -1,7 +1,8 @@
 /**
  * Centralized cleanup for global/singleton resources.
- * Called by /clear command and application exit (incl. fatal crash path)
- * to reclaim memory and avoid orphaned MCP / browser / OTEL handles on Windows.
+ * Called by /clear and application exit to reclaim restartable in-process
+ * resources. Process-lifetime services (MCP clients and OpenTelemetry) are
+ * shut down only by the CLI exit path, because /clear keeps the process alive.
  */
 
 import {logger} from './logger.js';
@@ -25,40 +26,15 @@ export async function cleanupGlobalResources(): Promise<void> {
 		// websearch module not loaded or already closed
 	}
 
-	// 3. Dispose ACECodeSearchService caches
+	// 3. Clear ACECodeSearchService caches without disposing its process singleton
 	try {
 		const {aceCodeSearchService} = await import('../../mcp/aceCodeSearch.js');
-		aceCodeSearchService.dispose();
+		aceCodeSearchService.clearSessionCaches();
 	} catch {
 		// ACE module not loaded
 	}
 
-	// 4. Close persistent MCP clients + drop tools cache (prevents orphaned children)
-	try {
-		const {closeAllMCPConnections, clearMCPToolsCache} = await import(
-			'../execution/mcpToolsManager.js'
-		);
-		await Promise.race([
-			closeAllMCPConnections(),
-			new Promise<void>(resolve => setTimeout(resolve, 2000)),
-		]);
-		clearMCPToolsCache();
-	} catch {
-		// MCP manager not loaded
-	}
-
-	// 5. Flush OpenTelemetry (process.exit bypasses beforeExit)
-	try {
-		const {shutdownTelemetry} = await import('../telemetry/otel.js');
-		await Promise.race([
-			shutdownTelemetry(),
-			new Promise<void>(resolve => setTimeout(resolve, 2000)),
-		]);
-	} catch {
-		// OTEL not started
-	}
-
-	// 6. Clear sub-agent stream state maps
+	// 4. Clear sub-agent stream state maps
 	try {
 		const {clearAllTeammateStreamEntries, clearAllSubAgentStreamEntries} =
 			await import('../../hooks/conversation/core/subAgentMessageHandler.js');
@@ -68,7 +44,7 @@ export async function cleanupGlobalResources(): Promise<void> {
 		// Not loaded
 	}
 
-	// 7. Clear runningSubAgentTracker
+	// 5. Clear runningSubAgentTracker
 	try {
 		const {runningSubAgentTracker} = await import(
 			'../execution/runningSubAgentTracker.js'
@@ -78,7 +54,7 @@ export async function cleanupGlobalResources(): Promise<void> {
 		// Not loaded
 	}
 
-	// 8. Clear conversation context
+	// 6. Clear conversation context
 	try {
 		const {clearConversationContext} = await import(
 			'../codebase/conversationContext.js'
@@ -88,7 +64,7 @@ export async function cleanupGlobalResources(): Promise<void> {
 		// Not loaded
 	}
 
-	// 9. Clear Ink fullStaticOutput buffer
+	// 7. Clear Ink fullStaticOutput buffer
 	try {
 		const ink = (await import('ink')) as any;
 		if (typeof ink.clearInkStaticOutput === 'function') {
@@ -98,7 +74,7 @@ export async function cleanupGlobalResources(): Promise<void> {
 		// Ink module not loaded
 	}
 
-	// 10. Force GC if available
+	// 8. Force GC if available
 	if (global.gc) {
 		global.gc();
 	}

--- a/source/utils/core/usageHistory.ts
+++ b/source/utils/core/usageHistory.ts
@@ -33,11 +33,7 @@ export interface AggregatedStats {
 export type UsagePeriod = 'hour' | 'day' | 'week' | 'month';
 
 /** Human-readable rolling windows corresponding to UsagePeriod. */
-export type UsageWindow =
-	| 'last_24h'
-	| 'last_7d'
-	| 'last_30d'
-	| 'last_12m';
+export type UsageWindow = 'last_24h' | 'last_7d' | 'last_30d' | 'last_12m';
 
 export const USAGE_PERIODS: readonly UsagePeriod[] = [
 	'hour',
@@ -89,9 +85,7 @@ export function isUsagePeriod(value: string): value is UsagePeriod {
  */
 export function parseUsagePeriod(
 	raw?: string | null,
-):
-	| {ok: true; period: UsagePeriod}
-	| {ok: false; message: string} {
+): {ok: true; period: UsagePeriod} | {ok: false; message: string} {
 	const token = (raw ?? '').trim().toLowerCase();
 	if (!token) {
 		return {ok: true, period: DEFAULT_USAGE_PERIOD};
@@ -109,6 +103,11 @@ export function parseUsagePeriod(
 
 export function getUsageRootDir(homeDir: string = os.homedir()): string {
 	return path.join(homeDir, '.snow', 'usage');
+}
+
+function normalizeTokenCount(value: unknown): number {
+	const number = Number(value);
+	return Number.isFinite(number) && number >= 0 ? number : 0;
 }
 
 /**
@@ -132,7 +131,12 @@ export async function loadUsageData(
 			}
 			if (!stats.isDirectory()) continue;
 
-			const files = await fs.readdir(datePath);
+			let files: string[];
+			try {
+				files = await fs.readdir(datePath);
+			} catch {
+				continue;
+			}
 			for (const file of files) {
 				if (!file.endsWith('.jsonl')) continue;
 				const filePath = path.join(datePath, file);
@@ -153,25 +157,29 @@ export async function loadUsageData(
 						if (
 							!entry ||
 							typeof entry.timestamp !== 'string' ||
-							typeof entry.model !== 'string'
+							!Number.isFinite(Date.parse(entry.timestamp)) ||
+							typeof entry.model !== 'string' ||
+							!entry.model.trim()
 						) {
 							continue;
 						}
 						entries.push({
-							model: entry.model,
+							model: entry.model.trim(),
 							profileName:
 								typeof entry.profileName === 'string'
-									? entry.profileName
+									? entry.profileName.trim() || 'default'
 									: 'default',
-							inputTokens: Number(entry.inputTokens) || 0,
-							outputTokens: Number(entry.outputTokens) || 0,
+							inputTokens: normalizeTokenCount(entry.inputTokens),
+							outputTokens: normalizeTokenCount(entry.outputTokens),
 							...(entry.cacheCreationInputTokens !== undefined && {
-								cacheCreationInputTokens:
-									Number(entry.cacheCreationInputTokens) || 0,
+								cacheCreationInputTokens: normalizeTokenCount(
+									entry.cacheCreationInputTokens,
+								),
 							}),
 							...(entry.cacheReadInputTokens !== undefined && {
-								cacheReadInputTokens:
-									Number(entry.cacheReadInputTokens) || 0,
+								cacheReadInputTokens: normalizeTokenCount(
+									entry.cacheReadInputTokens,
+								),
 							}),
 							timestamp: entry.timestamp,
 						});
@@ -214,7 +222,10 @@ export function filterByPeriod(
 			break;
 	}
 
-	return entries.filter(e => new Date(e.timestamp) >= cutoff);
+	return entries.filter(entry => {
+		const timestamp = new Date(entry.timestamp);
+		return timestamp >= cutoff && timestamp <= now;
+	});
 }
 
 /** @deprecated Prefer filterByPeriod — kept for call-site clarity during migration. */

--- a/source/utils/core/version.ts
+++ b/source/utils/core/version.ts
@@ -1,4 +1,4 @@
-import {readFileSync} from 'fs';
+import {existsSync, readFileSync} from 'fs';
 import {join, dirname} from 'path';
 import {fileURLToPath} from 'url';
 
@@ -15,10 +15,18 @@ export function getPackageVersion(): string {
 	}
 
 	try {
-		// In bundled code, __filename points to bundle/cli.mjs
-		// So we need to go up one level to reach package.json
 		const currentDir = dirname(fileURLToPath(import.meta.url));
-		const packageJsonPath = join(currentDir, '../package.json');
+		const packageJsonPath = [
+			// Bundled code: bundle/cli.mjs -> ../package.json
+			join(currentDir, '../package.json'),
+			// Source code: source/utils/core/version.ts -> ../../../package.json
+			join(currentDir, '../../../package.json'),
+			// Test/dev runners may relocate modules while retaining the project cwd.
+			join(process.cwd(), 'package.json'),
+		].find(existsSync);
+		if (!packageJsonPath) {
+			throw new Error('package.json not found');
+		}
 		const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 		cachedVersion = packageJson.version || '1.0.0';
 		return cachedVersion;

--- a/source/utils/execution/hookStatusEvents.ts
+++ b/source/utils/execution/hookStatusEvents.ts
@@ -9,6 +9,7 @@ export type HookStatusPhase =
 	| 'idle';
 
 export type HookStatusEvent = {
+	executionId: string;
 	phase: HookStatusPhase;
 	hookType: HookType;
 	/** Current action label (command / prompt snippet) */

--- a/source/utils/execution/sessionCommandHandlers.ts
+++ b/source/utils/execution/sessionCommandHandlers.ts
@@ -854,10 +854,12 @@ function handleProfiles(
 				meta.risk,
 			);
 		} catch (error) {
+			const msg =
+				error instanceof Error ? error.message : 'Profile switch failed';
 			return failResult(
 				meta.id,
-				'NOT_FOUND',
-				error instanceof Error ? error.message : 'Profile switch failed',
+				msg === 'Invalid profile name' ? 'INVALID_ARGS' : 'NOT_FOUND',
+				msg,
 				meta.risk,
 			);
 		}
@@ -886,9 +888,12 @@ function handleProfiles(
 		} catch (error) {
 			const msg =
 				error instanceof Error ? error.message : 'Profile create failed';
-			const code = msg.includes('already exists')
-				? 'ALREADY_EXISTS'
-				: 'EXECUTION_FAILED';
+			const code =
+				msg === 'Invalid profile name'
+					? 'INVALID_ARGS'
+					: msg.includes('already exists')
+					? 'ALREADY_EXISTS'
+					: 'EXECUTION_FAILED';
 			return failResult(meta.id, code, msg, meta.risk);
 		}
 	}
@@ -924,7 +929,12 @@ function handleProfiles(
 		} catch (error) {
 			const msg =
 				error instanceof Error ? error.message : 'Profile delete failed';
-			const code = msg.includes('not found') ? 'NOT_FOUND' : 'EXECUTION_FAILED';
+			const code =
+				msg === 'Invalid profile name'
+					? 'INVALID_ARGS'
+					: msg.includes('not found')
+					? 'NOT_FOUND'
+					: 'EXECUTION_FAILED';
 			return failResult(meta.id, code, msg, meta.risk);
 		}
 	}
@@ -957,11 +967,14 @@ function handleProfiles(
 		} catch (error) {
 			const msg =
 				error instanceof Error ? error.message : 'Profile rename failed';
-			const code = msg.includes('not found')
-				? 'NOT_FOUND'
-				: msg.includes('already exists')
-				? 'ALREADY_EXISTS'
-				: 'EXECUTION_FAILED';
+			const code =
+				msg === 'Invalid profile name'
+					? 'INVALID_ARGS'
+					: msg.includes('not found')
+					? 'NOT_FOUND'
+					: msg.includes('already exists')
+					? 'ALREADY_EXISTS'
+					: 'EXECUTION_FAILED';
 			return failResult(meta.id, code, msg, meta.risk);
 		}
 	}

--- a/source/utils/execution/sessionCommandHandlers.ts
+++ b/source/utils/execution/sessionCommandHandlers.ts
@@ -97,9 +97,21 @@ import {
 	type SessionCommandMeta,
 	type SessionCommandResult,
 } from './sessionCommandTypes.js';
+import {
+	getUsageHistorySnapshot,
+	parseUsagePeriod,
+} from '../core/usageHistory.js';
 
 function parseTokens(args?: string): string[] {
-	return (args ?? '').trim().split(/\s+/).filter(Boolean);
+	const tokens: string[] = [];
+	const input = (args ?? '').trim();
+	const pattern = /"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'|(\S+)/g;
+	let match: RegExpExecArray | null;
+	while ((match = pattern.exec(input)) !== null) {
+		const value = match[1] ?? match[2] ?? match[3] ?? '';
+		tokens.push(value.replace(/\\([\\"'])/g, '$1'));
+	}
+	return tokens;
 }
 
 function parseOnOffToggle(
@@ -1510,13 +1522,68 @@ function handlePrivacy(
 		meta.risk,
 	);
 }
+function parseUsageArgs(args?: string): ReturnType<typeof parseUsagePeriod> {
+	const tokens = parseTokens(args);
+	let periodToken: string | undefined;
+
+	for (let i = 0; i < tokens.length; i++) {
+		const token = tokens[i]!;
+		const lower = token.toLowerCase();
+		if (lower === 'status') {
+			continue;
+		}
+		if (lower.startsWith('--period=')) {
+			if (periodToken !== undefined) {
+				return {ok: false, message: 'Usage period may only be specified once.'};
+			}
+			const value = token.slice('--period='.length);
+			if (!value) {
+				return {
+					ok: false,
+					message: 'Usage: usage [--period=hour|day|week|month]',
+				};
+			}
+			periodToken = value;
+			continue;
+		}
+		if (lower === '--period' || lower === '-p') {
+			if (periodToken !== undefined || !tokens[i + 1]) {
+				return {
+					ok: false,
+					message: 'Usage: usage [--period=hour|day|week|month]',
+				};
+			}
+			periodToken = tokens[i + 1];
+			i += 1;
+			continue;
+		}
+		if (periodToken === undefined && !token.startsWith('-')) {
+			periodToken = token;
+			continue;
+		}
+		return {
+			ok: false,
+			message: `Invalid usage argument "${token}". Usage: usage [--period=hour|day|week|month]`,
+		};
+	}
+
+	return parseUsagePeriod(periodToken);
+}
+
 async function handleUsage(
 	meta: SessionCommandMeta,
+	args?: string,
 ): Promise<SessionCommandResult> {
+	const parsed = parseUsageArgs(args);
+	if (!parsed.ok) {
+		return failResult(meta.id, 'INVALID_ARGS', parsed.message, meta.risk);
+	}
+
 	// Prefer session contextUsage when present.
 	const {sessionManager} = await import('../session/sessionManager.js');
 	const session = sessionManager.getCurrentSession();
 	const contextUsage = session?.contextUsage ?? null;
+	const history = await getUsageHistorySnapshot(parsed.period);
 	return okResult(
 		meta.id,
 		{
@@ -1529,10 +1596,9 @@ async function handleUsage(
 				plan: getPlanMode(),
 				toolSearch: getToolSearchEnabled(),
 			},
+			history,
 		},
-		contextUsage
-			? 'Usage snapshot from current session context.'
-			: 'Usage snapshot (no active session contextUsage).',
+		`Usage snapshot (${history.window}, ${history.entryCount} history entries).`,
 		meta.risk,
 	);
 }
@@ -1560,20 +1626,36 @@ function parseExportArgs(args?: string):
 		const lower = token.toLowerCase();
 
 		if (lower.startsWith('--session=')) {
-			sessionId = token.slice('--session='.length).trim() || undefined;
+			const value = token.slice('--session='.length).trim();
+			if (!value) {
+				return {ok: false, message: '--session requires a session id.'};
+			}
+			sessionId = value;
 			continue;
 		}
 		if (lower === '--session') {
-			sessionId = tokens[i + 1];
+			const value = tokens[i + 1];
+			if (!value || value.startsWith('-')) {
+				return {ok: false, message: '--session requires a session id.'};
+			}
+			sessionId = value;
 			i += 1;
 			continue;
 		}
 		if (lower.startsWith('--out=')) {
-			outPath = token.slice('--out='.length).trim() || undefined;
+			const value = token.slice('--out='.length).trim();
+			if (!value) {
+				return {ok: false, message: '--out requires an output path.'};
+			}
+			outPath = value;
 			continue;
 		}
 		if (lower === '--out' || lower === '-o') {
-			outPath = tokens[i + 1];
+			const value = tokens[i + 1];
+			if (!value || value.startsWith('-')) {
+				return {ok: false, message: `${token} requires an output path.`};
+			}
+			outPath = value;
 			i += 1;
 			continue;
 		}
@@ -1843,7 +1925,9 @@ async function handleExport(
 			parsed.outPath,
 		);
 
-		await exportSessionToFile(session, filePath, parsed.format);
+		await exportSessionToFile(session, filePath, parsed.format, {
+			exclusive: !parsed.outPath,
+		});
 
 		return okResult(
 			meta.id,
@@ -2149,7 +2233,7 @@ export async function executeSessionCommandHandler(
 		case 'telemetry':
 			return handleTelemetry(meta, normalizedArgs);
 		case 'usage':
-			return handleUsage(meta);
+			return handleUsage(meta, normalizedArgs);
 		case 'permissions': {
 			const {handlePermissions} = await import(
 				'./sessionCommandHandlersExtra.js'
@@ -2242,13 +2326,14 @@ function normalizeArgsForMeta(
 	if (!args) {
 		return args;
 	}
-	const tokens = parseTokens(args);
 	if (!meta.subcommand) {
 		return args;
 	}
-	// If first token equals subcommand, drop it (e.g. "hatch Mochi" stays, "status" becomes "")
-	if (tokens[0]?.toLowerCase() === meta.subcommand.toLowerCase()) {
-		return tokens.slice(1).join(' ');
+	// Strip only the leading subcommand text so quoted args and JSON remain byte-for-byte intact.
+	const trimmed = args.trimStart();
+	const firstToken = /^\S+/u.exec(trimmed)?.[0];
+	if (firstToken?.toLowerCase() === meta.subcommand.toLowerCase()) {
+		return trimmed.slice(firstToken.length).trimStart() || undefined;
 	}
 	return args;
 }

--- a/source/utils/execution/sessionCommandHandlersExtra.ts
+++ b/source/utils/execution/sessionCommandHandlersExtra.ts
@@ -622,6 +622,38 @@ export async function handleMcpManage(
 		const toolName = tokens[1];
 
 		try {
+			const {
+				toggleBuiltInService,
+				isBuiltInServiceEnabled,
+				getDisabledBuiltInServices,
+			} = await import('../config/disabledBuiltInTools.js');
+			const {getMCPConfig} = await import('../config/apiConfig.js');
+			const mcpConfig = getMCPConfig();
+			const knownBuiltIns = new Set([
+				'filesystem',
+				'terminal',
+				'todo',
+				'ace',
+				'websearch',
+				'snow-docs',
+				'codebase',
+				'askuser',
+				'scheduler',
+				'subagent',
+				'team',
+				...getDisabledBuiltInServices(),
+			]);
+			const isKnownBuiltIn = knownBuiltIns.has(serviceName);
+			const isKnownExternal = Boolean(mcpConfig.mcpServers?.[serviceName]);
+			if (!isKnownBuiltIn && !isKnownExternal) {
+				return failResult(
+					meta.id,
+					'NOT_FOUND',
+					`MCP service "${serviceName}" not found.`,
+					meta.risk,
+				);
+			}
+
 			if (toolName) {
 				const {toggleMCPTool, isMCPToolEnabled} = await import(
 					'../config/disabledMCPTools.js'
@@ -647,32 +679,7 @@ export async function handleMcpManage(
 				);
 			}
 
-			const {
-				toggleBuiltInService,
-				isBuiltInServiceEnabled,
-				getDisabledBuiltInServices,
-			} = await import('../config/disabledBuiltInTools.js');
-			const {getMCPConfig} = await import('../config/apiConfig.js');
-			const mcpConfig = getMCPConfig();
-			const knownBuiltIns = new Set([
-				'filesystem',
-				'terminal',
-				'todo',
-				'ace',
-				'websearch',
-				'snow-docs',
-				'codebase',
-				'askuser',
-				'scheduler',
-				'subagent',
-				'team',
-				...getDisabledBuiltInServices(),
-			]);
-
-			if (
-				knownBuiltIns.has(serviceName) ||
-				!mcpConfig.mcpServers?.[serviceName]
-			) {
+			if (isKnownBuiltIn) {
 				const previous = isBuiltInServiceEnabled(serviceName);
 				if (previous !== wantEnabled) {
 					toggleBuiltInService(serviceName);

--- a/source/utils/execution/sessionCommandPlane.ts
+++ b/source/utils/execution/sessionCommandPlane.ts
@@ -32,7 +32,7 @@ export {
 	resolveSessionCommandMeta,
 } from './sessionCommandRegistry.js';
 
-/** Treat status/list/current queries as read even when command meta is write-capable. */
+/** Treat explicit query invocations as read even when a command also supports writes. */
 function isStatusOnlyArgs(meta: SessionCommandMeta, args?: string): boolean {
 	if (meta.risk === 'read') {
 		return true;
@@ -40,8 +40,36 @@ function isStatusOnlyArgs(meta: SessionCommandMeta, args?: string): boolean {
 	const trimmed = (args ?? '').trim().toLowerCase();
 	// Only the first token decides read-vs-write. Extra flags like
 	// "status --period=day" must still count as status-only.
-	const token = trimmed.split(/\s+/).filter(Boolean)[0] ?? '';
-	if (token === 'status' || token === 'list' || token === 'current') {
+	const tokens = trimmed.split(/\s+/).filter(Boolean);
+	const token = tokens[0] ?? '';
+	// Only a command resolved as a bare/query command may use a query token as
+	// a read-only operation. Explicit write subcommands (e.g. profiles.switch
+	// status) must retain their write risk and confirmation requirement.
+	if (
+		(meta.subcommand === undefined ||
+			meta.subcommand === 'status' ||
+			meta.subcommand === 'list' ||
+			meta.subcommand === 'current') &&
+		(token === 'status' || token === 'list' || token === 'current')
+	) {
+		return true;
+	}
+	if (
+		meta.id === 'codebase' &&
+		(token === 'agent-review' ||
+			token === 'agent_review' ||
+			token === 'reranking' ||
+			token === 'rerank') &&
+		(!tokens[1] || tokens[1] === 'status')
+	) {
+		return true;
+	}
+	if (
+		meta.id === 'privacy' &&
+		token === 'scope' &&
+		(tokens[1] === 'global' || tokens[1] === 'project') &&
+		(!tokens[2] || tokens[2] === 'status')
+	) {
 		return true;
 	}
 	if (!token) {
@@ -70,12 +98,21 @@ function isStatusOnlyArgs(meta: SessionCommandMeta, args?: string): boolean {
 	return false;
 }
 
+function serializeArgTokens(tokens: readonly string[]): string | undefined {
+	const serialized = tokens
+		.map(token => (/\s|["']/u.test(token) ? JSON.stringify(token) : token))
+		.join(' ');
+	return serialized || undefined;
+}
+
 function normalizeCommandInput(request: SessionCommandRequest): {
 	command: string;
 	args?: string;
 } {
 	let command = (request.command ?? '').trim().replace(/^\//, '');
-	let args = request.args?.trim() || undefined;
+	let args = request.argTokens
+		? serializeArgTokens(request.argTokens)
+		: request.args?.trim() || undefined;
 
 	// Support "buddy hatch foo" entirely in command field
 	if (command.includes(' ') && !args) {
@@ -100,7 +137,7 @@ function normalizeCommandInput(request: SessionCommandRequest): {
 /**
  * Run an allowlisted session/slash control command.
  */
-export async function runSessionCommand(
+async function runSessionCommandUnlocked(
 	request: SessionCommandRequest,
 ): Promise<SessionCommandResult> {
 	const mode: SessionCommandMode = request.mode ?? 'cli';
@@ -172,7 +209,16 @@ export async function runSessionCommand(
 		: resolved.risk;
 	const effectiveMeta = {...resolved, risk: effectiveRisk};
 
-	if (needsConfirmation(effectiveMeta, mode, request.confirm)) {
+	if (
+		needsConfirmation(
+			effectiveMeta,
+			mode,
+			// Only the CLI's explicit flag is user-confirmed. Agent/SSE callers
+			// must provide a transport-level trusted confirmation.
+			mode === 'cli' ? request.confirm : undefined,
+			request.trustedConfirm,
+		)
+	) {
 		return failResult(
 			resolved.id,
 			'CONFIRMATION_REQUIRED',
@@ -212,6 +258,27 @@ export async function runSessionCommand(
 	}
 }
 
+let commandQueue: Promise<void> = Promise.resolve();
+
+/**
+ * Serialize control-plane commands because handlers mutate shared process-wide
+ * session/config state and persisted JSON files. This intentionally means a
+ * long compact blocks later status reads so callers observe entry order.
+ */
+export function runSessionCommand(
+	request: SessionCommandRequest,
+): Promise<SessionCommandResult> {
+	const queuedRequest = {...request};
+	const result = commandQueue.then(() =>
+		runSessionCommandUnlocked(queuedRequest),
+	);
+	commandQueue = result.then(
+		() => undefined,
+		() => undefined,
+	);
+	return result;
+}
+
 /**
  * Parse CLI argv after `snow cmd` into a SessionCommandRequest.
  * Example: ["buddy", "hatch", "Fox", "--species=fox", "--json", "--yes"]
@@ -233,12 +300,14 @@ export function parseCmdArgv(argv: string[]): {
 	);
 
 	const command = filtered[0] ?? '';
-	const args = filtered.slice(1).join(' ') || undefined;
+	const argTokens = filtered.slice(1);
+	const args = argTokens.join(' ') || undefined;
 
 	return {
 		request: {
 			command,
 			args,
+			argTokens,
 			mode: 'cli',
 			confirm,
 		},

--- a/source/utils/execution/sessionCommandRegistry.ts
+++ b/source/utils/execution/sessionCommandRegistry.ts
@@ -214,6 +214,18 @@ export const SESSION_COMMAND_ALLOWLIST: SessionCommandMeta[] = [
 		subcommand: 'switch',
 		requiresConfirm: true,
 	}),
+	meta('profiles.create', 'profiles', 'medium_write', 'Create a profile', {
+		subcommand: 'create',
+		requiresConfirm: true,
+	}),
+	meta('profiles.delete', 'profiles', 'high_risk', 'Delete a profile', {
+		subcommand: 'delete',
+		requiresConfirm: true,
+	}),
+	meta('profiles.rename', 'profiles', 'medium_write', 'Rename a profile', {
+		subcommand: 'rename',
+		requiresConfirm: true,
+	}),
 	meta(
 		'codebase',
 		'codebase',
@@ -280,8 +292,8 @@ export const SESSION_COMMAND_ALLOWLIST: SessionCommandMeta[] = [
 		requiresConfirm: true,
 		headlessSupported: true,
 	}),
-	meta('export', 'export', 'low_write', 'Export session (headless path)', {
-		requiresConfirm: false,
+	meta('export', 'export', 'medium_write', 'Export session (headless path)', {
+		requiresConfirm: true,
 	}),
 	meta(
 		'permissions.status',
@@ -535,8 +547,9 @@ export function needsConfirmation(
 	meta: SessionCommandMeta,
 	mode: 'cli' | 'agent' | 'sse',
 	confirm?: boolean,
+	trustedConfirm?: boolean,
 ): boolean {
-	if (confirm) {
+	if (confirm || trustedConfirm) {
 		return false;
 	}
 

--- a/source/utils/execution/sessionCommandTypes.ts
+++ b/source/utils/execution/sessionCommandTypes.ts
@@ -29,9 +29,13 @@ export interface SessionCommandRequest {
 	command: string;
 	/** Remaining args string, e.g. "hatch 小雪 --species=fox". */
 	args?: string;
+	/** Lossless argument tokens from CLI argv; `args` remains for API compatibility. */
+	argTokens?: string[];
 	mode?: SessionCommandMode;
 	/** Explicit confirmation for medium/high risk writes. */
 	confirm?: boolean;
+	/** Confirmation established by a trusted transport, never model input. */
+	trustedConfirm?: boolean;
 }
 
 export interface SessionCommandResult {

--- a/source/utils/execution/unifiedHooksExecutor.ts
+++ b/source/utils/execution/unifiedHooksExecutor.ts
@@ -19,6 +19,8 @@ import {createStreamingAnthropicCompletion} from '../../api/anthropic.js';
 import type {RequestMethod} from '../config/apiConfig.js';
 import {emitHookStatus, summarizeHookAction} from './hookStatusEvents.js';
 
+let hookExecutionSequence = 0;
+
 /**
  * Prompt Hook 执行结果（小模型返回的 JSON）
  *
@@ -50,6 +52,7 @@ export interface CommandHookResult {
 	success: boolean;
 	command: string; // 执行的命令
 	exitCode: number; // 进程退出码
+	signal?: NodeJS.Signals | string;
 	output?: string;
 	error?: string;
 }
@@ -205,8 +208,10 @@ export class UnifiedHooksExecutor {
 				skippedActions: rules.reduce((n, r) => n + r.hooks.length, 0),
 			};
 		}
+		const executionId = `${Date.now()}-${++hookExecutionSequence}`;
 
 		emitHookStatus({
+			executionId,
 			phase: 'start',
 			hookType,
 			totalActions: plannedActions.length,
@@ -254,6 +259,7 @@ export class UnifiedHooksExecutor {
 					actionType = 'command';
 					actionLabel = summarizeHookAction(action.command);
 					emitHookStatus({
+						executionId,
 						phase: 'action',
 						hookType,
 						actionType,
@@ -266,6 +272,7 @@ export class UnifiedHooksExecutor {
 					actionType = 'prompt';
 					actionLabel = summarizeHookAction(action.prompt);
 					emitHookStatus({
+						executionId,
 						phase: 'action',
 						hookType,
 						actionType,
@@ -294,7 +301,10 @@ export class UnifiedHooksExecutor {
 						failedActions++;
 
 						// 如果是 Command 类型且 exitCode >= 2,停止后续 Action 执行
-						if (result.type === 'command' && result.exitCode >= 2) {
+						if (
+							result.type === 'command' &&
+							(result.exitCode >= 2 || result.exitCode < 0)
+						) {
 							abortedHard = true;
 							break;
 						}
@@ -307,6 +317,7 @@ export class UnifiedHooksExecutor {
 		}
 
 		emitHookStatus({
+			executionId,
 			phase: hasHardError ? 'failed' : 'success',
 			hookType,
 			executedActions: totalExecuted,
@@ -315,7 +326,7 @@ export class UnifiedHooksExecutor {
 			totalActions: plannedActions.length,
 			message: hasHardError
 				? abortedHard
-					? 'stopped (exit ≥ 2)'
+					? 'stopped (hard failure)'
 					: `${failedActions} action(s) failed`
 				: softActions > 0
 				? `${softActions} applied (exit 1)`
@@ -575,7 +586,7 @@ export class UnifiedHooksExecutor {
 				childProcess.on('close', (code, signal) => {
 					if (signal) {
 						const error: any = new Error(`Process killed by signal ${signal}`);
-						error.code = code || 1;
+						error.code = code;
 						error.stdout = stdoutData;
 						error.stderr = stderrData;
 						error.signal = signal;
@@ -613,13 +624,18 @@ export class UnifiedHooksExecutor {
 
 			// 命令本身执行失败（如命令不存在、语法错误等）
 			// error.code 可能是字符串（如 'ENOENT'），此时应返回 exitCode 2
-			const exitCode = typeof error.code === 'number' ? error.code : 2;
+			const exitCode = error.signal
+				? -1
+				: typeof error.code === 'number'
+				? error.code
+				: 2;
 
 			return {
 				type: 'command',
 				success: false,
 				command,
 				exitCode,
+				signal: error.signal,
 				output: error.stdout ? this.truncateOutput(error.stdout) : undefined,
 				error:
 					error.stderr || error.message

--- a/source/utils/platform/notification.ts
+++ b/source/utils/platform/notification.ts
@@ -29,7 +29,6 @@ export type AgentTurnCompletionNotificationState = {
 	wasUserInterrupted?: boolean;
 	willAutoContinue?: boolean;
 	pendingMessageCount?: number;
-	hasOnStopHook?: boolean;
 };
 
 type NotificationPayload = {
@@ -131,15 +130,13 @@ export function shouldNotifyAgentTurnCompletion({
 	wasUserInterrupted = false,
 	willAutoContinue = false,
 	pendingMessageCount = 0,
-	hasOnStopHook = false,
 }: AgentTurnCompletionNotificationState): boolean {
 	// Snow only asks the terminal for attention when it is actually unfocused.
 	return (
 		!terminalFocused &&
 		!wasUserInterrupted &&
 		!willAutoContinue &&
-		pendingMessageCount === 0 &&
-		!hasOnStopHook
+		pendingMessageCount === 0
 	);
 }
 
@@ -187,13 +184,6 @@ function Register-SnowCliToastIdentity {
     New-Item -Path $regPath -Force | Out-Null
   }
   New-ItemProperty -Path $regPath -Name 'DisplayName' -Value $displayName -PropertyType String -Force | Out-Null
-
-  $settingsPath = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Notifications\\Settings\\$appUserModelId"
-  if (-not (Test-Path -LiteralPath $settingsPath)) {
-    New-Item -Path $settingsPath -Force | Out-Null
-  }
-  New-ItemProperty -Path $settingsPath -Name 'Enabled' -Value 1 -PropertyType DWord -Force | Out-Null
-  New-ItemProperty -Path $settingsPath -Name 'ShowInActionCenter' -Value 1 -PropertyType DWord -Force | Out-Null
 }
 
 function Show-SnowCliWinRtToast {
@@ -297,10 +287,15 @@ function writeTerminalNotification(title: string, body: string): void {
 	}
 }
 
-function spawnDetachedBestEffort(command: string, args: string[]): void {
+function spawnBestEffort(
+	command: string,
+	args: string[],
+	options: {detached?: boolean} = {},
+): void {
 	try {
+		const detached = options.detached ?? true;
 		const child = spawn(command, args, {
-			detached: true,
+			detached,
 			stdio: 'ignore',
 			windowsHide: true,
 		});
@@ -312,45 +307,48 @@ function spawnDetachedBestEffort(command: string, args: string[]): void {
 	}
 }
 
-function showWindowsToastNotification({
-	title,
-	body,
-}: NotificationPayload): void {
+export function buildWindowsNotificationArguments(
+	title: string,
+	body: string,
+): string[] {
 	const encodedCommand = Buffer.from(
 		buildToastScript(title, body),
 		'utf16le',
 	).toString('base64');
 
-	spawnDetachedBestEffort('cmd.exe', [
-		'/d',
-		'/s',
-		'/c',
-		'start',
-		'""',
-		'/min',
-		'powershell',
+	// windowsHide already suppresses the console window. PowerShell's
+	// -WindowStyle Hidden can exit before running EncodedCommand on Windows.
+	return [
 		'-NoProfile',
-		'-WindowStyle',
-		'Hidden',
 		'-ExecutionPolicy',
 		'Bypass',
 		'-EncodedCommand',
 		encodedCommand,
-	]);
+	];
+}
+
+function showWindowsToastNotification({
+	title,
+	body,
+}: NotificationPayload): void {
+	// Do not use DETACHED_PROCESS here: on Windows it can report success while
+	// the encoded PowerShell payload never runs. A normal hidden child plus
+	// unref keeps notification dispatch non-blocking without opening a console.
+	spawnBestEffort(
+		'powershell',
+		buildWindowsNotificationArguments(title, body),
+		{
+			detached: false,
+		},
+	);
 }
 
 function showMacOsNotification({title, body}: NotificationPayload): void {
-	spawnDetachedBestEffort(
-		'osascript',
-		buildMacOsNotificationArguments(title, body),
-	);
+	spawnBestEffort('osascript', buildMacOsNotificationArguments(title, body));
 }
 
 function showLinuxNotification({title, body}: NotificationPayload): void {
-	spawnDetachedBestEffort(
-		'notify-send',
-		buildLinuxNotificationArguments(title, body),
-	);
+	spawnBestEffort('notify-send', buildLinuxNotificationArguments(title, body));
 }
 
 function showDesktopNotification(payload: NotificationPayload): void {

--- a/source/utils/plugins/anypanel/loader.ts
+++ b/source/utils/plugins/anypanel/loader.ts
@@ -13,6 +13,7 @@ import {pathToFileURL} from 'node:url';
 
 import {ANYPANEL_PLUGIN_DIR} from '../../config/apiConfig.js';
 import {logger} from '../../core/logger.js';
+import {importFreshPluginModule} from '../importFresh.js';
 import type {AnyPanelPlugin, AnyPanelPluginModule} from './types.js';
 
 export const SUPPORTED_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
@@ -93,12 +94,11 @@ export async function loadAnyPanelPlugins(
 	for (const file of files) {
 		const modulePath = join(ANYPANEL_PLUGIN_DIR, file.name);
 		try {
-			let moduleUrl = pathToFileURL(modulePath).href;
-			if (bustCache) {
-				// 追加随机查询参数绕过 ESM 模块缓存，实现热重载
-				moduleUrl += `?t=${Date.now()}`;
-			}
-			const mod = (await import(moduleUrl)) as AnyPanelPluginModule;
+			const mod = (
+				bustCache
+					? await importFreshPluginModule(modulePath)
+					: await import(pathToFileURL(modulePath).href)
+			) as AnyPanelPluginModule;
 			const collected = collectFromModule(mod);
 			if (collected.length === 0) {
 				logger.warn(

--- a/source/utils/plugins/customHeaders/index.ts
+++ b/source/utils/plugins/customHeaders/index.ts
@@ -26,10 +26,10 @@ import {
 	type FSWatcher,
 } from 'node:fs';
 import {extname, join} from 'node:path';
-import {pathToFileURL} from 'node:url';
 
 import {CUSTOM_HEADERS_PLUGIN_DIR} from '../../config/apiConfig.js';
 import {logger} from '../../core/logger.js';
+import {importFreshPluginModule} from '../importFresh.js';
 import type {CustomHeaderPlugin, CustomHeaderPluginContext} from './types.js';
 
 export type {CustomHeaderPlugin, CustomHeaderPluginContext} from './types.js';
@@ -81,10 +81,6 @@ function collectFromModule(
 }
 
 /** Bust ESM import cache so edited plugins reload without process restart. */
-function buildCacheBustedModuleUrl(modulePath: string): string {
-	return `${pathToFileURL(modulePath).href}?t=${Date.now()}`;
-}
-
 // ---------------------------------------------------------------------------
 // External plugin loading (lazy, hot-reloadable)
 // ---------------------------------------------------------------------------
@@ -100,10 +96,11 @@ let reloadInFlight: Promise<void> | null = null;
 let reloadQueued = false;
 let pluginWatcher: FSWatcher | null = null;
 let pluginReloadTimer: ReturnType<typeof setTimeout> | null = null;
+let pluginWatchRetryTimer: ReturnType<typeof setTimeout> | null = null;
 let watcherBootstrapped = false;
 
-async function loadExternalPlugins(): Promise<void> {
-	if (!existsSync(CUSTOM_HEADERS_PLUGIN_DIR)) return;
+async function loadExternalPlugins(): Promise<CustomHeaderPlugin[]> {
+	if (!existsSync(CUSTOM_HEADERS_PLUGIN_DIR)) return [];
 
 	let entries: Array<import('node:fs').Dirent>;
 	try {
@@ -113,7 +110,7 @@ async function loadExternalPlugins(): Promise<void> {
 			directory: CUSTOM_HEADERS_PLUGIN_DIR,
 			error,
 		});
-		return;
+		return [];
 	}
 
 	const files = entries
@@ -129,8 +126,9 @@ async function loadExternalPlugins(): Promise<void> {
 	for (const file of files) {
 		const modulePath = join(CUSTOM_HEADERS_PLUGIN_DIR, file.name);
 		try {
-			const moduleUrl = buildCacheBustedModuleUrl(modulePath);
-			const mod = (await import(moduleUrl)) as CustomHeaderPluginModule;
+			const mod = (await importFreshPluginModule(
+				modulePath,
+			)) as CustomHeaderPluginModule;
 			const plugins = collectFromModule(mod);
 			if (plugins.length === 0) {
 				logger.warn(
@@ -149,16 +147,30 @@ async function loadExternalPlugins(): Promise<void> {
 		}
 	}
 
-	PLUGINS = nextPlugins;
+	return nextPlugins;
 }
 
 function ensurePluginWatcher(): void {
 	if (watcherBootstrapped) return;
 	watcherBootstrapped = true;
+	let shouldReloadAfterAttach = false;
+
+	const scheduleWatchRetry = (delayMs: number) => {
+		if (pluginWatcher || pluginWatchRetryTimer) return;
+		pluginWatchRetryTimer = setTimeout(() => {
+			pluginWatchRetryTimer = null;
+			startWatch();
+		}, delayMs);
+		pluginWatchRetryTimer.unref?.();
+	};
 
 	const startWatch = () => {
 		if (pluginWatcher) return;
-		if (!existsSync(CUSTOM_HEADERS_PLUGIN_DIR)) return;
+		if (!existsSync(CUSTOM_HEADERS_PLUGIN_DIR)) {
+			shouldReloadAfterAttach = true;
+			scheduleWatchRetry(800);
+			return;
+		}
 		try {
 			pluginWatcher = watchDir(
 				CUSTOM_HEADERS_PLUGIN_DIR,
@@ -183,15 +195,20 @@ function ensurePluginWatcher(): void {
 					// ignore
 				}
 				pluginWatcher = null;
-				setTimeout(startWatch, 300);
+				shouldReloadAfterAttach = true;
+				scheduleWatchRetry(300);
 			});
+			if (shouldReloadAfterAttach) {
+				shouldReloadAfterAttach = false;
+				void reloadCustomHeaderPlugins();
+			}
 		} catch {
-			setTimeout(startWatch, 400);
+			shouldReloadAfterAttach = true;
+			scheduleWatchRetry(400);
 		}
 	};
 
 	startWatch();
-	setTimeout(startWatch, 800);
 }
 
 /**
@@ -205,8 +222,9 @@ export function ensureCustomHeaderPluginsLoaded(): Promise<void> {
 	if (externalLoaded) return Promise.resolve();
 	if (externalLoadPromise) return externalLoadPromise;
 	const gen = loadGeneration;
-	externalLoadPromise = loadExternalPlugins().then(() => {
+	externalLoadPromise = loadExternalPlugins().then(nextPlugins => {
 		if (gen === loadGeneration) {
+			PLUGINS = nextPlugins;
 			externalLoaded = true;
 		}
 	});
@@ -234,11 +252,9 @@ export async function reloadCustomHeaderPlugins(): Promise<void> {
 			const gen = loadGeneration;
 			externalLoaded = false;
 			externalLoadPromise = null;
-			// Clear only after claiming generation so ensure* waits on reloadInFlight.
-			// loadExternalPlugins assigns PLUGINS = next when done.
-			PLUGINS = [];
-			const loadPromise = loadExternalPlugins().then(() => {
+			const loadPromise = loadExternalPlugins().then(nextPlugins => {
 				if (gen === loadGeneration) {
+					PLUGINS = nextPlugins;
 					externalLoaded = true;
 				}
 			});

--- a/source/utils/plugins/games/loader.ts
+++ b/source/utils/plugins/games/loader.ts
@@ -9,10 +9,10 @@
  */
 import {existsSync, readdirSync} from 'node:fs';
 import {extname, join} from 'node:path';
-import {pathToFileURL} from 'node:url';
 
 import {GAMES_PLUGIN_DIR} from '../../config/apiConfig.js';
 import {logger} from '../../core/logger.js';
+import {importFreshPluginModule} from '../importFresh.js';
 import {snakeGamePlugin} from './builtin/snake.js';
 import type {GamePlugin, GamePluginModule} from './types.js';
 
@@ -59,11 +59,6 @@ function collectFromModule(mod: GamePluginModule): GamePlugin[] {
 	return candidates.filter(isGamePlugin);
 }
 
-/** Bust ESM import cache so edited plugins reload without process restart. */
-function buildCacheBustedModuleUrl(modulePath: string): string {
-	return `${pathToFileURL(modulePath).href}?t=${Date.now()}`;
-}
-
 /**
  * 加载外部游戏插件（从 `~/.snow/plugin/games/` 目录）。
  * 每次调用都会 cache-bust 重新 import，保证改插件后重新打开面板即可生效。
@@ -87,7 +82,8 @@ export async function loadExternalGamePlugins(): Promise<GamePlugin[]> {
 
 	const files = entries
 		.filter(
-			e => e.isFile() && SUPPORTED_EXTENSIONS.has(extname(e.name).toLowerCase()),
+			e =>
+				e.isFile() && SUPPORTED_EXTENSIONS.has(extname(e.name).toLowerCase()),
 		)
 		.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -96,8 +92,9 @@ export async function loadExternalGamePlugins(): Promise<GamePlugin[]> {
 	for (const file of files) {
 		const modulePath = join(GAMES_PLUGIN_DIR, file.name);
 		try {
-			const moduleUrl = buildCacheBustedModuleUrl(modulePath);
-			const mod = (await import(moduleUrl)) as GamePluginModule;
+			const mod = (await importFreshPluginModule(
+				modulePath,
+			)) as GamePluginModule;
 			const collected = collectFromModule(mod);
 			if (collected.length === 0) {
 				logger.warn(
@@ -121,9 +118,7 @@ export async function loadExternalGamePlugins(): Promise<GamePlugin[]> {
  * 合并内置游戏与外部插件。
  * 外部插件的 id 与内置游戏相同时，外部插件覆盖内置游戏。
  */
-export function mergeGamePlugins(
-	externalPlugins: GamePlugin[],
-): GamePlugin[] {
+export function mergeGamePlugins(externalPlugins: GamePlugin[]): GamePlugin[] {
 	const merged = new Map<string, GamePlugin>();
 
 	// 先放内置游戏

--- a/source/utils/plugins/importFresh.ts
+++ b/source/utils/plugins/importFresh.ts
@@ -1,0 +1,59 @@
+import {createRequire} from 'node:module';
+import {dirname, extname, sep} from 'node:path';
+import {pathToFileURL} from 'node:url';
+
+const localRequire = createRequire(import.meta.url);
+let esmImportSequence = 0;
+
+function clearCommonJsCache(
+	moduleId: string,
+	pluginRoot: string,
+	visited: Set<string> = new Set(),
+): void {
+	if (visited.has(moduleId)) return;
+	visited.add(moduleId);
+
+	const cached = localRequire.cache[moduleId];
+	if (!cached) return;
+	// Delete before walking children so CommonJS dependency cycles cannot recurse
+	// back into the same cached module indefinitely.
+	delete localRequire.cache[moduleId];
+	const rootPrefix = pluginRoot.endsWith(sep)
+		? pluginRoot
+		: `${pluginRoot}${sep}`;
+	for (const child of cached.children) {
+		if (child.id === pluginRoot || child.id.startsWith(rootPrefix)) {
+			clearCommonJsCache(child.id, pluginRoot, visited);
+		}
+	}
+}
+
+function wrapCommonJsModule(value: unknown): Record<string, unknown> {
+	return value && typeof value === 'object'
+		? {default: value, ...(value as Record<string, unknown>)}
+		: {default: value};
+}
+
+/** Load plugin code without reusing ESM or CommonJS module caches. */
+export async function importFreshPluginModule(
+	modulePath: string,
+): Promise<Record<string, unknown>> {
+	const extension = extname(modulePath).toLowerCase();
+	if (extension === '.cjs' || extension === '.js') {
+		try {
+			const moduleId = localRequire.resolve(modulePath);
+			clearCommonJsCache(moduleId, dirname(modulePath));
+			return wrapCommonJsModule(localRequire(moduleId));
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException | undefined)?.code;
+			if (extension === '.cjs' || code !== 'ERR_REQUIRE_ESM') {
+				throw error;
+			}
+		}
+	}
+
+	const moduleUrl = `${
+		pathToFileURL(modulePath).href
+	}?t=${Date.now()}-${++esmImportSequence}`;
+	return (await import(moduleUrl)) as Record<string, unknown>;
+}

--- a/source/utils/session/chatExporter.ts
+++ b/source/utils/session/chatExporter.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import {existsSync} from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type {ChatMessage, Session} from './sessionManager.js';
@@ -18,7 +19,6 @@ export function buildDefaultExportFileName(
 	format: ExportFormat,
 ): string {
 	const shortId = sessionId.slice(0, 8);
-	// ISO seconds only: 2026-07-15T08-52-40 (drop ms / trailing Z)
 	const timestamp = new Date().toISOString().slice(0, 19).replace(/:/g, '-');
 	return `snow-export-${timestamp}-${shortId}.${format}`;
 }
@@ -36,10 +36,28 @@ export function resolveExportFilePath(
 	if (outPath) {
 		return path.resolve(outPath);
 	}
-	return path.join(
-		getDefaultExportDirectory(),
+	const directory = getDefaultExportDirectory();
+	const initial = path.join(
+		directory,
 		buildDefaultExportFileName(sessionId, format),
 	);
+	if (!existsSync(initial)) return initial;
+	// Avoid overwriting an existing export when multiple exports happen within
+	// the same second by advancing the timestamp until the path is unused.
+	let attempt = 1;
+	let candidate = initial;
+	while (existsSync(candidate)) {
+		const stamp = new Date(Date.now() + attempt * 1000)
+			.toISOString()
+			.slice(0, 19)
+			.replace(/:/g, '-');
+		candidate = path.join(
+			directory,
+			`snow-export-${stamp}-${sessionId.slice(0, 8)}.${format}`,
+		);
+		attempt += 1;
+	}
+	return candidate;
 }
 
 const ROLE_LABELS: Record<string, string> = {
@@ -609,8 +627,13 @@ export async function exportSessionToFile(
 	session: Session,
 	filePath: string,
 	format: ExportFormat = 'txt',
+	options?: {exclusive?: boolean},
 ): Promise<void> {
 	const content = renderSession(session, format);
 	await fs.mkdir(path.dirname(filePath), {recursive: true});
-	await fs.writeFile(filePath, content, 'utf-8');
+	await fs.writeFile(
+		filePath,
+		content,
+		options?.exclusive ? {encoding: 'utf-8', flag: 'wx'} : 'utf-8',
+	);
 }

--- a/source/utils/session/sessionManager.ts
+++ b/source/utils/session/sessionManager.ts
@@ -46,6 +46,13 @@ export interface Session {
 	hasGoal?: boolean;
 }
 
+type LegacySessionProjectFields = {
+	cwd?: unknown;
+	workingDirectory?: unknown;
+	workspaceRoot?: unknown;
+	projectRoot?: unknown;
+};
+
 export interface SessionListItem {
 	id: string;
 	title: string;
@@ -71,11 +78,18 @@ export interface PaginatedSessionList {
 	hasMore: boolean;
 }
 
+const SAFE_SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+
+function isSafeSessionId(sessionId: string): boolean {
+	return SAFE_SESSION_ID_PATTERN.test(sessionId);
+}
+
 class SessionManager {
 	private readonly sessionsDir: string;
 	private currentSession: Session | null = null;
 	private readonly currentProjectId: string;
 	private readonly currentProjectPath: string;
+	private readonly currentProjectRoot: string;
 	private readonly projectAliasIds: string[];
 	// 会话列表缓存
 	private sessionListCache: SessionListItem[] | null = null;
@@ -91,6 +105,7 @@ class SessionManager {
 		const identity = resolveProjectIdentity();
 		this.currentProjectId = identity.projectId;
 		this.currentProjectPath = identity.projectPath;
+		this.currentProjectRoot = identity.projectRoot;
 		this.projectAliasIds = identity.projectAliasIds;
 	}
 
@@ -319,12 +334,19 @@ class SessionManager {
 	private async loadSessionFromDisk(
 		sessionId: string,
 	): Promise<Session | null> {
+		if (!isSafeSessionId(sessionId)) return null;
+
 		// 首先尝试从旧格式加载（向下兼容）
 		try {
 			const oldSessionPath = path.join(this.sessionsDir, `${sessionId}.json`);
 			const data = await fs.readFile(oldSessionPath, 'utf-8');
 			const session: Session = JSON.parse(data);
-			return session;
+			if (
+				session.id === sessionId &&
+				this.acceptCurrentProjectSession(session)
+			) {
+				return session;
+			}
 		} catch {
 			// 旧格式不存在，搜索日期文件夹
 		}
@@ -407,11 +429,25 @@ class SessionManager {
 		}));
 	}
 
-	private isCurrentProjectSession(session: Session): boolean {
-		if (!session.projectId && !session.projectPath) {
-			return true;
+	private normalizeProjectPath(value: unknown): string | undefined {
+		if (typeof value !== 'string' || !value.trim() || !path.isAbsolute(value)) {
+			return undefined;
 		}
 
+		try {
+			const normalized = path.normalize(path.resolve(value));
+			return process.platform === 'win32'
+				? normalized.toLowerCase()
+				: normalized;
+		} catch {
+			return undefined;
+		}
+	}
+
+	private isCurrentProjectSession(
+		session: Session,
+		sourceProjectOwned = false,
+	): boolean {
 		if (session.projectId) {
 			return (
 				session.projectId === this.currentProjectId ||
@@ -419,7 +455,66 @@ class SessionManager {
 			);
 		}
 
-		return session.projectPath === this.currentProjectPath;
+		const legacy = session as Session & LegacySessionProjectFields;
+		const declaredPaths = [
+			session.projectPath,
+			legacy.cwd,
+			legacy.workingDirectory,
+			legacy.workspaceRoot,
+			legacy.projectRoot,
+		].filter(value => value !== undefined && value !== null && value !== '');
+
+		if (declaredPaths.length === 0) {
+			// A project-scoped directory is reliable ownership evidence. Global
+			// legacy locations are not, so metadata-free records there stay hidden.
+			return sourceProjectOwned;
+		}
+
+		const normalizedPaths = declaredPaths.map(value =>
+			this.normalizeProjectPath(value),
+		);
+		if (normalizedPaths.some(value => value === undefined)) {
+			return false;
+		}
+
+		const currentPaths = new Set(
+			[this.currentProjectPath, this.currentProjectRoot]
+				.map(value => this.normalizeProjectPath(value))
+				.filter((value): value is string => Boolean(value)),
+		);
+		return normalizedPaths.every(value => currentPaths.has(value!));
+	}
+
+	private acceptCurrentProjectSession(
+		session: Session,
+		sourceProjectOwned = false,
+	): boolean {
+		if (!this.isCurrentProjectSession(session, sourceProjectOwned)) {
+			return false;
+		}
+
+		// Attribute accepted legacy records in memory. The next normal save moves
+		// them to the stable project directory and persists explicit ownership.
+		session.projectId ||= this.currentProjectId;
+		session.projectPath ||= this.currentProjectPath;
+		return true;
+	}
+
+	private async isOwnedSessionFile(
+		filePath: string,
+		sessionId: string,
+		sourceProjectOwned = false,
+	): Promise<boolean> {
+		try {
+			const data = await fs.readFile(filePath, 'utf8');
+			const session = JSON.parse(data) as Session;
+			return (
+				session.id === sessionId &&
+				this.acceptCurrentProjectSession(session, sourceProjectOwned)
+			);
+		} catch {
+			return false;
+		}
 	}
 
 	private toSessionListItem(session: Session): SessionListItem {
@@ -442,8 +537,12 @@ class SessionManager {
 		sessions: SessionListItem[],
 		seenIds: Set<string>,
 		session: Session,
+		sourceProjectOwned = false,
 	): void {
-		if (seenIds.has(session.id) || !this.isCurrentProjectSession(session)) {
+		if (
+			seenIds.has(session.id) ||
+			!this.acceptCurrentProjectSession(session, sourceProjectOwned)
+		) {
 			return;
 		}
 
@@ -456,7 +555,7 @@ class SessionManager {
 	 * 搜索顺序:
 	 * 1. 稳定项目目录
 	 * 2. 当前项目的旧路径别名目录
-	 * 3. 其他项目目录和旧格式日期目录（向后兼容）
+	 * 3. 旧格式日期目录（向后兼容）
 	 */
 	private async findSessionInDateFolders(
 		sessionId: string,
@@ -478,22 +577,18 @@ class SessionManager {
 				if (!stat.isDirectory()) continue;
 				if (preferredProjectIds.has(file)) continue;
 
-				// 新格式：项目文件夹（项目名-哈希）
-				if (isProjectFolder(file)) {
-					const session = await this.findSessionInProjectDir(
-						filePath,
-						sessionId,
-					);
-					if (session) return session;
-				}
-
 				// 旧格式：日期文件夹 YYYY-MM-DD（无项目层级）
 				if (isDateFolder(file)) {
 					const sessionPath = path.join(filePath, `${sessionId}.json`);
 					try {
 						const data = await fs.readFile(sessionPath, 'utf-8');
 						const session: Session = JSON.parse(data);
-						return session;
+						if (
+							session.id === sessionId &&
+							this.acceptCurrentProjectSession(session)
+						) {
+							return session;
+						}
 					} catch (error) {
 						// 文件不存在，继续搜索
 						continue;
@@ -514,6 +609,7 @@ class SessionManager {
 		projectDir: string,
 		sessionId: string,
 	): Promise<Session | null> {
+		if (!isSafeSessionId(sessionId)) return null;
 		try {
 			const dateFolders = await fs.readdir(projectDir);
 
@@ -528,7 +624,12 @@ class SessionManager {
 				try {
 					const data = await fs.readFile(sessionPath, 'utf-8');
 					const session: Session = JSON.parse(data);
-					return session;
+					if (
+						session.id === sessionId &&
+						this.acceptCurrentProjectSession(session, true)
+					) {
+						return session;
+					}
 				} catch (error) {
 					// 文件不存在，继续搜索
 					continue;
@@ -558,7 +659,7 @@ class SessionManager {
 					for (const dateFolder of dateFolders) {
 						if (!isDateFolder(dateFolder)) continue;
 						const datePath = path.join(dir, dateFolder);
-						await this.readSessionsFromDir(datePath, sessions, seenIds);
+						await this.readSessionsFromDir(datePath, sessions, seenIds, true);
 					}
 				} catch (error) {
 					// 项目目录不存在，继续读取其他兼容来源
@@ -698,6 +799,7 @@ class SessionManager {
 		dirPath: string,
 		sessions: SessionListItem[],
 		seenIds: Set<string>,
+		sourceProjectOwned = false,
 	): Promise<void> {
 		try {
 			const files = await fs.readdir(dirPath);
@@ -709,7 +811,12 @@ class SessionManager {
 					const sessionPath = path.join(dirPath, file);
 					const data = await fs.readFile(sessionPath, 'utf-8');
 					const session: Session = JSON.parse(data);
-					this.addSessionListItem(sessions, seenIds, session);
+					this.addSessionListItem(
+						sessions,
+						seenIds,
+						session,
+						sourceProjectOwned,
+					);
 				} catch (error) {
 					// Skip invalid session files
 					continue;
@@ -1109,13 +1216,16 @@ class SessionManager {
 	}
 
 	async deleteSession(sessionId: string): Promise<boolean> {
+		if (!isSafeSessionId(sessionId)) return false;
 		let sessionDeleted = false;
 
 		// 1. 首先尝试删除旧格式（向下兼容）
 		try {
 			const oldSessionPath = path.join(this.sessionsDir, `${sessionId}.json`);
-			await fs.unlink(oldSessionPath);
-			sessionDeleted = true;
+			if (await this.isOwnedSessionFile(oldSessionPath, sessionId)) {
+				await fs.unlink(oldSessionPath);
+				sessionDeleted = true;
+			}
 		} catch (error) {
 			// 旧格式不存在，继续搜索
 		}
@@ -1128,7 +1238,7 @@ class SessionManager {
 			}
 		}
 
-		// 3. 在所有项目文件夹和旧格式日期文件夹中查找
+		// 3. 仅在旧格式日期文件夹中查找；不得跨项目删除。
 		if (!sessionDeleted) {
 			try {
 				const files = await fs.readdir(this.sessionsDir);
@@ -1146,22 +1256,15 @@ class SessionManager {
 					if (!stat.isDirectory()) continue;
 					if (preferredProjectIds.has(file)) continue;
 
-					// 新格式：项目文件夹
-					if (isProjectFolder(file)) {
-						sessionDeleted = await this.deleteSessionFromProjectDir(
-							filePath,
-							sessionId,
-						);
-						if (sessionDeleted) break;
-					}
-
 					// 旧格式：日期文件夹
 					if (isDateFolder(file)) {
 						const sessionPath = path.join(filePath, `${sessionId}.json`);
 						try {
-							await fs.unlink(sessionPath);
-							sessionDeleted = true;
-							break;
+							if (await this.isOwnedSessionFile(sessionPath, sessionId)) {
+								await fs.unlink(sessionPath);
+								sessionDeleted = true;
+								break;
+							}
 						} catch (error) {
 							// 文件不存在，继续搜索
 							continue;
@@ -1217,8 +1320,10 @@ class SessionManager {
 					`${sessionId}.json`,
 				);
 				try {
-					await fs.unlink(sessionPath);
-					return true;
+					if (await this.isOwnedSessionFile(sessionPath, sessionId, true)) {
+						await fs.unlink(sessionPath);
+						return true;
+					}
 				} catch (error) {
 					// 文件不存在，继续搜索
 					continue;


### PR DESCRIPTION
## 为什么需要这个 PR

PR #191 已于 2026-07-16 合并到 `main`。在合并后的多轮安全审查、运行态审查和真实端到端测试中，又发现了一批会影响控制面安全性、跨项目隔离、热重载可靠性与 Windows 通知可用性的问题。

这些修复不能继续追加到已经合并关闭的 #191，也不应直接推送上游 `main`：

- 新建 follow-up PR 可以让维护者只审查增量修复，不重复 #191 的功能代码；
- 安全边界和兼容性变更保留独立、可回滚的审查记录；
- CI、自动化测试和人工测试结果可以在合并前再次确认。

本分支直接基于 #191 的上游合并提交 `b72d7e4`，因此 PR diff 只包含后续修复。

## 修复内容

### 控制面与安全

- SSE 全端点共享 token / Origin 校验，限制 1 MiB 请求体；仅认证传输可提供可信确认。
- Session ID、Profile 名称与导出路径参数统一校验，阻止路径穿越和跨项目旧会话访问。
- Agent 不能通过模型参数自签中高风险确认；CLI `--yes` 保持可信。
- CLI 保留 argv 参数边界，修复带空格路径和 Profile 参数被错误拆分。
- 修复 Usage 时间窗口、无效数据、未来记录、空 `--period=` 和未知 MCP 服务处理。
- 控制面写操作串行化，Profile 切换同步更新当前 TUI 状态。

### Hook 与生命周期

- onUserMessage Hook 替换内容只发送给模型，用户气泡保留原文和正确的文件/图片来源。
- Hook 状态增加 execution ID，支持并发执行；exit 1 显示为 soft applied 而非失败。
- `/clear` 不再关闭进程级 MCP、OTel 或永久销毁 ACE code search。
- 修复 onStop 通知抑制、Assistant XML mask 和 signal-killed Hook 状态。

### 热重载

- Config / Theme watcher 支持 atomic rename 后重挂载并主动 reload，非法临时 JSON 保留 last-known-good。
- StatusLine、customHeaders、websearch 和插件目录支持晚创建与并发 reload。
- CommonJS 插件显式清理 `require.cache`，循环依赖不会递归溢出。

### Windows 与显示

- 修复 Windows Toast 启动：`detached: true` / PowerShell `-WindowStyle Hidden` 会导致编码脚本未执行，现改用 `windowsHide + unref()`。
- 注册 `Snow.CLI` AppUserModelID 时不覆盖用户通知偏好。
- 修复英文多词、冒号和批量工具显示名解析。

## 提交划分

- `264a65f` `fix(control-plane): harden remote command execution`
- `39cfa85` `fix(hooks): preserve message context and runtime state`
- `374bd77` `fix(config): keep watchers and plugins hot-reloadable`
- `b969918` `fix(platform): repair notifications and tool labels`
- `a988534` `fix(config): reject non-portable profile names`

## 验证

- [x] `npm run build`
- [x] TypeScript 编译
- [x] AVA：`110 tests passed`
- [x] 56 个 PR 文件通过 Prettier
- [x] `git diff --check`
- [x] CLI 纯 JSON、确认边界、空参数、带空格路径和 traversal 人工验收
- [x] SSE 401 / 403 / 413、认证读取和 trusted confirm 人工验收
- [x] 真实 `grok-4.5` 请求返回 `SNOW_E2E_OK`
- [x] onUserMessage / onStop Hook 真实执行
- [x] Windows Toast 身份注册与修复后派发测试

## 实际端到端测试结果

以下结果来自合并前在 Windows 环境中对全局链接的 `snow 0.8.18` 和当前 PR bundle 进行的实际调用，不只是单元测试。

### CLI 控制面

| 场景 | 实际结果 |
|---|---|
| `snow --version` | `0.8.18` |
| `usage --period=day --json` | 纯 JSON，可由 PowerShell `ConvertFrom-Json` 解析；`exit=0`，`period=day` |
| `usage --period= --json` | `exit=1`，`code=INVALID_ARGS` |
| 未确认执行 `yolo off` | `exit=1`，`code=CONFIRMATION_REQUIRED`，配置未修改 |
| 带空格导出路径 `C:/My Exports/chat.md` | 参数边界保留；正确报告指定的缺失 session，没有把路径片段误解析成 session ID |
| `session load ../../config` | `exit=1`，`code=NOT_FOUND`，路径穿越被阻止 |

### SSE 安全与协议

| 场景 | 实际结果 |
|---|---|
| 未携带 token 调用 `/session/command` | HTTP `401` |
| 携带有效 token 执行只读 usage | HTTP `200`，`period=day` |
| 有效 token + 恶意 `Origin: http://evil.local` | HTTP `403` |
| 认证传输携带 `confirm:true` | trusted confirm 生效，继续执行到业务层并返回 `NOT_FOUND`，而不是 `CONFIRMATION_REQUIRED` |
| `/message` 请求体超过 1 MiB | HTTP `413` |
| 服务停止后的端口状态 | 不再监听，无测试服务残留 |

### 真实模型请求

使用当前 Profile 的 `grok-4.5` 发起真实 SSE 对话：

```text
Prompt: 这是端到端测试。请不要调用任何工具，只回复 SNOW_E2E_OK。
Response: SNOW_E2E_OK
Events: connected, message, usage, complete
Prompt tokens: 4874
Completion tokens: 51
Total tokens: 4925
Cached tokens: 128
```

请求成功创建并保存项目隔离的 session，完成事件正常返回 session ID。

### Hook 运行态

在隔离临时项目中配置并执行真实 Hook：

```text
onUserMessage action: replace
replacement: HOOK_REPLACED_OK
status phases: start -> action -> success
softActions: 1
onStop marker: ON_STOP_OK
```

这验证了 command exit 1 被显示为 soft applied，而不是 hard failure；onStop 同样在真实模型响应结束后执行。

### Windows Toast

实际测试复现了旧通知启动路径的问题：

- `detached: true` 或 PowerShell `-WindowStyle Hidden` 时，编码脚本没有执行，隔离标记文件未生成；
- `detached: false + windowsHide: true + unref()` 可以无窗口执行，标记文件正常生成；
- 修复后通过产品的 `notifyAgentTurnComplete` 路径派发；
- `HKCU\Software\Classes\AppUserModelId\Snow.CLI` 正确注册，`DisplayName=Snow CLI`；
- 2.5 秒后没有残留 PowerShell helper 进程；
- 注册流程未写入 `Enabled` 或 `ShowInActionCenter`，不会覆盖用户通知偏好。

### 最终自动化回归

```text
npm run build        PASS
TypeScript           PASS
AVA                  110 tests passed
Prettier             56 PR files passed
git diff --check     PASS
Bundle               30.1 MB
```
## 关联

- Follow-up to #191
- Original issue: #190