### PR TITLE
fix(ui)/feat(ui): DiffViewer success path, panel chrome polish, context breakdown

### DIFF
--- a/docs/usage/en/08.Theme Settings.md
+++ b/docs/usage/en/08.Theme Settings.md
@@ -594,9 +594,11 @@ Theme configuration is stored in `~/.snow/theme.json` file.
   - `true`: Enable simple mode
   - `false`: Use standard mode
 
-- **toolDisplayMode**: Tool-call display density
+- **toolDisplayMode**: Tool-call display density (exactly three modes; no fourth tier)
 
-  - `full` (default) / `compact` / `hidden`
+  - `full` (default): tool name + args + full result; file create/edit DiffViewer shows on **pending and success**
+  - `compact`: tool name + brief status summary only (no Diff / args tree / full preview)
+  - `hidden`: hide all tool process
   - Also via `/tool-display` or `snow cmd tool-display`
 
 - **thinkDisplayMode**: Thinking content display mode

--- a/docs/usage/en/09.2.Mode Switching Commands.md
+++ b/docs/usage/en/09.2.Mode Switching Commands.md
@@ -69,9 +69,12 @@ Toggle Image Context Compression mode.
 
 Switch tool call display density.
 
-- **Function**: Control how tool calls and results are rendered in the conversation. Three modes are available: `full`, `compact`, `hidden`
+- **Function**: Control how tool calls and results are rendered in the conversation. **Exactly three modes** (do not invent a fourth “compact-with-diff” tier): `full`, `compact`, `hidden`
   - `full` (default): Show tool name + arguments + full result
-  - `compact`: Show only tool name + brief status summary
+    - Includes **DiffViewer** for `filesystem-create` / `filesystem-edit` / `filesystem-replaceedit`
+    - Diff renders on both **pending** (in-flight) and **success** (completed); success uses result-side `editDiffData`
+  - `compact`: Show only tool name + brief status summary (single-line collapse)
+    - **No** argument tree, **no** DiffViewer, **no** full result preview
   - `hidden`: Hide all tool call process, show only AI reply
 - **Arguments**:
   - No argument or `status`: Show the current display mode
@@ -79,6 +82,7 @@ Switch tool call display density.
 - **Status**: Persisted in `~/.snow/theme.json` (`toolDisplayMode` field), synced to the UI in real time
 - **Use Cases**: Reduce visual noise when a task issues many tool calls, or fully hide tool activity to keep the conversation focused on AI replies
 - **Example**:
+  - `/tool-display full` — full tool process + edit diffs
   - `/tool-display compact` — collapse tool calls to a single status line
   - `/tool-display hidden` — hide all tool activity
   - `/tool-display` — show the current mode

--- a/docs/usage/zh/08.主题设置.md
+++ b/docs/usage/zh/08.主题设置.md
@@ -594,9 +594,11 @@ A: 复制 `~/.snow/theme.json` 文件中的 `customColors` 部分，分享给团
   - `true`: 启用简洁模式
   - `false`: 使用标准模式
 
-- **toolDisplayMode**: 工具调用显示密度
+- **toolDisplayMode**: 工具调用显示密度（仅三档，无第四档）
 
-  - `full`（默认）/ `compact` / `hidden`
+  - `full`（默认）：工具名 + 参数 + 完整结果；文件 create/edit 的 DiffViewer 在 **pending 与 success** 均显示
+  - `compact`：仅工具名 + 简要状态摘要（不含 Diff / 参数树 / 完整预览）
+  - `hidden`：隐藏全部工具过程
   - 也可用 `/tool-display` 或 `snow cmd tool-display`
 
 - **thinkDisplayMode**: 思考内容显示模式

--- a/docs/usage/zh/09.2.模式切换指令.md
+++ b/docs/usage/zh/09.2.模式切换指令.md
@@ -69,9 +69,12 @@
 
 切换工具调用显示密度。
 
-- **作用**: 控制工具调用及结果在对话中的渲染方式，共三档：`full`、`compact`、`hidden`
+- **作用**: 控制工具调用及结果在对话中的渲染方式，**仅三档**（不要把 Diff 单独做成第四档）：`full`、`compact`、`hidden`
   - `full`（默认）：显示工具名 + 参数 + 完整结果
-  - `compact`：仅显示工具名 + 简要状态摘要
+    - 含 `filesystem-create` / `filesystem-edit` / `filesystem-replaceedit` 的 **DiffViewer**
+    - Diff 在工具 **pending（执行中）与 success（完成后）** 都会渲染；success 路径依赖结果侧 `editDiffData`
+  - `compact`：仅显示工具名 + 简要状态摘要（一行折叠）
+    - **不**展示参数树、**不**展示 DiffViewer、**不**展示完整结果预览
   - `hidden`：完全隐藏工具调用过程，只显示 AI 回复
 - **参数**:
   - 无参数或 `status`：查看当前显示模式
@@ -79,6 +82,7 @@
 - **状态**: 持久化于 `~/.snow/theme.json`（`toolDisplayMode` 字段），实时同步至界面
 - **使用场景**: 任务中工具调用过多时降低视觉噪音，或完全隐藏工具活动以让对话聚焦于 AI 回复
 - **示例**:
+  - `/tool-display full` — 完整工具过程 + 编辑 diff
   - `/tool-display compact` — 将工具调用折叠为一行状态
   - `/tool-display hidden` — 隐藏所有工具活动
   - `/tool-display` — 查看当前模式

