### PR TITLE
fix(agents): read unified StreamChunk format when requestMethod is 'chat'

### DIFF
--- a/source/agents/bashOutputSummaryAgent.ts
+++ b/source/agents/bashOutputSummaryAgent.ts
@@ -109,11 +109,7 @@ export class BashOutputSummaryAgent {
 				throw new Error('Request aborted');
 			}
 
-			if (this.requestMethod === 'chat') {
-				if (chunk.choices && chunk.choices[0]?.delta?.content) {
-					content += chunk.choices[0].delta.content;
-				}
-			} else if (chunk.type === 'content' && chunk.content) {
+			if (chunk.type === 'content' && chunk.content) {
 				content += chunk.content;
 			}
 		}

--- a/source/agents/codebaseReviewAgent.ts
+++ b/source/agents/codebaseReviewAgent.ts
@@ -185,41 +185,12 @@ export class CodebaseReviewAgent {
 					throw new Error('Request aborted');
 				}
 
-				if (this.requestMethod === 'chat') {
-					// OpenAI chat format
-					if (chunk.choices && chunk.choices[0]?.delta?.content) {
-						completeContent += chunk.choices[0].delta.content;
-					}
-					if (chunk.choices && chunk.choices[0]?.delta?.tool_calls) {
-						// Accumulate tool calls
-						const deltaToolCalls = chunk.choices[0].delta.tool_calls;
-						for (const tc of deltaToolCalls) {
-							if (tc.index !== undefined) {
-								if (!tool_calls[tc.index]) {
-									tool_calls[tc.index] = {
-										id: tc.id || '',
-										type: 'function',
-										function: {name: '', arguments: ''},
-									};
-								}
-								if (tc.function?.name) {
-									tool_calls[tc.index].function.name += tc.function.name;
-								}
-								if (tc.function?.arguments) {
-									tool_calls[tc.index].function.arguments +=
-										tc.function.arguments;
-								}
-							}
-						}
-					}
-				} else {
-					// Anthropic/Gemini/Responses format
-					if (chunk.type === 'content' && chunk.content) {
-						completeContent += chunk.content;
-					}
-					if (chunk.type === 'tool_calls' && chunk.tool_calls) {
-						tool_calls = chunk.tool_calls;
-					}
+				// All streaming APIs yield the unified StreamChunk format
+				if (chunk.type === 'content' && chunk.content) {
+					completeContent += chunk.content;
+				}
+				if (chunk.type === 'tool_calls' && chunk.tool_calls) {
+					tool_calls = chunk.tool_calls;
 				}
 			}
 		} catch (streamError) {

--- a/source/agents/compactAgent.ts
+++ b/source/agents/compactAgent.ts
@@ -162,17 +162,17 @@ export class CompactAgent {
 			let chunkCount = 0;
 
 			// Initialize token encoder for token counting
-		let encoder;
-		try {
-			const {encoding_for_model} = await import('tiktoken');
+			let encoder;
 			try {
-				encoder = encoding_for_model('gpt-5');
-			} catch {
-				encoder = encoding_for_model('gpt-3.5-turbo');
+				const {encoding_for_model} = await import('tiktoken');
+				try {
+					encoder = encoding_for_model('gpt-5');
+				} catch {
+					encoder = encoding_for_model('gpt-3.5-turbo');
+				}
+			} catch (e) {
+				// tiktoken unavailable, token counting will be skipped
 			}
-		} catch (e) {
-			// tiktoken unavailable, token counting will be skipped
-		}
 
 			try {
 				for await (const chunk of streamGenerator) {
@@ -183,35 +183,17 @@ export class CompactAgent {
 						throw new Error('Request aborted');
 					}
 
-					// Handle different chunk formats based on request method
-					if (this.requestMethod === 'chat') {
-						// Chat API uses standard OpenAI format: {choices: [{delta: {content}}]}
-						if (chunk.choices && chunk.choices[0]?.delta?.content) {
-							completeContent += chunk.choices[0].delta.content;
+					// All streaming APIs yield the unified StreamChunk format: {type: 'content', content: string}
+					if (chunk.type === 'content' && chunk.content) {
+						completeContent += chunk.content;
 
-							// Update token count if callback provided
-							if (onTokenUpdate && encoder) {
-								try {
-									const tokens = encoder.encode(completeContent);
-									onTokenUpdate(tokens.length);
-								} catch (e) {
-									// Ignore encoding errors
-								}
-							}
-						}
-					} else {
-						// Responses, Gemini, and Anthropic APIs all use: {type: 'content', content: string}
-						if (chunk.type === 'content' && chunk.content) {
-							completeContent += chunk.content;
-
-							// Update token count if callback provided
-							if (onTokenUpdate && encoder) {
-								try {
-									const tokens = encoder.encode(completeContent);
-									onTokenUpdate(tokens.length);
-								} catch (e) {
-									// Ignore encoding errors
-								}
+						// Update token count if callback provided
+						if (onTokenUpdate && encoder) {
+							try {
+								const tokens = encoder.encode(completeContent);
+								onTokenUpdate(tokens.length);
+							} catch (e) {
+								// Ignore encoding errors
 							}
 						}
 					}

--- a/source/agents/summaryAgent.ts
+++ b/source/agents/summaryAgent.ts
@@ -153,17 +153,9 @@ export class SummaryAgent {
 					throw new Error('Request aborted');
 				}
 
-				// Handle different chunk formats based on request method
-				if (this.requestMethod === 'chat') {
-					// Chat API uses standard OpenAI format
-					if (chunk.choices && chunk.choices[0]?.delta?.content) {
-						completeContent += chunk.choices[0].delta.content;
-					}
-				} else {
-					// Responses, Gemini, and Anthropic APIs use unified format
-					if (chunk.type === 'content' && chunk.content) {
-						completeContent += chunk.content;
-					}
+				// All streaming APIs yield the unified StreamChunk format
+				if (chunk.type === 'content' && chunk.content) {
+					completeContent += chunk.content;
 				}
 			}
 		} catch (streamError) {

--- a/source/agents/visionAgent.ts
+++ b/source/agents/visionAgent.ts
@@ -184,11 +184,7 @@ export class VisionAgent {
 				throw new Error('Request aborted');
 			}
 
-			if (requestMethod === 'chat') {
-				if (chunk.choices && chunk.choices[0]?.delta?.content) {
-					completeContent += chunk.choices[0].delta.content;
-				}
-			} else if (chunk.type === 'content' && chunk.content) {
+			if (chunk.type === 'content' && chunk.content) {
 				completeContent += chunk.content;
 			}
 		}

--- a/source/utils/execution/unifiedHooksExecutor.ts
+++ b/source/utils/execution/unifiedHooksExecutor.ts
@@ -854,15 +854,9 @@ Rules:
 					throw new Error('Request aborted');
 				}
 
-				// 处理不同格式的 chunk
-				if (this.requestMethod === 'chat') {
-					if (chunk.choices && chunk.choices[0]?.delta?.content) {
-						completeContent += chunk.choices[0].delta.content;
-					}
-				} else {
-					if (chunk.type === 'content' && chunk.content) {
-						completeContent += chunk.content;
-					}
+				// All streaming APIs yield the unified StreamChunk format
+				if (chunk.type === 'content' && chunk.content) {
+					completeContent += chunk.content;
 				}
 			}
 		} catch (streamError) {


### PR DESCRIPTION
## Problem

All agents that consume `createStreamingChatCompletion()` return empty content when `requestMethod` is `'chat'`.

Most visible symptom: session titles are never generated. `logger.warn('Summary agent: Empty response, using fallback')` fires on every conversation, and the title/summary end up being the raw first user message.

## Root cause

`createStreamingChatCompletion()` is declared as `AsyncGenerator<StreamChunk, void, unknown>` and yields the **normalized** shape (`source/api/chat.ts`):

```ts
yield {
    type: 'content',
    content,
};
```

But six consumers branch on `requestMethod` and expect the **raw** OpenAI shape for `'chat'`, e.g. `source/agents/summaryAgent.ts`:

```ts
if (this.requestMethod === 'chat') {
    // Chat API uses standard OpenAI format
    if (chunk.choices && chunk.choices[0]?.delta?.content) {   // never true
        completeContent += chunk.choices[0].delta.content;
    }
} else {
    if (chunk.type === 'content' && chunk.content) {           // correct
        completeContent += chunk.content;
    }
}
```

`chunk.choices` does not exist on `StreamChunk` — the raw SSE frames are already parsed inside `chat.ts`. So the `'chat'` branch accumulates nothing and `completeContent` stays `''`. No error is thrown or logged, which is why this is silent.

Affected files and impact:

| File | Impact when `requestMethod: 'chat'` |
| --- | --- |
| `agents/summaryAgent.ts` | session titles/summaries never generated |
| `agents/compactAgent.ts` | context compaction returns nothing |
| `agents/visionAgent.ts` | image analysis returns nothing |
| `agents/codebaseReviewAgent.ts` | content **and** `tool_calls` dropped |
| `agents/bashOutputSummaryAgent.ts` | bash output summaries return nothing |
| `utils/execution/unifiedHooksExecutor.ts` | hook output returns nothing |

Only `requestMethod: 'chat'` is affected — i.e. every OpenAI-compatible endpoint (LM Studio, Ollama, vLLM, DeepSeek, ...). `anthropic` / `gemini` / `responses` already took the correct branch, which is why this went unnoticed.

## Fix

All four streaming APIs yield the same unified `StreamChunk` format, so the branching is unnecessary. Each `if (requestMethod === 'chat') { ... } else { ... }` is collapsed to the already-correct unified branch — the diff is mostly deletions (24 insertions, 91 deletions).

`source/api/chat.ts` is intentionally **untouched**: its `chunk.choices?.[0]` usage is the raw SSE parser that produces the unified chunks in the first place.

## Verification

Reproduced against LM Studio (`requestMethod: 'chat'`, `qwen2.5-coder-7b-instruct`). The model itself is fine — replaying the exact summary prompt directly against the endpoint returns valid JSON:

```
SSE chunks: 36 | finish_reason: stop | delta.content: 142 chars
{"title": "AI Capabilities", "summary": "User asks about AI abilities; ..."}
```

Before the fix, the same conversation logs `Summary agent: Empty response, using fallback` every time.

Checks run:
- `npx tsc --noEmit` — no errors
- `npx prettier --check` on all touched files — clean