--- a/source/i18n/lang/en.ts
+++ b/source/i18n/lang/en.ts
@@ -973,8 +973,7 @@ export const en: TranslationKeys = {
 				sourceProject: 'source: project settings',
 				sourceGlobal: 'source: global settings',
 				sourceDefault: 'source: default (opt-in)',
-				invalid:
-					'Invalid args. Usage: /agents-inject [on|off|status]',
+				invalid: 'Invalid args. Usage: /agents-inject [on|off|status]',
 			},
 			// Tool display mode command messages
 			toolDisplay: {
@@ -1605,6 +1604,13 @@ export const en: TranslationKeys = {
 		saveSuccessMessage:
 			"Custom command '{name}' saved successfully!\nType: {type}\nLocation: {location}\nYou can now use /{name}",
 	},
+	panelChrome: {
+		loading: 'Loading…',
+		escHint: 'Press ESC to close',
+	},
+	todoTree: {
+		more: 'more',
+	},
 	chatScreen: {
 		// Header
 		headerTitle: 'Programming efficiency x10!',
@@ -2225,11 +2231,11 @@ export const en: TranslationKeys = {
 		noFilesConfirmHint: 'Enter confirm · ESC cancel',
 	},
 	contextPanel: {
-		title: 'Context Breakdown',
-		subtitle: 'system · ROLE · AGENTS · hooks · tools · messages',
-		loading: 'Loading context breakdown…',
+		title: 'Context Usage',
+		subtitle: 'system · tools · memory · skills · messages',
+		loading: 'Loading context usage…',
 		error: 'Failed: {error}',
-		hint: 'Already expanded for viewing · ↑↓ select · Enter expand · A/C all · ESC close',
+		hint: '↑↓ select · Enter/Space expand · A all · C collapse · ESC close',
 		apiLast: 'Last API prompt',
 		displayOnly: 'in sys',
 		truncated: '[trunc]',
@@ -2241,17 +2247,37 @@ export const en: TranslationKeys = {
 		colBucket: 'Bucket',
 		colTokens: 'Tokens',
 		colShare: 'Share',
+		estimatedByCategory: 'Estimated usage by category',
+		autoCompactWindow: 'Auto-compact window',
+		autoCompressOff: 'auto-compress off',
+		categories: {
+			system: 'System prompt',
+			tools: 'System tools',
+			memory: 'Memory files',
+			skills: 'Skills',
+			messages: 'Messages',
+			free: 'Free space',
+			autocompact: 'Autocompact buffer',
+		},
 		buckets: {
 			system: 'System prompt',
 			role: 'ROLE.md',
 			agents: 'AGENTS.md inject',
 			hooks: 'Hooks context',
-			tools: 'Tool definitions',
-			messages: 'Conversation',
+			tools: 'System tools',
+			skills: 'Skills',
+			messages: 'Messages',
 		},
 	},
 	usagePanel: {
 		title: 'Token Usage Statistics',
+		overview: {
+			total: 'total',
+			cacheHit: 'cache hit',
+			create: 'create',
+			models: '{count} model',
+			modelsPlural: '{count} models',
+		},
 		granularity: {
 			last24h: 'Last 24h',
 			last7d: 'Last 7d',

--- a/source/i18n/lang/zh-TW.ts
+++ b/source/i18n/lang/zh-TW.ts
@@ -918,8 +918,7 @@ export const zhTW: TranslationKeys = {
 				sourceProject: '來源: 專案設定',
 				sourceGlobal: '來源: 全域設定',
 				sourceDefault: '來源: 預設（opt-in）',
-				invalid:
-					'參數無效。用法: /agents-inject [on|off|status]',
+				invalid: '參數無效。用法: /agents-inject [on|off|status]',
 			},
 			// 工具顯示模式命令訊息
 			toolDisplay: {
@@ -1517,6 +1516,13 @@ export const zhTW: TranslationKeys = {
 		saveSuccessMessage:
 			"自訂命令 '{name}' 儲存成功！\n類型: {type}\n位置: {location}\n你現在可以使用 /{name}",
 	},
+	panelChrome: {
+		loading: '載入中…',
+		escHint: '按 ESC 關閉',
+	},
+	todoTree: {
+		more: '更多',
+	},
 	chatScreen: {
 		// Header
 		headerTitle: '程式設計效率 x10!',
@@ -2104,11 +2110,11 @@ export const zhTW: TranslationKeys = {
 		noFilesConfirmHint: 'Enter 確認 · ESC 取消',
 	},
 	contextPanel: {
-		title: '上下文拆解',
-		subtitle: 'system · ROLE · AGENTS · hooks · tools · messages',
-		loading: '正在載入上下文拆解…',
+		title: '上下文用量',
+		subtitle: 'system · tools · memory · skills · messages',
+		loading: '正在載入上下文用量…',
 		error: '失敗: {error}',
-		hint: '預設已展開可直接看 · ↑↓ 選擇 · Enter 展開 · A/C 全開/收起 · ESC 關閉',
+		hint: '↑↓ 選擇 · Enter/空白鍵 展開 · A 全開 · C 收起 · ESC 關閉',
 		apiLast: '上次 API prompt',
 		displayOnly: '計入sys',
 		truncated: '[截斷]',
@@ -2120,17 +2126,37 @@ export const zhTW: TranslationKeys = {
 		colBucket: '分桶',
 		colTokens: 'Tokens',
 		colShare: '佔比',
+		estimatedByCategory: '按類別估算用量',
+		autoCompactWindow: '自動壓縮視窗',
+		autoCompressOff: '自動壓縮關閉',
+		categories: {
+			system: 'System prompt',
+			tools: 'System tools',
+			memory: 'Memory files',
+			skills: 'Skills',
+			messages: 'Messages',
+			free: 'Free space',
+			autocompact: 'Autocompact buffer',
+		},
 		buckets: {
 			system: 'System prompt',
 			role: 'ROLE.md',
 			agents: 'AGENTS.md 注入',
 			hooks: 'Hooks 上下文',
-			tools: '工具定義',
-			messages: '對話歷史',
+			tools: 'System tools',
+			skills: 'Skills',
+			messages: 'Messages',
 		},
 	},
 	usagePanel: {
 		title: 'Token 使用統計',
+		overview: {
+			total: '總計',
+			cacheHit: '快取命中',
+			create: '建立',
+			models: '{count} 個模型',
+			modelsPlural: '{count} 個模型',
+		},
 		granularity: {
 			last24h: '最近24小時',
 			last7d: '最近7天',

--- a/source/i18n/lang/zh.ts
+++ b/source/i18n/lang/zh.ts
@@ -917,8 +917,7 @@ export const zh: TranslationKeys = {
 				sourceProject: '来源: 项目设置',
 				sourceGlobal: '来源: 全局设置',
 				sourceDefault: '来源: 默认（opt-in）',
-				invalid:
-					'参数无效。用法: /agents-inject [on|off|status]',
+				invalid: '参数无效。用法: /agents-inject [on|off|status]',
 			},
 			// 工具显示模式命令消息
 			toolDisplay: {
@@ -1516,6 +1515,13 @@ export const zh: TranslationKeys = {
 		saveSuccessMessage:
 			"自定义命令 '{name}' 保存成功！\n类型: {type}\n位置: {location}\n你现在可以使用 /{name}",
 	},
+	panelChrome: {
+		loading: '加载中…',
+		escHint: '按 ESC 关闭',
+	},
+	todoTree: {
+		more: '更多',
+	},
 	chatScreen: {
 		// Header
 		headerTitle: '编程效率 x10!',
@@ -2104,11 +2110,11 @@ export const zh: TranslationKeys = {
 		noFilesConfirmHint: 'Enter 确认 · ESC 取消',
 	},
 	contextPanel: {
-		title: '上下文拆解',
-		subtitle: 'system · ROLE · AGENTS · hooks · tools · messages',
-		loading: '正在加载上下文拆解…',
+		title: '上下文用量',
+		subtitle: 'system · tools · memory · skills · messages',
+		loading: '正在加载上下文用量…',
 		error: '失败: {error}',
-		hint: '默认已展开可直接看 · ↑↓ 选择 · Enter 展开 · A/C 全开/收起 · ESC 关闭',
+		hint: '↑↓ 选择 · Enter/空格 展开 · A 全开 · C 收起 · ESC 关闭',
 		apiLast: '上次 API prompt',
 		displayOnly: '计入sys',
 		truncated: '[截断]',
@@ -2120,17 +2126,37 @@ export const zh: TranslationKeys = {
 		colBucket: '分桶',
 		colTokens: 'Tokens',
 		colShare: '占比',
+		estimatedByCategory: '按类别估算用量',
+		autoCompactWindow: '自动压缩窗口',
+		autoCompressOff: '自动压缩关闭',
+		categories: {
+			system: 'System prompt',
+			tools: 'System tools',
+			memory: 'Memory files',
+			skills: 'Skills',
+			messages: 'Messages',
+			free: 'Free space',
+			autocompact: 'Autocompact buffer',
+		},
 		buckets: {
 			system: 'System prompt',
 			role: 'ROLE.md',
 			agents: 'AGENTS.md 注入',
 			hooks: 'Hooks 上下文',
-			tools: '工具定义',
-			messages: '对话历史',
+			tools: 'System tools',
+			skills: 'Skills',
+			messages: 'Messages',
 		},
 	},
 	usagePanel: {
 		title: 'Token 使用统计',
+		overview: {
+			total: '总计',
+			cacheHit: '缓存命中',
+			create: '创建',
+			models: '{count} 个模型',
+			modelsPlural: '{count} 个模型',
+		},
 		granularity: {
 			last24h: '最近24小时',
 			last7d: '最近7天',

--- a/source/i18n/types.ts
+++ b/source/i18n/types.ts
@@ -1,6 +1,13 @@
 export type {Language} from '../utils/config/languageConfig.js';
 
 export type TranslationKeys = {
+	panelChrome: {
+		loading: string;
+		escHint: string;
+	};
+	todoTree: {
+		more: string;
+	};
 	welcome: {
 		title: string;
 		subtitle: string;
@@ -1947,6 +1954,13 @@ export type TranslationKeys = {
 	};
 	usagePanel: {
 		title: string;
+		overview: {
+			total: string;
+			cacheHit: string;
+			create: string;
+			models: string;
+			modelsPlural: string;
+		};
 		granularity: {
 			last24h: string;
 			last7d: string;
@@ -1988,12 +2002,25 @@ export type TranslationKeys = {
 		colBucket: string;
 		colTokens: string;
 		colShare: string;
+		estimatedByCategory: string;
+		autoCompactWindow: string;
+		autoCompressOff: string;
+		categories: {
+			system: string;
+			tools: string;
+			memory: string;
+			skills: string;
+			messages: string;
+			free: string;
+			autocompact: string;
+		};
 		buckets: {
 			system: string;
 			role: string;
 			agents: string;
 			hooks: string;
 			tools: string;
+			skills: string;
 			messages: string;
 		};
 	};

--- a/source/test/context-breakdown.test.ts
+++ b/source/test/context-breakdown.test.ts
@@ -1,0 +1,67 @@
+import anyTest, {type TestFn} from 'ava';
+
+const test = anyTest as unknown as TestFn;
+
+test('context breakdown types and pure helpers are importable', async t => {
+	const mod = await import('../utils/core/contextBreakdown.js');
+	t.truthy(mod.buildContextBreakdown);
+	t.is(typeof mod.buildContextBreakdown, 'function');
+});
+
+test('buildContextBreakdown returns categories free/autocompact and skills bucket', async t => {
+	const {buildContextBreakdown} = await import(
+		'../utils/core/contextBreakdown.js'
+	);
+	const breakdown = await buildContextBreakdown({precise: false});
+
+	t.true(breakdown.maxContextTokens > 0);
+	t.true(typeof breakdown.modelName === 'string');
+	t.true(Array.isArray(breakdown.categories));
+	t.true(Array.isArray(breakdown.buckets));
+
+	const catIds = breakdown.categories.map(c => c.id);
+	for (const id of [
+		'system',
+		'tools',
+		'memory',
+		'skills',
+		'messages',
+		'free',
+		'autocompact',
+	] as const) {
+		t.true(catIds.includes(id), `missing category ${id}`);
+	}
+
+	const bucketIds = breakdown.buckets.map(b => b.id);
+	t.true(bucketIds.includes('skills'));
+	t.true(bucketIds.includes('tools'));
+	t.true(bucketIds.includes('system'));
+
+	// free + used + autocompact should cover the window (allowing used overlap with reserved buffer)
+	const free = breakdown.categories.find(c => c.id === 'free');
+	const auto = breakdown.categories.find(c => c.id === 'autocompact');
+	t.truthy(free);
+	t.truthy(auto);
+	t.true((free?.tokens ?? 0) >= 0);
+	t.true((auto?.tokens ?? 0) >= 0);
+
+	// ROLE is display-only and must not inflate totals
+	const role = breakdown.buckets.find(b => b.id === 'role');
+	if (role) {
+		t.true(role.displayOnly === true);
+	}
+
+	const counted = breakdown.buckets
+		.filter(b => !b.displayOnly)
+		.reduce((s, b) => s + b.tokens, 0);
+	t.is(counted, breakdown.totalEstimatedTokens);
+
+	// free usable + used should not exceed window
+	t.true(
+		breakdown.totalEstimatedTokens + breakdown.freeTokens +
+			breakdown.autocompactBufferTokens >=
+			breakdown.maxContextTokens - 1 ||
+			breakdown.totalEstimatedTokens + breakdown.freeTokens <=
+				breakdown.maxContextTokens,
+	);
+});

--- a/source/ui/components/chat/ChatFooter.tsx
+++ b/source/ui/components/chat/ChatFooter.tsx
@@ -366,7 +366,8 @@ const ChatFooter = React.memo(function ChatFooter(props: ChatFooterProps) {
 								fallback={
 									<Box>
 										<Text>
-											<Spinner type="dots" /> Loading...
+											<Spinner type="dots" />{' '}
+											{(t as any).panelChrome?.loading || 'Loading…'}
 										</Text>
 									</Box>
 								}
@@ -472,7 +473,7 @@ const ChatFooter = React.memo(function ChatFooter(props: ChatFooterProps) {
 						fallback={
 							<Box>
 								<Text>
-									<Spinner type="dots" /> Loading...
+									<Spinner type="dots" /> {(t as any).panelChrome?.loading || 'Loading…'}
 								</Text>
 							</Box>
 						}
@@ -502,7 +503,7 @@ const ChatFooter = React.memo(function ChatFooter(props: ChatFooterProps) {
 						fallback={
 							<Box>
 								<Text>
-									<Spinner type="dots" /> Loading...
+									<Spinner type="dots" /> {(t as any).panelChrome?.loading || 'Loading…'}
 								</Text>
 							</Box>
 						}
@@ -519,7 +520,7 @@ const ChatFooter = React.memo(function ChatFooter(props: ChatFooterProps) {
 					fallback={
 						<Box>
 							<Text>
-								<Spinner type="dots" /> Loading...
+								<Spinner type="dots" /> {(t as any).panelChrome?.loading || 'Loading…'}
 							</Text>
 						</Box>
 					}

--- a/source/ui/components/chat/MessageRenderer.tsx
+++ b/source/ui/components/chat/MessageRenderer.tsx
@@ -478,12 +478,14 @@ function MessageRendererImpl({
 											const branch = isLast ? '└─' : '├─';
 											return (
 												<Box key={ti}>
-													<Text color="magenta" dimColor>
+													<Text color={theme.colors.menuInfo} dimColor>
 														{branch}{' '}
 													</Text>
-													<Text color="magenta">{target.agentName}</Text>
+													<Text color={theme.colors.menuInfo}>
+														{target.agentName}
+													</Text>
 													{target.promptSnippet ? (
-														<Text color="gray" dimColor>
+														<Text color={theme.colors.menuSecondary} dimColor>
 															{' '}
 															{target.promptSnippet}
 														</Text>
@@ -625,12 +627,12 @@ function MessageRendererImpl({
 																	'\u2591'.repeat(empty);
 																const barColor =
 																	pct >= 80
-																		? 'red'
+																		? theme.colors.error
 																		: pct >= 65
-																		? 'yellow'
+																		? theme.colors.warning
 																		: pct >= 50
-																		? 'cyan'
-																		: 'gray';
+																		? theme.colors.cyan
+																		: theme.colors.menuSecondary;
 																return (
 																	<Text color={barColor} dimColor>
 																		{'└─ Context: '}
@@ -748,11 +750,17 @@ function MessageRendererImpl({
 												))}
 											</Box>
 										)}
+									{/* DiffViewer for create/edit: full mode only (pending + success).
+                                                                    Success attaches editDiffData as toolCall.arguments; without success support,
+                                                                    full mode suppresses ToolResultPreview (has diff) but never shows DiffViewer.
+                                                                    compact = title + summary only; hidden = no tools. Do not invent a 4th tier. */}
 									{message.toolCall &&
 										message.toolCall.name === 'filesystem-create' &&
 										!message.toolCall.arguments.isBatch &&
 										message.toolCall.arguments.content &&
-										message.messageStatus === 'pending' && (
+										(message.messageStatus === 'pending' ||
+											message.messageStatus === 'success') &&
+										toolDisplayMode === 'full' && (
 											<Box marginTop={1}>
 												<DiffViewer
 													newContent={message.toolCall.arguments.content}
@@ -765,7 +773,9 @@ function MessageRendererImpl({
 											message.toolCall.name === 'filesystem-replaceedit') &&
 										typeof message.toolCall.arguments.oldContent === 'string' &&
 										typeof message.toolCall.arguments.newContent === 'string' &&
-										message.messageStatus === 'pending' && (
+										(message.messageStatus === 'pending' ||
+											message.messageStatus === 'success') &&
+										toolDisplayMode === 'full' && (
 											<Box marginTop={1}>
 												<DiffViewer
 													oldContent={message.toolCall.arguments.oldContent}
@@ -783,14 +793,16 @@ function MessageRendererImpl({
 												/>
 											</Box>
 										)}
-									{/* Show batch edit results (pending only — success uses tool result) */}
+									{/* Batch edit results — pending preview + success final diff */}
 									{message.toolCall &&
 										(message.toolCall.name === 'filesystem-edit' ||
 											message.toolCall.name === 'filesystem-replaceedit') &&
 										message.toolCall.arguments.isBatch &&
 										message.toolCall.arguments.batchResults &&
 										Array.isArray(message.toolCall.arguments.batchResults) &&
-										message.messageStatus === 'pending' && (
+										(message.messageStatus === 'pending' ||
+											message.messageStatus === 'success') &&
+										toolDisplayMode === 'full' && (
 											<Box marginTop={1} flexDirection="column">
 												{message.toolCall.arguments.batchResults.map(
 													(fileResult: any, index: number) => {
@@ -831,13 +843,15 @@ function MessageRendererImpl({
 												)}
 											</Box>
 										)}
-									{/* Show batch create results (pending only — success uses tool result) */}
+									{/* Batch create results — pending preview + success final diff */}
 									{message.toolCall &&
 										message.toolCall.name === 'filesystem-create' &&
 										message.toolCall.arguments.isBatch &&
 										message.toolCall.arguments.batchResults &&
 										Array.isArray(message.toolCall.arguments.batchResults) &&
-										message.messageStatus === 'pending' && (
+										(message.messageStatus === 'pending' ||
+											message.messageStatus === 'success') &&
+										toolDisplayMode === 'full' && (
 											<Box marginTop={1} flexDirection="column">
 												{message.toolCall.arguments.batchResults.map(
 													(fileResult: any, index: number) => {

--- a/source/ui/components/common/PanelChrome.tsx
+++ b/source/ui/components/common/PanelChrome.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {Box, Text} from 'ink';
+import Spinner from 'ink-spinner';
+import {useTheme} from '../../contexts/ThemeContext.js';
+import {useI18n} from '../../../i18n/index.js';
+
+type PanelChromeProps = {
+	title: string;
+	subtitle?: string;
+	hint?: string;
+	loading?: boolean;
+	loadingLabel?: string;
+	error?: string | null;
+	width?: number;
+	children?: React.ReactNode;
+	/** When false, omit outer border (inline panels). Default true. */
+	bordered?: boolean;
+};
+
+/**
+ * Shared panel shell: rounded border, title row, loading/error states, footer hint.
+ */
+export function PanelChrome({
+	title,
+	subtitle,
+	hint,
+	loading,
+	loadingLabel,
+	error,
+	width,
+	children,
+	bordered = true,
+}: PanelChromeProps) {
+	const {theme} = useTheme();
+	const {t} = useI18n();
+	const tp = (t as any).panelChrome || {};
+	const resolvedLoading =
+		loadingLabel || tp.loading || t.workingDirectoryPanel?.loading || 'Loading…';
+	const escHint = hint || tp.escHint || t.chatScreen?.pressEscToClose;
+
+	if (loading) {
+		return (
+			<Box
+				borderStyle={bordered ? 'round' : undefined}
+				borderColor={theme.colors.menuInfo}
+				paddingX={2}
+				width={width}
+			>
+				<Text color={theme.colors.menuSecondary}>
+					<Spinner type="dots" /> {resolvedLoading}
+				</Text>
+			</Box>
+		);
+	}
+
+	if (error) {
+		return (
+			<Box
+				borderStyle={bordered ? 'round' : undefined}
+				borderColor={theme.colors.error}
+				paddingX={2}
+				width={width}
+			>
+				<Text color={theme.colors.error}>{error}</Text>
+			</Box>
+		);
+	}
+
+	return (
+		<Box
+			borderStyle={bordered ? 'round' : undefined}
+			borderColor={theme.colors.menuInfo}
+			paddingX={2}
+			paddingY={bordered ? 1 : 0}
+			flexDirection="column"
+			width={width}
+		>
+			<Box>
+				<Text color={theme.colors.menuInfo} bold>
+					{title}
+				</Text>
+				{subtitle ? (
+					<Text color={theme.colors.menuSecondary} dimColor>
+						{'  '}
+						{subtitle}
+					</Text>
+				) : null}
+			</Box>
+			{children}
+			{escHint ? (
+				<Box marginTop={1}>
+					<Text color={theme.colors.menuSecondary} dimColor>
+						{escHint}
+					</Text>
+				</Box>
+			) : null}
+		</Box>
+	);
+}
+
+export function PanelLoadingFallback({label}: {label?: string}) {
+	const {theme} = useTheme();
+	const {t} = useI18n();
+	const tp = (t as any).panelChrome || {};
+	const text = label || tp.loading || 'Loading…';
+	return (
+		<Box>
+			<Text color={theme.colors.menuSecondary}>
+				<Spinner type="dots" /> {text}
+			</Text>
+		</Box>
+	);
+}
+
+export default PanelChrome;

--- a/source/ui/components/common/StatusLine.tsx
+++ b/source/ui/components/common/StatusLine.tsx
@@ -32,6 +32,11 @@ import type {
 	VSCodeConnectionStatus,
 } from './statusline/types.js';
 import {GradientText} from './statusline/GradientText.js';
+import {
+	formatTokenBar,
+	formatTokens,
+	pctColorName,
+} from '../../utils/formatTokens.js';
 
 const MEMORY_REFRESH_INTERVAL_MS = 5000;
 const PROCESS_MEMORY_COMMAND_TIMEOUT_MS = 1500;
@@ -541,31 +546,38 @@ export default function StatusLine({
 		const {
 			percentage,
 			totalInputTokens,
+			maxContextTokens,
 			hasAnthropicCache,
 			hasOpenAICache,
 			hasAnyCache,
 			cacheReadTokens = 0,
 			cacheCreationTokens = 0,
 			cachedTokens = 0,
-		} = contextWindowState;
+		} = contextWindowState as StatusLineContextUsage &
+			StatusLineContextWindowMetrics & {maxContextTokens?: number};
 
-		let color: string;
-		if (percentage < 50) color = theme.colors.success;
-		else if (percentage < 75) color = theme.colors.warning;
-		else if (percentage < 90) color = theme.colors.warning;
-		else color = theme.colors.error;
-
-		const formatNumber = (num: number) => {
-			if (num >= 1000) return `${(num / 1000).toFixed(1)}k`;
-			return num.toString();
-		};
+		const colorKey = pctColorName(percentage);
+		const color = theme.colors[colorKey];
+		const miniBar = formatTokenBar(percentage, simpleMode ? 8 : 12);
+		const maxLabel =
+			typeof maxContextTokens === 'number' && maxContextTokens > 0
+				? formatTokens(maxContextTokens, true)
+				: null;
 
 		return (
 			<Text color={theme.colors.menuSecondary} dimColor>
-				<Text color={color}>{percentage.toFixed(1)}%</Text>
+				<Text color={color}>{miniBar}</Text>
+				<Text> </Text>
+				<Text color={color} bold>
+					{percentage.toFixed(0)}%
+				</Text>
 				<Text> · </Text>
-				<Text color={color}>{formatNumber(totalInputTokens)}</Text>
-				<Text>{t.chatScreen.tokens}</Text>
+				<Text color={color}>{formatTokens(totalInputTokens, true)}</Text>
+				{maxLabel ? (
+					<Text color={theme.colors.menuSecondary}>/{maxLabel}</Text>
+				) : (
+					<Text>{t.chatScreen.tokens}</Text>
+				)}
 				{hasAnyCache && (
 					<>
 						<Text> · </Text>
@@ -573,14 +585,15 @@ export default function StatusLine({
 							<>
 								{cacheReadTokens > 0 && (
 									<Text color={theme.colors.menuInfo}>
-										↯ {formatNumber(cacheReadTokens)} {t.chatScreen.cached}
+										↯ {formatTokens(cacheReadTokens, true)}{' '}
+										{t.chatScreen.cached}
 									</Text>
 								)}
 								{cacheCreationTokens > 0 && (
 									<>
 										{cacheReadTokens > 0 && <Text> · </Text>}
 										<Text color={theme.colors.warning}>
-											◆ {formatNumber(cacheCreationTokens)}{' '}
+											◆ {formatTokens(cacheCreationTokens, true)}{' '}
 											{t.chatScreen.newCache}
 										</Text>
 									</>
@@ -589,7 +602,7 @@ export default function StatusLine({
 						)}
 						{hasOpenAICache && (
 							<Text color={theme.colors.menuInfo}>
-								↯ {formatNumber(cachedTokens)} {t.chatScreen.cached}
+								↯ {formatTokens(cachedTokens, true)} {t.chatScreen.cached}
 							</Text>
 						)}
 					</>

--- a/source/ui/components/panels/ContextPanel.tsx
+++ b/source/ui/components/panels/ContextPanel.tsx
@@ -8,6 +8,8 @@ import {
 	type ContextBreakdown,
 	type ContextBucket,
 	type ContextBucketId,
+	type ContextCategory,
+	type ContextCategoryId,
 } from '../../../utils/core/contextBreakdown.js';
 
 function formatTokens(n: number): string {
@@ -29,6 +31,36 @@ function bar(
 	);
 }
 
+/** Dot-grid visualization similar to the screenshot reference. */
+function dotGrid(
+	categories: ContextCategory[],
+	totalDots: number,
+): Array<{id: ContextCategoryId; char: string}> {
+	const dots: Array<{id: ContextCategoryId; char: string}> = [];
+	const usable = categories.filter(c => c.tokens > 0 || c.synthetic);
+	let assigned = 0;
+	for (let i = 0; i < usable.length; i++) {
+		const cat = usable[i]!;
+		const isLast = i === usable.length - 1;
+		const count = isLast
+			? Math.max(0, totalDots - assigned)
+			: Math.max(
+					cat.percentage > 0 ? 1 : 0,
+					Math.round((cat.percentage / 100) * totalDots),
+			  );
+		const capped = Math.min(count, totalDots - assigned);
+		for (let d = 0; d < capped; d++) {
+			dots.push({id: cat.id, char: '●'});
+		}
+		assigned += capped;
+		if (assigned >= totalDots) break;
+	}
+	while (dots.length < totalDots) {
+		dots.push({id: 'free', char: '○'});
+	}
+	return dots;
+}
+
 function pctColor(
 	pct: number,
 	theme: {colors: {success: string; warning: string; error: string}},
@@ -38,9 +70,38 @@ function pctColor(
 	return theme.colors.error;
 }
 
-function bucketShare(bucket: ContextBucket, total: number): number {
-	if (bucket.displayOnly || total <= 0) return 0;
-	return (bucket.tokens / total) * 100;
+function categoryColor(
+	id: ContextCategoryId,
+	theme: {
+		colors: {
+			success: string;
+			warning: string;
+			error: string;
+			menuInfo: string;
+			menuSecondary: string;
+			cyan: string;
+			diffModified: string;
+		};
+	},
+): string {
+	switch (id) {
+		case 'system':
+			return theme.colors.menuInfo;
+		case 'tools':
+			return theme.colors.cyan;
+		case 'memory':
+			return theme.colors.warning;
+		case 'skills':
+			return theme.colors.diffModified || theme.colors.menuInfo;
+		case 'messages':
+			return theme.colors.success;
+		case 'free':
+			return theme.colors.menuSecondary;
+		case 'autocompact':
+			return theme.colors.warning;
+		default:
+			return theme.colors.menuSecondary;
+	}
 }
 
 function pad(text: string, width: number): string {
@@ -54,6 +115,12 @@ function padLeft(text: string, width: number): string {
 }
 
 type Row =
+	| {
+			kind: 'category';
+			key: string;
+			category: ContextCategory;
+			canExpand: boolean;
+	  }
 	| {
 			kind: 'bucket';
 			key: string;
@@ -87,14 +154,21 @@ export default function ContextPanel() {
 	// Only show selection cursor after user presses keys (view-first UX)
 	const [navActive, setNavActive] = useState(false);
 	const [scrollOffset, setScrollOffset] = useState(0);
-	// Default expand AGENTS/tools/ROLE so pure viewing shows content
+	// Default: collapsed summary (screenshot style). Expand on demand.
 	const [expanded, setExpanded] = useState<Record<string, boolean>>({
-		agents: true,
-		tools: true,
-		role: true,
 		system: false,
+		role: false,
+		agents: false,
 		hooks: false,
+		tools: false,
+		skills: false,
 		messages: false,
+		// category-level expand keys
+		'cat-system': false,
+		'cat-tools': false,
+		'cat-memory': false,
+		'cat-skills': false,
+		'cat-messages': false,
 	});
 
 	const tp = (t as any).contextPanel || {};
@@ -123,42 +197,80 @@ export default function ContextPanel() {
 		};
 	}, []);
 
+	const bucketById = useMemo(() => {
+		const map = new Map<ContextBucketId, ContextBucket>();
+		if (!data) return map;
+		for (const b of data.buckets) map.set(b.id, b);
+		return map;
+	}, [data]);
+
 	const rows: Row[] = useMemo(() => {
 		if (!data) return [];
 		const out: Row[] = [];
-		for (const bucket of data.buckets) {
-			const canExpand = Boolean(bucket.files && bucket.files.length > 0);
+
+		for (const category of data.categories) {
+			const sourceIds = category.sourceBucketIds || [];
+			const canExpand =
+				!category.synthetic &&
+				sourceIds.some(id => {
+					const b = bucketById.get(id);
+					return Boolean(b && ((b.files && b.files.length > 0) || b.meta));
+				});
 			out.push({
-				kind: 'bucket',
-				key: `b-${bucket.id}`,
-				bucket,
+				kind: 'category',
+				key: `c-${category.id}`,
+				category,
 				canExpand,
 			});
-			const isOpen = expanded[bucket.id] ?? false;
-			if (canExpand && isOpen && bucket.files) {
-				if (bucket.meta) {
+
+			const catOpen = expanded[`cat-${category.id}`] ?? false;
+			if (!canExpand || !catOpen) continue;
+
+			for (const bucketId of sourceIds) {
+				const bucket = bucketById.get(bucketId);
+				if (!bucket) continue;
+				const bucketCanExpand = Boolean(
+					bucket.files && bucket.files.length > 0,
+				);
+				out.push({
+					kind: 'bucket',
+					key: `b-${bucket.id}`,
+					bucket,
+					canExpand: bucketCanExpand,
+				});
+
+				const isOpen = expanded[bucket.id] ?? false;
+				if (bucketCanExpand && isOpen && bucket.files) {
+					if (bucket.meta) {
+						out.push({
+							kind: 'meta',
+							key: `m-${bucket.id}`,
+							text: bucket.meta,
+						});
+					}
+					for (const file of bucket.files) {
+						out.push({
+							kind: 'file',
+							key: `f-${bucket.id}-${file.label}`,
+							bucketId: bucket.id,
+							label: file.label,
+							tokens: file.tokens,
+							included: file.included,
+							truncated: file.truncated,
+							note: file.note,
+						});
+					}
+				} else if (!isOpen && bucket.meta) {
 					out.push({
 						kind: 'meta',
-						key: `m-${bucket.id}`,
-						text: bucket.meta,
-					});
-				}
-				for (const file of bucket.files) {
-					out.push({
-						kind: 'file',
-						key: `f-${bucket.id}-${file.label}`,
-						bucketId: bucket.id,
-						label: file.label,
-						tokens: file.tokens,
-						included: file.included,
-						truncated: file.truncated,
-						note: file.note,
+						key: `m-${bucket.id}-closed`,
+						text: bucket.meta + (bucket.detail ? ` · ${bucket.detail}` : ''),
 					});
 				}
 			}
 		}
 		return out;
-	}, [data, expanded]);
+	}, [data, expanded, bucketById]);
 
 	// Keep cursor in range when rows change
 	useEffect(() => {
@@ -168,16 +280,12 @@ export default function ContextPanel() {
 	}, [rows.length, cursor]);
 
 	const panelWidth = Math.min(Math.max(terminalWidth - 4, 56), 96);
-	const labelWidth = 20;
-	const tokenWidth = 7;
+	const labelWidth = 22;
+	const tokenWidth = 8;
 	const pctWidth = 7;
-	const barWidth = Math.max(
-		10,
-		Math.min(28, panelWidth - labelWidth - tokenWidth - pctWidth - 10),
-	);
 
-	// Header takes ~6 lines; leave room for footer hint
-	const visibleRows = Math.max(8, Math.min(terminalHeight - 12, 22));
+	// Header takes ~10 lines (title + model + grid + footer); leave room for hint
+	const visibleRows = Math.max(8, Math.min(terminalHeight - 16, 22));
 
 	// Keep cursor visible in scroll window only when navigating
 	useEffect(() => {
@@ -188,7 +296,7 @@ export default function ContextPanel() {
 		}
 	}, [cursor, scrollOffset, visibleRows, navActive]);
 
-	const toggleBucket = (id: string) => {
+	const toggleKey = (id: string) => {
 		setExpanded(prev => ({
 			...prev,
 			[id]: !Boolean(prev[id]),
@@ -198,6 +306,9 @@ export default function ContextPanel() {
 	const expandAll = (open: boolean) => {
 		if (!data) return;
 		const next: Record<string, boolean> = {};
+		for (const c of data.categories) {
+			if (!c.synthetic) next[`cat-${c.id}`] = open;
+		}
 		for (const b of data.buckets) {
 			if (b.files && b.files.length > 0) next[b.id] = open;
 		}
@@ -220,22 +331,27 @@ export default function ContextPanel() {
 			return;
 		}
 		if (key.return || input === ' ') {
-			// Without prior navigation: toggle the first expandable bucket under viewport
 			if (!navActive) {
 				const firstExpandable = rows.find(
-					r => r.kind === 'bucket' && r.canExpand,
+					r =>
+						(r.kind === 'category' && r.canExpand) ||
+						(r.kind === 'bucket' && r.canExpand),
 				);
-				if (firstExpandable && firstExpandable.kind === 'bucket') {
-					toggleBucket(firstExpandable.bucket.id);
+				if (firstExpandable?.kind === 'category') {
+					toggleKey(`cat-${firstExpandable.category.id}`);
+				} else if (firstExpandable?.kind === 'bucket') {
+					toggleKey(firstExpandable.bucket.id);
 				}
 				return;
 			}
 			const row = rows[cursor];
 			if (!row) return;
-			if (row.kind === 'bucket' && row.canExpand) {
-				toggleBucket(row.bucket.id);
+			if (row.kind === 'category' && row.canExpand) {
+				toggleKey(`cat-${row.category.id}`);
+			} else if (row.kind === 'bucket' && row.canExpand) {
+				toggleKey(row.bucket.id);
 			} else if (row.kind === 'file') {
-				toggleBucket(row.bucketId);
+				toggleKey(row.bucketId);
 			}
 			return;
 		}
@@ -248,10 +364,7 @@ export default function ContextPanel() {
 			return;
 		}
 		if (key.tab) {
-			// Toggle all expandable sections
-			const anyOpen = data?.buckets.some(
-				b => (b.files?.length ?? 0) > 0 && (expanded[b.id] ?? false),
-			);
+			const anyOpen = Object.values(expanded).some(Boolean);
 			expandAll(!anyOpen);
 		}
 	});
@@ -260,7 +373,7 @@ export default function ContextPanel() {
 		return (
 			<Box borderStyle="round" borderColor={theme.colors.menuInfo} paddingX={2}>
 				<Text color={theme.colors.menuSecondary}>
-					{tp.loading || 'Loading context breakdown…'}
+					{tp.loading || 'Loading context usage…'}
 				</Text>
 			</Box>
 		);
@@ -290,6 +403,20 @@ export default function ContextPanel() {
 			? tp.precise || 'precise'
 			: tp.estimate || 'estimate';
 
+	const gridCols = Math.min(20, Math.max(12, Math.floor((panelWidth - 6) / 2)));
+	const gridRows = 4;
+	const gridDots = dotGrid(data.categories, gridCols * gridRows);
+
+	const categoryLabel = (cat: ContextCategory) => {
+		const fromI18n = tp.categories?.[cat.id];
+		if (fromI18n) return fromI18n;
+		return cat.label;
+	};
+
+	const bucketLabel = (bucket: ContextBucket) => {
+		return (tp.buckets && tp.buckets[bucket.id]) || bucket.label;
+	};
+
 	return (
 		<Box
 			borderStyle="round"
@@ -302,24 +429,50 @@ export default function ContextPanel() {
 			{/* Title */}
 			<Box>
 				<Text color={theme.colors.menuInfo} bold>
-					{tp.title || 'Context Breakdown'}
+					/context
 				</Text>
 				<Text color={theme.colors.menuSecondary} dimColor>
+					{'  '}
+					{tp.title || 'Context Usage'}
 					{'  '}[{estimateLabel}]
 				</Text>
 			</Box>
 
-			{/* Window usage */}
+			{/* Model + used/max */}
 			<Box marginTop={1}>
+				<Text color={theme.colors.menuInfo} bold>
+					{data.modelName}
+				</Text>
+			</Box>
+			<Box>
 				<Text color={headerColor} bold>
-					{padLeft(data.percentage.toFixed(1) + '%', 6)}
+					{formatTokens(data.totalEstimatedTokens)}/
+					{formatTokens(data.maxContextTokens)} tokens
 				</Text>
-				<Text color={headerColor}> {bar(data.percentage, windowBarWidth)}</Text>
-				<Text color={theme.colors.menuSecondary}>
-					{' '}
-					{formatTokens(data.totalEstimatedTokens)} /{' '}
-					{formatTokens(data.maxContextTokens)}
+				<Text color={headerColor}>
+					{'  '}({data.percentage.toFixed(0)}%)
 				</Text>
+			</Box>
+			<Box>
+				<Text color={headerColor}>{bar(data.percentage, windowBarWidth)}</Text>
+			</Box>
+
+			{/* Dot grid */}
+			<Box marginTop={1} flexDirection="column">
+				{Array.from({length: gridRows}, (_, rowIdx) => (
+					<Box key={`grid-row-${rowIdx}`}>
+						{gridDots
+							.slice(rowIdx * gridCols, rowIdx * gridCols + gridCols)
+							.map((dot, colIdx) => (
+								<Text
+									key={`d-${rowIdx}-${colIdx}`}
+									color={categoryColor(dot.id, theme)}
+								>
+									{dot.char}{' '}
+								</Text>
+							))}
+					</Box>
+				))}
 			</Box>
 
 			{typeof data.apiPromptTokens === 'number' && (
@@ -332,22 +485,12 @@ export default function ContextPanel() {
 				</Text>
 			)}
 
-			{/* Column header */}
+			{/* Category legend header */}
 			<Box marginTop={1}>
 				<Text color={theme.colors.menuSecondary} dimColor>
-					{pad(tp.colBucket || 'Bucket', labelWidth)} {pad('', barWidth)}{' '}
-					{padLeft(tp.colTokens || 'Tokens', tokenWidth)}{' '}
-					{padLeft(tp.colShare || 'Share', pctWidth)}
+					{tp.estimatedByCategory || 'Estimated usage by category'}
 				</Text>
 			</Box>
-			<Text color={theme.colors.menuSecondary} dimColor>
-				{'─'.repeat(
-					Math.min(
-						panelWidth - 4,
-						labelWidth + barWidth + tokenWidth + pctWidth + 4,
-					),
-				)}
-			</Text>
 
 			{hiddenAbove > 0 && (
 				<Text color={theme.colors.menuSecondary} dimColor>
@@ -400,52 +543,52 @@ export default function ContextPanel() {
 					);
 				}
 
-				// bucket row
-				const bucket = row.bucket;
-				const share = bucketShare(bucket, data.totalEstimatedTokens);
-				const ofWindow =
-					data.maxContextTokens > 0
-						? (bucket.tokens / data.maxContextTokens) * 100
-						: 0;
-				const color = bucket.displayOnly
-					? theme.colors.menuSecondary
-					: selected
-					? theme.colors.menuInfo
-					: pctColor(ofWindow, theme);
-				const label = (tp.buckets && tp.buckets[bucket.id]) || bucket.label;
-				const isOpen = expanded[bucket.id] ?? false;
-				const chevron = row.canExpand ? (isOpen ? '▼' : '▶') : ' ';
-				const shareText = bucket.displayOnly
-					? tp.displayOnly || 'in sys'
-					: `${share.toFixed(1)}%`;
-
-				return (
-					<Box key={row.key} flexDirection="column">
-						<Box>
-							<Text color={color} bold={selected || !bucket.displayOnly}>
-								{marker}
-								{chevron} {pad(label, labelWidth - 2)}
-							</Text>
-							<Text color={color}>
-								{bar(bucket.displayOnly ? 0 : share, barWidth)}
-							</Text>
-							<Text color={color}>
-								{' '}
-								{padLeft(formatTokens(bucket.tokens), tokenWidth)}
+				if (row.kind === 'bucket') {
+					const bucket = row.bucket;
+					const isOpen = expanded[bucket.id] ?? false;
+					const chevron = row.canExpand ? (isOpen ? '▼' : '▶') : ' ';
+					const color = bucket.displayOnly
+						? theme.colors.menuSecondary
+						: selected
+						? theme.colors.menuInfo
+						: theme.colors.menuSecondary;
+					return (
+						<Box key={row.key}>
+							<Text color={color} bold={selected}>
+								{marker} {chevron} {bucketLabel(bucket)}
 							</Text>
 							<Text color={theme.colors.menuSecondary} dimColor>
-								{' '}
-								{padLeft(shareText, pctWidth)}
+								{'  '}
+								{formatTokens(bucket.tokens)}
+								{bucket.displayOnly ? ` · ${tp.displayOnly || 'in sys'}` : ''}
 							</Text>
 						</Box>
-						{/* Compact meta under closed buckets only when not expanded */}
-						{!isOpen && bucket.meta && (
-							<Text color={theme.colors.menuSecondary} dimColor>
-								{'    '}
-								{bucket.meta}
-								{bucket.detail ? ` · ${bucket.detail}` : ''}
-							</Text>
-						)}
+					);
+				}
+
+				// category row (screenshot-style)
+				const cat = row.category;
+				const color = selected
+					? theme.colors.menuInfo
+					: categoryColor(cat.id, theme);
+				const isOpen = expanded[`cat-${cat.id}`] ?? false;
+				const chevron = row.canExpand ? (isOpen ? '▼' : '▶') : ' ';
+				const icon =
+					cat.id === 'free' ? '○' : cat.id === 'autocompact' ? '◌' : '●';
+
+				return (
+					<Box key={row.key}>
+						<Text color={color} bold={selected || !cat.synthetic}>
+							{marker}
+							{chevron} {icon} {pad(categoryLabel(cat), labelWidth - 4)}
+						</Text>
+						<Text color={color}>
+							{padLeft(formatTokens(cat.tokens), tokenWidth)}
+						</Text>
+						<Text color={theme.colors.menuSecondary} dimColor>
+							{' '}
+							{padLeft(`${cat.percentage.toFixed(1)}%`, pctWidth)}
+						</Text>
 					</Box>
 				);
 			})}
@@ -456,7 +599,15 @@ export default function ContextPanel() {
 				</Text>
 			)}
 
-			<Box marginTop={1}>
+			{/* Footer: auto-compact window */}
+			<Box marginTop={1} flexDirection="column">
+				<Text color={theme.colors.menuSecondary} dimColor>
+					{(tp.autoCompactWindow || 'Auto-compact window') + ': '}
+					{formatTokens(data.maxContextTokens)} tokens
+					{data.enableAutoCompress
+						? ` · threshold ${data.autoCompressThreshold}%`
+						: ` · ${tp.autoCompressOff || 'off'}`}
+				</Text>
 				<Text color={theme.colors.menuSecondary} dimColor>
 					{tp.hint ||
 						'↑↓ select · Enter/Space expand · A all · C collapse · ESC close'}

--- a/source/ui/components/panels/HelpPanel.tsx
+++ b/source/ui/components/panels/HelpPanel.tsx
@@ -1,8 +1,8 @@
 import React, {useState, useMemo} from 'react';
 import {Box, Text, useInput} from 'ink';
 import {useI18n} from '../../../i18n/index.js';
-
-const MAX_VISIBLE_LINES = 10;
+import {useTheme} from '../../contexts/ThemeContext.js';
+import {useTerminalSize} from '../../../hooks/ui/useTerminalSize.js';
 
 // Get platform-specific paste key
 const getPasteKey = () => {
@@ -10,23 +10,47 @@ const getPasteKey = () => {
 };
 
 type HelpLine =
-	| {type: 'title'; text: string; color: string}
+	| {
+			type: 'title';
+			text: string;
+			colorKey: 'info' | 'warning' | 'success' | 'cyan' | 'menu';
+	  }
 	| {type: 'item'; text: string; dim?: boolean}
 	| {type: 'spacer'};
 
 export default function HelpPanel() {
 	const pasteKey = getPasteKey();
 	const {t} = useI18n();
+	const {theme} = useTheme();
+	const {rows: terminalHeight} = useTerminalSize();
+
+	const colorFor = (
+		key: 'info' | 'warning' | 'success' | 'cyan' | 'menu',
+	): string => {
+		switch (key) {
+			case 'warning':
+				return theme.colors.warning;
+			case 'success':
+				return theme.colors.success;
+			case 'cyan':
+				return theme.colors.cyan;
+			case 'menu':
+				return theme.colors.menuInfo;
+			case 'info':
+			default:
+				return theme.colors.menuInfo;
+		}
+	};
 
 	const lines: HelpLine[] = useMemo(() => {
 		const result: HelpLine[] = [];
-		result.push({type: 'title', text: t.helpPanel.title, color: 'cyan'});
+		result.push({type: 'title', text: t.helpPanel.title, colorKey: 'info'});
 		result.push({type: 'spacer'});
 
 		result.push({
 			type: 'title',
 			text: t.helpPanel.textEditingTitle,
-			color: 'yellow',
+			colorKey: 'warning',
 		});
 		result.push({type: 'item', text: ` • ${t.helpPanel.deleteToStart}`});
 		result.push({type: 'item', text: ` • ${t.helpPanel.deleteToEnd}`});
@@ -41,7 +65,7 @@ export default function HelpPanel() {
 		result.push({
 			type: 'title',
 			text: t.helpPanel.readlineTitle,
-			color: 'cyan',
+			colorKey: 'cyan',
 		});
 		result.push({type: 'item', text: ` • ${t.helpPanel.moveToLineStart}`});
 		result.push({type: 'item', text: ` • ${t.helpPanel.moveToLineEnd}`});
@@ -56,7 +80,7 @@ export default function HelpPanel() {
 		result.push({
 			type: 'title',
 			text: t.helpPanel.quickAccessTitle,
-			color: 'green',
+			colorKey: 'success',
 		});
 		result.push({type: 'item', text: ` • ${t.helpPanel.insertFiles}`});
 		result.push({type: 'item', text: ` • ${t.helpPanel.searchContent}`});
@@ -67,7 +91,7 @@ export default function HelpPanel() {
 		result.push({
 			type: 'title',
 			text: t.helpPanel.bashModeTitle,
-			color: 'yellow',
+			colorKey: 'warning',
 		});
 		result.push({type: 'item', text: ` • ${t.helpPanel.bashModeTrigger}`});
 		result.push({
@@ -80,7 +104,7 @@ export default function HelpPanel() {
 		result.push({
 			type: 'title',
 			text: t.helpPanel.navigationTitle,
-			color: 'blue',
+			colorKey: 'menu',
 		});
 		result.push({type: 'item', text: ` • ${t.helpPanel.navigateHistory}`});
 		result.push({type: 'item', text: ` • ${t.helpPanel.selectItem}`});
@@ -91,7 +115,7 @@ export default function HelpPanel() {
 		result.push({
 			type: 'title',
 			text: t.helpPanel.tipsTitle,
-			color: 'magenta',
+			colorKey: 'info',
 		});
 		result.push({type: 'item', text: ` • ${t.helpPanel.tipUseHelp}`});
 		result.push({type: 'item', text: ` • ${t.helpPanel.tipShowCommands}`});
@@ -100,7 +124,11 @@ export default function HelpPanel() {
 		return result;
 	}, [t, pasteKey]);
 
-	const maxVisible = Math.min(lines.length, MAX_VISIBLE_LINES);
+	// Adaptive height: leave room for chrome + scroll hints
+	const maxVisible = Math.max(
+		8,
+		Math.min(lines.length, Math.max(10, terminalHeight - 8)),
+	);
 	const canScroll = lines.length > maxVisible;
 
 	const [offset, setOffset] = useState(0);
@@ -132,13 +160,17 @@ export default function HelpPanel() {
 		}
 		if (line.type === 'title') {
 			return (
-				<Text key={`line-${index}`} bold color={line.color}>
+				<Text key={`line-${index}`} bold color={colorFor(line.colorKey)}>
 					{line.text}
 				</Text>
 			);
 		}
 		return (
-			<Text key={`line-${index}`} dimColor={line.dim}>
+			<Text
+				key={`line-${index}`}
+				color={theme.colors.menuSecondary}
+				dimColor={line.dim}
+			>
 				{line.text}
 			</Text>
 		);
@@ -147,19 +179,19 @@ export default function HelpPanel() {
 	return (
 		<Box flexDirection="column" paddingX={1}>
 			{canScroll && hiddenAbove > 0 && (
-				<Text color="gray" dimColor>
+				<Text color={theme.colors.menuSecondary} dimColor>
 					↑ {t.commandPanel.moreAbove.replace('{count}', String(hiddenAbove))}
 				</Text>
 			)}
 			{visibleLines.map((line, idx) => renderLine(line, clampedOffset + idx))}
 			{canScroll && hiddenBelow > 0 && (
-				<Text color="gray" dimColor>
+				<Text color={theme.colors.menuSecondary} dimColor>
 					↓ {t.commandPanel.moreBelow.replace('{count}', String(hiddenBelow))}
 				</Text>
 			)}
 			{canScroll && (
 				<Box marginTop={1}>
-					<Text color="gray" dimColor>
+					<Text color={theme.colors.menuSecondary} dimColor>
 						{t.commandPanel.scrollHint}
 					</Text>
 				</Box>

--- a/source/ui/components/panels/MCPInfoPanel.tsx
+++ b/source/ui/components/panels/MCPInfoPanel.tsx
@@ -29,6 +29,8 @@ interface ToolsListProps {
 	disabledLabel?: string;
 	scopeLabels?: Record<string, string>;
 	toolScopeMap?: Record<string, string>;
+	moreAboveLabel?: string;
+	moreBelowLabel?: string;
 }
 
 function ToolsList({
@@ -39,6 +41,8 @@ function ToolsList({
 	disabledLabel,
 	scopeLabels,
 	toolScopeMap,
+	moreAboveLabel,
+	moreBelowLabel,
 }: ToolsListProps) {
 	const {theme} = useTheme();
 	// Calculate display window for scrolling
@@ -74,7 +78,10 @@ function ToolsList({
 		<Box flexDirection="column">
 			{displayWindow.hiddenAbove > 0 && (
 				<Text color={theme.colors.menuSecondary} dimColor>
-					↑ {displayWindow.hiddenAbove} more above
+					{(moreAboveLabel || '↑ {count} more above').replace(
+						'{count}',
+						String(displayWindow.hiddenAbove),
+					)}
 				</Text>
 			)}
 			{displayWindow.tools.map((tool, displayIdx) => {
@@ -140,7 +147,10 @@ function ToolsList({
 			})}
 			{displayWindow.hiddenBelow > 0 && (
 				<Text color={theme.colors.menuSecondary} dimColor>
-					↓ {displayWindow.hiddenBelow} more below
+					{(moreBelowLabel || '↓ {count} more below').replace(
+						'{count}',
+						String(displayWindow.hiddenBelow),
+					)}
 				</Text>
 			)}
 		</Box>
@@ -555,6 +565,8 @@ export default function MCPInfoPanel({onClose}: Props) {
 									project: t.mcpInfoPanel.toolScopeProject,
 								}}
 								toolScopeMap={toolScopeMap}
+								moreAboveLabel={t.mcpInfoPanel.moreAbove}
+								moreBelowLabel={t.mcpInfoPanel.moreBelow}
 							/>
 						)}
 						{togglingTool && (
@@ -584,7 +596,7 @@ export default function MCPInfoPanel({onClose}: Props) {
 								: t.mcpInfoPanel.title}
 							{!isReconnecting &&
 								!togglingService &&
-								selectItems.length > MAX_DISPLAY_ITEMS &&
+								selectItems.length > 1 &&
 								` (${selectedIndex + 1}/${selectItems.length})`}
 						</Text>
 						{!isReconnecting &&
@@ -621,12 +633,16 @@ export default function MCPInfoPanel({onClose}: Props) {
 										: !item.isBuiltIn && item.source === 'global'
 										? t.mcpInfoPanel.mcpSourceGlobal
 										: '';
+								const service = mcpStatus.find(s => s.name === item.value);
+								const toolCount = service?.tools?.length ?? 0;
+								const toolBadge =
+									isEnabled && toolCount > 0 ? ` · ${toolCount} tools` : '';
 								const suffix = !isEnabled
 									? t.mcpInfoPanel.statusDisabled
 									: item.isBuiltIn
-									? t.mcpInfoPanel.statusSystem
+									? `${t.mcpInfoPanel.statusSystem}${toolBadge}`
 									: item.connected
-									? `${t.mcpInfoPanel.statusExternal}${sourceSuffix}`
+									? `${t.mcpInfoPanel.statusExternal}${sourceSuffix}${toolBadge}`
 									: ` - ${item.error || t.mcpInfoPanel.statusFailed}`;
 
 								return (

--- a/source/ui/components/panels/PanelsManager.tsx
+++ b/source/ui/components/panels/PanelsManager.tsx
@@ -163,8 +163,11 @@ export default function PanelsManager({
 
 	const loadingFallback = (
 		<Box>
-			<Text>
-				<Spinner type="dots" /> Loading...
+			<Text color={theme.colors.menuSecondary}>
+				<Spinner type="dots" />{' '}
+				{(t as any).panelChrome?.loading ||
+					t.workingDirectoryPanel.loading ||
+					'Loading…'}
 			</Text>
 		</Box>
 	);

--- a/source/ui/components/panels/SessionListPanel.tsx
+++ b/source/ui/components/panels/SessionListPanel.tsx
@@ -400,9 +400,10 @@ export default function SessionListPanel({
 					{selectedIndex + 1}/{sessions.length}
 					{totalCount > sessions.length && ` of ${totalCount}`})
 					{currentSession &&
-						` • ${
-							currentSession.messageCount
-						} ${t.sessionListPanel.messages.replace('{count}', '')}`}
+						` • ${t.sessionListPanel.messages.replace(
+							'{count}',
+							String(currentSession.messageCount),
+						)}`}
 					{markedSessions.size > 0 && (
 						<Text color={theme.colors.warning}>
 							{' '}
@@ -515,18 +516,19 @@ export default function SessionListPanel({
 
 						// goalOnly 模式：额外渲染 goalStatus + objective 摘要，
 						// 用 dimColor 视觉上和会话标题区分开。
-						const goalSuffix =
-							goalOnly && session.goalStatus
-								? ` [${session.goalStatus}${
-										session.goalObjective
-											? ` • ${
-													session.goalObjective.length > 40
-														? session.goalObjective.slice(0, 37) + '...'
-														: session.goalObjective
-											  }`
-											: ''
-								  }]`
-								: '';
+						const goalStatusColor =
+							session.goalStatus === 'pursuing'
+								? theme.colors.warning
+								: session.goalStatus === 'achieved'
+								? theme.colors.success
+								: session.goalStatus === 'unmet' ||
+								  session.goalStatus === 'budget-limited'
+								? theme.colors.error
+								: theme.colors.menuSecondary;
+						const goalObj =
+							session.goalObjective && session.goalObjective.length > 40
+								? session.goalObjective.slice(0, 37) + '...'
+								: session.goalObjective;
 
 						return (
 							<Box key={session.id}>
@@ -560,8 +562,20 @@ export default function SessionListPanel({
 								<Text color={theme.colors.menuSecondary} dimColor>
 									{' '}
 									• {timeStr}
-									{goalSuffix}
+									{session.messageCount > 0
+										? ` · ${t.sessionListPanel.messages.replace(
+												'{count}',
+												String(session.messageCount),
+										  )}`
+										: ''}
 								</Text>
+								{goalOnly && session.goalStatus ? (
+									<Text color={goalStatusColor} dimColor>
+										{' '}
+										[{session.goalStatus}
+										{goalObj ? ` • ${goalObj}` : ''}]
+									</Text>
+								) : null}
 							</Box>
 						);
 					})}

--- a/source/ui/components/panels/SkillsListPanel.tsx
+++ b/source/ui/components/panels/SkillsListPanel.tsx
@@ -366,7 +366,7 @@ export default function SkillsListPanel({onClose}: Props) {
 	if (isLoading) {
 		return (
 			<Text color={theme.colors.menuSecondary}>
-				{t.skillsListPanel?.loading || 'Loading skills...'}
+				{t.skillsListPanel.loading}
 			</Text>
 		);
 	}
@@ -380,10 +380,7 @@ export default function SkillsListPanel({onClose}: Props) {
 				paddingY={0}
 			>
 				<Text color={theme.colors.error} dimColor>
-					{(t.skillsListPanel?.error || 'Error: {message}').replace(
-						'{message}',
-						errorMessage,
-					)}
+					{t.skillsListPanel.error.replace('{message}', errorMessage)}
 				</Text>
 			</Box>
 		);
@@ -399,7 +396,7 @@ export default function SkillsListPanel({onClose}: Props) {
 			>
 				<Box flexDirection="column">
 					<Text color={theme.colors.menuSecondary} dimColor>
-						{t.skillsListPanel?.noSkills || 'No skills available'}
+						{t.skillsListPanel.noSkills}
 					</Text>
 					{updateStatus !== 'idle' && updateMessage && (
 						<Box marginTop={1} flexDirection="column">
@@ -421,8 +418,7 @@ export default function SkillsListPanel({onClose}: Props) {
 					)}
 					<Box marginTop={1}>
 						<Text color={theme.colors.menuSecondary} dimColor>
-							{t.skillsListPanel?.navigationHint ||
-								'↑↓ Navigate • Tab/Space/Enter Toggle • U Update Selected • A Update All • ESC Close'}
+							{t.skillsListPanel.navigationHint}
 						</Text>
 					</Box>
 				</Box>
@@ -439,14 +435,14 @@ export default function SkillsListPanel({onClose}: Props) {
 		>
 			<Box flexDirection="column">
 				<Text color={theme.colors.menuInfo} bold>
-					{t.skillsListPanel?.title || 'Skills'}
-					{skills.length > MAX_DISPLAY_ITEMS &&
+					{t.skillsListPanel.title}
+					{skills.length > 0 &&
 						` (${selectedIndex + 1}/${skills.length})`}
 				</Text>
 
 				{hiddenAboveCount > 0 && (
 					<Text color={theme.colors.menuSecondary} dimColor>
-						{(t.skillsListPanel?.moreAbove || '↑ {count} more above').replace(
+						{t.skillsListPanel.moreAbove.replace(
 							'{count}',
 							String(hiddenAboveCount),
 						)}
@@ -459,8 +455,8 @@ export default function SkillsListPanel({onClose}: Props) {
 					const isEnabled = skillEnabledMap[skill.id] !== false;
 					const locationSuffix =
 						skill.location === 'project'
-							? t.skillsListPanel?.locationProject || '(Project)'
-							: t.skillsListPanel?.locationGlobal || '(Global)';
+							? t.skillsListPanel.locationProject
+							: t.skillsListPanel.locationGlobal;
 					const skillDescription = (skill.description || '').trim();
 					const hasDescription = Boolean(skillDescription);
 					const renderedDescription = hasDescription
@@ -478,7 +474,7 @@ export default function SkillsListPanel({onClose}: Props) {
 											: theme.colors.menuSecondary
 									}
 								>
-									◆{' '}
+									●{' '}
 								</Text>
 								<Text
 									color={
@@ -495,7 +491,7 @@ export default function SkillsListPanel({onClose}: Props) {
 									{' '}
 									{isEnabled
 										? locationSuffix
-										: t.skillsListPanel?.statusDisabled || '(Disabled)'}
+										: t.skillsListPanel.statusDisabled}
 								</Text>
 							</Text>
 							{isEnabled && hasDescription ? (
@@ -511,7 +507,7 @@ export default function SkillsListPanel({onClose}: Props) {
 
 				{hiddenBelowCount > 0 && (
 					<Text color={theme.colors.menuSecondary} dimColor>
-						{(t.skillsListPanel?.moreBelow || '↓ {count} more below').replace(
+						{t.skillsListPanel.moreBelow.replace(
 							'{count}',
 							String(hiddenBelowCount),
 						)}
@@ -550,8 +546,7 @@ export default function SkillsListPanel({onClose}: Props) {
 
 				<Box marginTop={1}>
 					<Text color={theme.colors.menuSecondary} dimColor>
-						{t.skillsListPanel?.navigationHint ||
-							'↑↓ Navigate • Tab/Space/Enter Toggle • U Update Selected • A Update All • ESC Close'}
+						{t.skillsListPanel.navigationHint}
 					</Text>
 				</Box>
 			</Box>

--- a/source/ui/components/panels/SkillsPickerPanel.tsx
+++ b/source/ui/components/panels/SkillsPickerPanel.tsx
@@ -47,7 +47,7 @@ const SkillsPickerPanel = memo(
 				<Box flexDirection="column">
 					<Box width="100%" flexDirection="column">
 						<Box>
-							<Text color={theme.colors.warning} bold>
+							<Text color={theme.colors.menuInfo} bold>
 								{t.skillsPickerPanel.title}
 							</Text>
 						</Box>
@@ -70,7 +70,7 @@ const SkillsPickerPanel = memo(
 				getItemKey={(skill: SkillsPickerItem) => skill.id}
 				title={
 					<>
-						<Text color={theme.colors.warning} bold>
+						<Text color={theme.colors.menuInfo} bold>
 							{t.skillsPickerPanel.title}{' '}
 							{skills.length > 5 && `(${selectedIndex + 1}/${skills.length})`}
 						</Text>
@@ -100,7 +100,7 @@ const SkillsPickerPanel = memo(
 				emptyContent={
 					<Box width="100%" flexDirection="column">
 						<Box>
-							<Text color={theme.colors.warning} bold>
+							<Text color={theme.colors.menuInfo} bold>
 								{t.skillsPickerPanel.title}
 							</Text>
 							<Text color={theme.colors.menuSecondary} dimColor>
@@ -162,7 +162,9 @@ const SkillsPickerPanel = memo(
 							bold
 						>
 							{isSelected ? '❯ ' : '  '}#{skill.id}{' '}
-							<Text dimColor>({skill.location})</Text>
+							<Text color={theme.colors.menuSecondary} dimColor>
+								[{skill.location}]
+							</Text>
 						</Text>
 						<Box marginLeft={3} overflow="hidden">
 							<Text

--- a/source/ui/components/panels/UsagePanel.tsx
+++ b/source/ui/components/panels/UsagePanel.tsx
@@ -4,6 +4,7 @@ import {useTerminalSize} from '../../../hooks/ui/useTerminalSize.js';
 import {useI18n} from '../../../i18n/index.js';
 import {useTheme} from '../../contexts/ThemeContext.js';
 import type {Theme} from '../../themes/index.js';
+import {formatTokens as sharedFormatTokens} from '../../utils/formatTokens.js';
 import {
 	loadUsageData,
 	filterByPeriod,
@@ -133,17 +134,7 @@ function getModelShortName(modelName: string, maxLength = 20): string {
 }
 
 function formatTokens(tokens: number, compact = false): string {
-	if (tokens >= 1000000) {
-		return compact
-			? `${(tokens / 1000000).toFixed(1)}M`
-			: `${(tokens / 1000000).toFixed(2)}M`;
-	}
-	if (tokens >= 1000) {
-		return compact
-			? `${Math.round(tokens / 1000)}K`
-			: `${(tokens / 1000).toFixed(1)}K`;
-	}
-	return String(tokens);
+	return sharedFormatTokens(tokens, compact);
 }
 
 function renderStackedBarChart(
@@ -490,6 +481,24 @@ export default function UsagePanel() {
 		);
 	}
 
+	const modelCount = stats.models.size;
+	const totalCacheRead = Array.from(stats.models.values()).reduce(
+		(sum, s) => sum + s.cacheRead,
+		0,
+	);
+	const totalCacheCreate = Array.from(stats.models.values()).reduce(
+		(sum, s) => sum + s.cacheCreation,
+		0,
+	);
+	const totalIO = Array.from(stats.models.values()).reduce(
+		(sum, s) => sum + s.input + s.output,
+		0,
+	);
+	const cacheHitPct =
+		totalIO + totalCacheRead > 0
+			? (totalCacheRead / (totalIO + totalCacheRead)) * 100
+			: 0;
+
 	return (
 		<Box
 			borderColor={theme.colors.menuInfo}
@@ -512,6 +521,46 @@ export default function UsagePanel() {
 					{t.usagePanel.tabToSwitch}
 				</Text>
 			</Box>
+
+			{/* Overview summary card */}
+			{modelCount > 0 && (
+				<Box marginBottom={1} flexDirection="column">
+					<Box>
+						<Text color={theme.colors.menuInfo} bold>
+							{formatTokens(stats.grandTotal)}
+						</Text>
+						<Text color={theme.colors.menuSecondary} dimColor>
+							{' '}
+							{t.usagePanel.overview.total}
+						</Text>
+						<Text color={theme.colors.menuSecondary}> · </Text>
+						<Text color={theme.colors.success}>{cacheHitPct.toFixed(0)}%</Text>
+						<Text color={theme.colors.menuSecondary} dimColor>
+							{' '}
+							{t.usagePanel.overview.cacheHit}
+						</Text>
+						{totalCacheCreate > 0 && (
+							<>
+								<Text color={theme.colors.menuSecondary}> · </Text>
+								<Text color={theme.colors.warning}>
+									{formatTokens(totalCacheCreate, true)}
+								</Text>
+								<Text color={theme.colors.menuSecondary} dimColor>
+									{' '}
+									{t.usagePanel.overview.create}
+								</Text>
+							</>
+						)}
+						<Text color={theme.colors.menuSecondary}> · </Text>
+						<Text color={theme.colors.menuSecondary} dimColor>
+							{(modelCount === 1
+								? t.usagePanel.overview.models
+								: t.usagePanel.overview.modelsPlural
+							).replace('{count}', String(modelCount))}
+						</Text>
+					</Box>
+				</Box>
+			)}
 
 			{stats.models.size === 0 ? (
 				<Text color={theme.colors.menuSecondary} dimColor>

--- a/source/ui/components/special/TodoTree.tsx
+++ b/source/ui/components/special/TodoTree.tsx
@@ -106,7 +106,12 @@ export default function TodoTree({todos}: TodoTreeProps) {
 					{' '}
 					[{pageIndex + 1}/{pageCount}] {t.toolConfirmation.commandPagerHint}
 				</Text>
-				{hiddenCount > 0 && <Text dimColor> +{hiddenCount} more</Text>}
+				{hiddenCount > 0 && (
+					<Text dimColor>
+						{' '}
+						+{hiddenCount} {(t as any).todoTree?.more || 'more'}
+					</Text>
+				)}
 			</Text>
 			{visibleTodos.map((todo, index) => renderTodoLine(todo, index))}
 		</Box>

--- a/source/ui/pages/chatScreen/ChatScreenPanels.tsx
+++ b/source/ui/pages/chatScreen/ChatScreenPanels.tsx
@@ -423,7 +423,7 @@ export default function ChatScreenPanels({
 						fallback={
 							<Box>
 								<Text>
-									<Spinner type="dots" /> Loading...
+									<Spinner type="dots" /> {(t as any).panelChrome?.loading || 'Loading…'}
 								</Text>
 							</Box>
 						}
@@ -447,7 +447,7 @@ export default function ChatScreenPanels({
 						fallback={
 							<Box>
 								<Text>
-									<Spinner type="dots" /> Loading...
+									<Spinner type="dots" /> {(t as any).panelChrome?.loading || 'Loading…'}
 								</Text>
 							</Box>
 						}
@@ -466,7 +466,7 @@ export default function ChatScreenPanels({
 						fallback={
 							<Box>
 								<Text>
-									<Spinner type="dots" /> Loading...
+									<Spinner type="dots" /> {(t as any).panelChrome?.loading || 'Loading…'}
 								</Text>
 							</Box>
 						}
@@ -539,7 +539,7 @@ export default function ChatScreenPanels({
 						fallback={
 							<Box>
 								<Text>
-									<Spinner type="dots" /> Loading...
+									<Spinner type="dots" /> {(t as any).panelChrome?.loading || 'Loading…'}
 								</Text>
 							</Box>
 						}
@@ -561,7 +561,7 @@ export default function ChatScreenPanels({
 						fallback={
 							<Box>
 								<Text>
-									<Spinner type="dots" /> Loading...
+									<Spinner type="dots" /> {(t as any).panelChrome?.loading || 'Loading…'}
 								</Text>
 							</Box>
 						}
@@ -586,7 +586,7 @@ export default function ChatScreenPanels({
 						fallback={
 							<Box>
 								<Text>
-									<Spinner type="dots" /> Loading...
+									<Spinner type="dots" /> {(t as any).panelChrome?.loading || 'Loading…'}
 								</Text>
 							</Box>
 						}

--- a/source/ui/utils/formatTokens.ts
+++ b/source/ui/utils/formatTokens.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared token/number formatters for TUI panels and status line.
+ */
+
+export function formatTokens(n: number, compact = false): string {
+	if (!Number.isFinite(n) || n < 0) return '0';
+	if (n >= 1_000_000) {
+		return compact
+			? `${(n / 1_000_000).toFixed(1)}M`
+			: `${(n / 1_000_000).toFixed(2)}M`;
+	}
+	if (n >= 1000) {
+		return compact ? `${Math.round(n / 1000)}k` : `${(n / 1000).toFixed(1)}k`;
+	}
+	return String(Math.round(n));
+}
+
+export function formatTokenBar(
+	pct: number,
+	width: number,
+	fillChar = '█',
+	emptyChar = '░',
+): string {
+	const clamped = Math.max(0, Math.min(100, pct));
+	const filled = Math.round((clamped / 100) * width);
+	return (
+		fillChar.repeat(filled) + emptyChar.repeat(Math.max(0, width - filled))
+	);
+}
+
+export function pctColorName(
+	pct: number,
+): 'success' | 'warning' | 'error' {
+	if (pct < 50) return 'success';
+	if (pct < 90) return 'warning';
+	return 'error';
+}

--- a/source/utils/core/contextBreakdown.ts
+++ b/source/utils/core/contextBreakdown.ts
@@ -8,7 +8,10 @@
  * so totals are not double-counted.
  */
 
-import {getSnowConfig} from '../config/apiConfig.js';
+import {
+	DEFAULT_AUTO_COMPRESS_THRESHOLD,
+	getSnowConfig,
+} from '../config/apiConfig.js';
 import {
 	getPlanMode,
 	getTeamMode,
@@ -24,13 +27,28 @@ import {
 	type RoleSource,
 } from '../../prompt/shared/promptHelpers.js';
 
+/** Expandable detail buckets (ROLE is display-only; already inside system). */
 export type ContextBucketId =
 	| 'system'
 	| 'role'
 	| 'agents'
 	| 'hooks'
 	| 'tools'
+	| 'skills'
 	| 'messages';
+
+/**
+ * Summary categories shown in the /context overview (screenshot-style).
+ * free / autocompact are synthetic residual buckets (not double-counted in used).
+ */
+export type ContextCategoryId =
+	| 'system'
+	| 'tools'
+	| 'memory'
+	| 'skills'
+	| 'messages'
+	| 'free'
+	| 'autocompact';
 
 export interface ContextFileItem {
 	label: string;
@@ -57,12 +75,33 @@ export interface ContextBucket {
 	detail?: string;
 }
 
+export interface ContextCategory {
+	id: ContextCategoryId;
+	label: string;
+	tokens: number;
+	/** Share of the full context window (0-100). */
+	percentage: number;
+	/** Synthetic residual row (free space / autocompact buffer). */
+	synthetic?: boolean;
+	/** Maps to expandable detail bucket(s). */
+	sourceBucketIds?: ContextBucketId[];
+}
+
 export interface ContextBreakdown {
+	modelName: string;
 	maxContextTokens: number;
 	totalEstimatedTokens: number;
 	percentage: number;
+	freeTokens: number;
+	freePercentage: number;
+	autocompactBufferTokens: number;
+	autocompactBufferPercentage: number;
+	autoCompressThreshold: number;
+	enableAutoCompress: boolean;
 	apiPromptTokens?: number;
 	apiPercentage?: number;
+	/** Screenshot-style category summary (includes free + autocompact). */
+	categories: ContextCategory[];
 	buckets: ContextBucket[];
 	mode: {
 		planMode: boolean;
@@ -73,6 +112,14 @@ export interface ContextBreakdown {
 	/** 'fast' = chars/4; 'precise' = tiktoken when available. */
 	estimateMode: 'fast' | 'precise';
 	generatedAt: number;
+}
+
+function isSkillToolName(name: string): boolean {
+	return name === 'skill-execute' || name.startsWith('skill-');
+}
+
+function toolNameOf(tool: {name?: string; function?: {name?: string}}): string {
+	return tool?.function?.name || tool?.name || '';
 }
 
 type TokenCounter = (text: string) => number;
@@ -277,63 +324,93 @@ export async function buildContextBreakdown(options?: {
 		const hooksText = pendingHooks?.trim() ?? '';
 		const hooksTokens = count(hooksText);
 
-		// --- Tool definitions ---
-		// Start tools fetch early so it overlaps with other work above.
+		// --- Tool definitions (split skills out so they are not double-counted) ---
 		// Never zero tools just because the first open is slow — wait for real cache.
 		let toolsJson = '[]';
+		let skillsJson = '[]';
 		let toolCount = 0;
+		let skillCount = 0;
 		let toolsTokens = 0;
+		let skillsTokens = 0;
 		const toolItems: ContextFileItem[] = [];
+		const skillItems: ContextFileItem[] = [];
 		try {
 			const tools = await toolsPromise;
-			toolCount = tools.length;
+			const regularTools: any[] = [];
+			const skillTools: any[] = [];
+			for (const tool of tools) {
+				const name = toolNameOf(tool as any);
+				if (isSkillToolName(name)) skillTools.push(tool);
+				else regularTools.push(tool);
+			}
+			toolCount = regularTools.length;
+			skillCount = skillTools.length;
+
 			// Cap stringify work for very large tool lists
 			const MAX_TOOLS_FOR_JSON = 120;
 			const toolsForJson =
-				tools.length > MAX_TOOLS_FOR_JSON
-					? tools.slice(0, MAX_TOOLS_FOR_JSON)
-					: tools;
+				regularTools.length > MAX_TOOLS_FOR_JSON
+					? regularTools.slice(0, MAX_TOOLS_FOR_JSON)
+					: regularTools;
 			toolsJson = JSON.stringify(toolsForJson);
 			const sampleTokens = count(toolsJson);
 			toolsTokens =
-				tools.length > MAX_TOOLS_FOR_JSON && toolsForJson.length > 0
-					? Math.round((sampleTokens / toolsForJson.length) * tools.length)
+				regularTools.length > MAX_TOOLS_FOR_JSON && toolsForJson.length > 0
+					? Math.round(
+							(sampleTokens / toolsForJson.length) * regularTools.length,
+					  )
 					: sampleTokens;
 
+			// Skills schema is usually a single skill-execute tool with a large description.
+			skillsJson = skillTools.length > 0 ? JSON.stringify(skillTools) : '[]';
+			skillsTokens = skillTools.length > 0 ? count(skillsJson) : 0;
+
+			const pushToolRows = (
+				list: any[],
+				out: ContextFileItem[],
+				maxRows: number,
+				moreLabel: string,
+			) => {
+				for (let i = 0; i < Math.min(list.length, maxRows); i++) {
+					// MCPTool is OpenAI-style: {type:'function', function:{name,description,parameters}}
+					const tool = list[i] as {
+						name?: string;
+						description?: string;
+						function?: {name?: string; description?: string};
+					};
+					const name = tool?.function?.name || tool?.name || `tool-${i + 1}`;
+					const description =
+						tool?.function?.description || tool?.description || '';
+					const desc =
+						typeof description === 'string' ? description.slice(0, 48) : '';
+					const raw = JSON.stringify(tool ?? {});
+					out.push({
+						label: name,
+						chars: raw.length,
+						tokens: estimateTokensFast(raw),
+						included: true,
+						note: desc || undefined,
+					});
+				}
+				if (list.length > maxRows) {
+					out.push({
+						label: `… +${list.length - maxRows} ${moreLabel}`,
+						chars: 0,
+						tokens: 0,
+						included: true,
+						note: 'truncated list',
+					});
+				}
+			};
+
 			const MAX_TOOL_ROWS = 40;
-			for (let i = 0; i < Math.min(tools.length, MAX_TOOL_ROWS); i++) {
-				// MCPTool is OpenAI-style: {type:'function', function:{name,description,parameters}}
-				const tool = tools[i] as {
-					name?: string;
-					description?: string;
-					function?: {name?: string; description?: string};
-				};
-				const name = tool?.function?.name || tool?.name || `tool-${i + 1}`;
-				const description =
-					tool?.function?.description || tool?.description || '';
-				const desc =
-					typeof description === 'string' ? description.slice(0, 48) : '';
-				const raw = JSON.stringify(tool ?? {});
-				toolItems.push({
-					label: name,
-					chars: raw.length,
-					tokens: estimateTokensFast(raw),
-					included: true,
-					note: desc || undefined,
-				});
-			}
-			if (tools.length > MAX_TOOL_ROWS) {
-				toolItems.push({
-					label: `… +${tools.length - MAX_TOOL_ROWS} more tools`,
-					chars: 0,
-					tokens: 0,
-					included: true,
-					note: 'truncated list',
-				});
-			}
+			pushToolRows(regularTools, toolItems, MAX_TOOL_ROWS, 'more tools');
+			pushToolRows(skillTools, skillItems, MAX_TOOL_ROWS, 'more skills');
 		} catch {
 			toolsJson = '[]';
+			skillsJson = '[]';
 			toolsTokens = 0;
+			skillsTokens = 0;
 		}
 
 		// --- Conversation messages ---
@@ -463,7 +540,7 @@ export async function buildContextBreakdown(options?: {
 			},
 			{
 				id: 'tools',
-				label: 'Tool definitions',
+				label: 'System tools',
 				chars: toolsJson.length,
 				tokens: toolsTokens,
 				files: toolItems,
@@ -473,8 +550,20 @@ export async function buildContextBreakdown(options?: {
 				detail: toolItems.length ? 'expand for names' : undefined,
 			},
 			{
+				id: 'skills',
+				label: 'Skills',
+				chars: skillsJson.length,
+				tokens: skillsTokens,
+				files: skillItems,
+				meta:
+					skillCount > 0
+						? `${skillCount} skill tool(s) · schema only`
+						: 'no skill tools loaded',
+				detail: skillItems.length ? 'SKILL.md body loads on invoke' : undefined,
+			},
+			{
 				id: 'messages',
-				label: 'Conversation',
+				label: 'Messages',
 				chars: messagesText.length,
 				tokens: messagesTokens,
 				files: messageItems,
@@ -494,6 +583,83 @@ export async function buildContextBreakdown(options?: {
 				: 0,
 		);
 
+		const autoCompressThreshold =
+			config.autoCompressThreshold ?? DEFAULT_AUTO_COMPRESS_THRESHOLD;
+		const enableAutoCompress = config.enableAutoCompress !== false;
+		// Reserved headroom: from threshold% to 100% of the window.
+		// e.g. threshold 80% on 200k → 40k buffer kept for safe auto-compact.
+		const autocompactBufferTokens = enableAutoCompress
+			? Math.max(
+					0,
+					Math.floor((maxContextTokens * (100 - autoCompressThreshold)) / 100),
+			  )
+			: 0;
+		const freeTokens = Math.max(0, maxContextTokens - totalEstimatedTokens);
+		// Free space excludes the reserved autocompact buffer when buffer fits.
+		const freeUsableTokens = Math.max(0, freeTokens - autocompactBufferTokens);
+		const freePercentage =
+			maxContextTokens > 0 ? (freeUsableTokens / maxContextTokens) * 100 : 0;
+		const autocompactBufferPercentage =
+			maxContextTokens > 0
+				? (autocompactBufferTokens / maxContextTokens) * 100
+				: 0;
+
+		const windowPct = (tokens: number) =>
+			maxContextTokens > 0 ? (tokens / maxContextTokens) * 100 : 0;
+
+		const memoryTokens = agentsTokens + hooksTokens;
+		const categories: ContextCategory[] = [
+			{
+				id: 'system',
+				label: 'System prompt',
+				tokens: systemTokens,
+				percentage: windowPct(systemTokens),
+				sourceBucketIds: ['system', 'role'],
+			},
+			{
+				id: 'tools',
+				label: 'System tools',
+				tokens: toolsTokens,
+				percentage: windowPct(toolsTokens),
+				sourceBucketIds: ['tools'],
+			},
+			{
+				id: 'memory',
+				label: 'Memory files',
+				tokens: memoryTokens,
+				percentage: windowPct(memoryTokens),
+				sourceBucketIds: ['agents', 'hooks'],
+			},
+			{
+				id: 'skills',
+				label: 'Skills',
+				tokens: skillsTokens,
+				percentage: windowPct(skillsTokens),
+				sourceBucketIds: ['skills'],
+			},
+			{
+				id: 'messages',
+				label: 'Messages',
+				tokens: messagesTokens,
+				percentage: windowPct(messagesTokens),
+				sourceBucketIds: ['messages'],
+			},
+			{
+				id: 'free',
+				label: 'Free space',
+				tokens: freeUsableTokens,
+				percentage: freePercentage,
+				synthetic: true,
+			},
+			{
+				id: 'autocompact',
+				label: 'Autocompact buffer',
+				tokens: autocompactBufferTokens,
+				percentage: autocompactBufferPercentage,
+				synthetic: true,
+			},
+		];
+
 		// Optional: last API-reported usage for comparison
 		let apiPromptTokens: number | undefined;
 		let apiPercentage: number | undefined;
@@ -510,12 +676,25 @@ export async function buildContextBreakdown(options?: {
 			apiPercentage = Math.min(100, (apiPromptTokens / maxContextTokens) * 100);
 		}
 
+		const modelName =
+			(config.advancedModel && config.advancedModel.trim()) ||
+			(config.basicModel && config.basicModel.trim()) ||
+			'unknown model';
+
 		return {
+			modelName,
 			maxContextTokens,
 			totalEstimatedTokens,
 			percentage,
+			freeTokens: freeUsableTokens,
+			freePercentage,
+			autocompactBufferTokens,
+			autocompactBufferPercentage,
+			autoCompressThreshold,
+			enableAutoCompress,
 			apiPromptTokens,
 			apiPercentage,
+			categories,
 			buckets,
 			mode,
 			estimateMode: counter.mode,


### PR DESCRIPTION
## Summary

This PR brings three focused UI improvements into official `Alpha`:

1. **Fix file-edit DiffViewer success path + `/tool-display` semantics**
2. **Shared panel chrome / surface polish across chat panels**
3. **Richer `/context` breakdown + panel i18n**

Base: `upstream/Alpha` (`5e276a04`)  
Head: `BaSui01:Alpha` (`6ab38e7b`, merge commit with graph)

### Commits

| Commit | Title |
|--------|--------|
| `882a9947` | `fix(ui): show file edit DiffViewer on success in full tool-display` |
| `89985349` | `feat(ui): polish shared panel chrome and themed panel surfaces` |
| `0b397b12` | `feat(context): enrich context breakdown and panel i18n strings` |
| `6ab38e7b` | `merge: bring tool-display DiffViewer and panel polish into Alpha` |

---

## 1) DiffViewer + `/tool-display` (bugfix)

### Problem
For `filesystem-create` / `filesystem-edit` / `filesystem-replaceedit`:

- DiffViewer was only rendered when `messageStatus === 'pending'`
- Success path already attaches `editDiffData` onto `toolCall.arguments`
- Full mode then **suppressed** `ToolResultPreview` because “has diff data”
- Result: even with `/tool-display full`, users only saw the tool title line after edit completed — **no DiffViewer**

### Fix
In `MessageRenderer.tsx`:

- Render DiffViewer on **`pending | success`**
- Gate DiffViewer with **`toolDisplayMode === 'full'` only**
- Keep exactly three modes (do **not** invent a 4th “compact-with-diff” tier):
  - `full`: tool name + args + full result + DiffViewer (pending & success)
  - `compact`: title + brief summary only (no Diff / args tree / full preview)
  - `hidden`: hide all tool activity

### Docs synced
- `docs/usage/zh/09.2.模式切换指令.md`
- `docs/usage/en/09.2.Mode Switching Commands.md`
- `docs/usage/zh/08.主题设置.md`
- `docs/usage/en/08.Theme Settings.md`

Clarify:
- only three modes
- DiffViewer is full-only
- Diff shows on both pending and success via result-side `editDiffData`

---

## 2) Panel chrome polish

### What changed
- New shared `PanelChrome.tsx` for consistent panel chrome
- New `formatTokens.ts` helper
- Align surfaces to theme tokens / denser layout:
  - `StatusLine`
  - `ChatFooter`
  - `ContextPanel` / `HelpPanel` / `MCPInfoPanel`
  - `SessionListPanel` / `SkillsListPanel` / `SkillsPickerPanel`
  - `UsagePanel` / `TodoTree` / `ChatScreenPanels` / `PanelsManager`

### Intent
Visual consistency and readability improvements **without changing panel behavior contracts**.

---

## 3) Context breakdown + i18n

### What changed
- Expand `contextBreakdown.ts` with clearer composition categories/coverage
- Add unit tests: `source/test/context-breakdown.test.ts`
- Wire matching panel strings for `en` / `zh` / `zh-TW` (`types.ts` + lang files)

Supports the polished Context panel labels and richer prompt composition display.

---

## Stats

- **25 files** changed
- **+1110 / -300**
- New files:
  - `source/ui/components/common/PanelChrome.tsx`
  - `source/ui/utils/formatTokens.ts`
  - `source/test/context-breakdown.test.ts`

---

## Test plan

- [x] `npm run build` succeeds with DiffViewer success-path fix
- [x] `/tool-display full` + create/edit shows DiffViewer after success
- [x] `/tool-display compact` keeps title+summary only (no DiffViewer)
- [x] `/tool-display hidden` hides tool process
- [x] Docs describe full-only Diff + pending/success semantics
- [ ] Manual re-check on a fresh Snow session after pull:
  - open Context / Help / Usage / Session / Skills panels for chrome consistency
  - run `/context` and confirm breakdown labels/i18n
  - switch `full` ↔ `compact` ↔ `hidden` during file edits

---

## Notes

- Branch was rebased/created from latest `upstream/Alpha` then merged with `--no-ff` so history keeps a clear merge graph.
- No intentional API contract breaks for tools; this is UI rendering + docs + context breakdown presentation.