### PR TITLE
修复：加强工作树路径校验与 TODO 扫描

### DIFF
--- a/source/mcp/codebaseSearch.ts
+++ b/source/mcp/codebaseSearch.ts
@@ -483,7 +483,7 @@ export const mcpTools = [
 	{
 		name: 'codebase-search',
 		description:
-			'**Important:When you need to search for code, this is the highest priority tool. You need to use this Codebase tool first.*** Semantic search across the codebase using LLM embeddings. * Finds code snippets based on semantic meaning, supports both keywords and natural language queries. * Returns full code content with similarity scores and file locations. * NOTE: Only available when codebase indexing is enabled and the index has been built. * If the index is not available, the tool will return an error message with instructions.',
+			'**Important: When you need to search for code, this is the highest priority tool. You need to use this Codebase tool first.*** Semantic search across the codebase using LLM embeddings. * Finds code snippets based on semantic meaning, supports both keywords and natural language queries. * Returns full code content with similarity scores and file locations. * NOTE: Only available when codebase indexing is enabled and the index has been built. * If the index is not available, the tool will return an error message with instructions.',
 		inputSchema: {
 			type: 'object',
 			properties: {

--- a/source/test/team-worktree-path.test.ts
+++ b/source/test/team-worktree-path.test.ts
@@ -1,0 +1,40 @@
+import anyTest, {type TestFn} from 'ava';
+import os from 'node:os';
+import path from 'node:path';
+
+import {enforceWorktreePath} from '../utils/team/teamWorktree.js';
+
+const test = anyTest as unknown as TestFn;
+
+test('enforceWorktreePath keeps relative paths inside the worktree', t => {
+	const worktree = path.resolve('.snow', 'worktrees', 'team', 'member');
+
+	t.is(
+		enforceWorktreePath('source/app.tsx', worktree),
+		path.join(worktree, 'source', 'app.tsx'),
+	);
+	t.is(enforceWorktreePath('.', worktree), worktree);
+});
+
+test('enforceWorktreePath rejects relative traversal outside the worktree', t => {
+	const worktree = path.resolve('.snow', 'worktrees', 'team', 'member');
+
+	t.is(enforceWorktreePath('../../../../outside.txt', worktree), null);
+	t.is(enforceWorktreePath('../member-evil/file.txt', worktree), null);
+});
+
+test('enforceWorktreePath rejects sibling absolute paths with a shared prefix', t => {
+	const worktree = path.join(os.tmpdir(), 'snow-worktree');
+	const sibling = path.join(os.tmpdir(), 'snow-worktree-evil');
+
+	t.is(enforceWorktreePath(path.join(sibling, 'file.txt'), worktree), null);
+});
+
+test('enforceWorktreePath allows names beginning with two dots', t => {
+	const worktree = path.resolve('.snow', 'worktrees', 'team', 'member');
+
+	t.is(
+		enforceWorktreePath('..config/file.txt', worktree),
+		path.join(worktree, '..config', 'file.txt'),
+	);
+});

--- a/source/test/todo-scanner.test.ts
+++ b/source/test/todo-scanner.test.ts
@@ -1,0 +1,41 @@
+import anyTest, {type TestFn} from 'ava';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {scanProjectTodos} from '../utils/core/todoScanner.js';
+
+const test = anyTest as unknown as TestFn;
+
+test('scanProjectTodos ignores only complete excluded path segments', async t => {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), 'snow-todos-'));
+
+	try {
+		await Promise.all([
+			fs.mkdir(path.join(root, 'build'), {recursive: true}),
+			fs.mkdir(path.join(root, 'builder'), {recursive: true}),
+			fs.mkdir(path.join(root, '.github'), {recursive: true}),
+		]);
+		await Promise.all([
+			fs.writeFile(path.join(root, 'build', 'ignored.ts'), '// TODO ignored'),
+			fs.writeFile(
+				path.join(root, 'builder', 'kept.ts'),
+				'// TODO keep builder',
+			),
+			fs.writeFile(
+				path.join(root, '.github', 'kept.yml'),
+				'# TODO keep github',
+			),
+			fs.writeFile(path.join(root, 'debug.log'), '// TODO ignored log'),
+		]);
+
+		const todos = scanProjectTodos(root);
+		t.deepEqual(todos.map(todo => todo.content).sort(), [
+			'keep builder',
+			'keep github',
+		]);
+		t.true(todos.every(todo => todo.line === 1));
+	} finally {
+		await fs.rm(root, {recursive: true, force: true});
+	}
+});

--- a/source/utils/core/todoScanner.ts
+++ b/source/utils/core/todoScanner.ts
@@ -9,7 +9,7 @@ export interface TodoItem {
 	fullLine: string;
 }
 
-const IGNORE_PATTERNS = [
+const IGNORED_PATH_SEGMENTS = new Set([
 	'node_modules',
 	'.git',
 	'dist',
@@ -20,12 +20,12 @@ const IGNORE_PATTERNS = [
 	'.output',
 	'out',
 	'.DS_Store',
-	'*.log',
-	'*.lock',
 	'yarn.lock',
 	'package-lock.json',
 	'pnpm-lock.yaml',
-];
+]);
+
+const IGNORED_FILE_SUFFIXES = ['.log', '.lock'];
 
 // Common task markers - support various formats
 // Only include markers that clearly indicate actionable tasks
@@ -48,20 +48,17 @@ const TODO_PATTERNS = [
 	// TODO with brackets/parentheses (common format for task assignment)
 	/\/\/\s*TODO\s*[\(\[\{]\s*(.+?)\s*[\)\]\}]/i,
 	/#\s*TODO\s*[\(\[\{]\s*(.+?)\s*[\)\]\}]/i,
-
-	// Multi-line block comment TODO (catches TODO on its own line)
-	/\/\*[\s\S]*?\bTODO:?\s*(.+?)[\s\S]*?\*\//i,
 ];
 
 function shouldIgnore(filePath: string): boolean {
-	const relativePath = filePath;
-	return IGNORE_PATTERNS.some(pattern => {
-		if (pattern.includes('*')) {
-			const regex = new RegExp(pattern.replace(/\*/g, '.*'));
-			return regex.test(relativePath);
-		}
-		return relativePath.includes(pattern);
-	});
+	// Match complete path components so names such as `builder` and `.github`
+	// are not accidentally treated as the ignored `build` and `.git` folders.
+	const segments = filePath.split(path.sep);
+	const basename = segments.at(-1) ?? '';
+	return (
+		segments.some(segment => IGNORED_PATH_SEGMENTS.has(segment)) ||
+		IGNORED_FILE_SUFFIXES.some(suffix => basename.endsWith(suffix))
+	);
 }
 
 function scanFileForTodos(filePath: string, rootDir: string): TodoItem[] {

--- a/source/utils/team/teamWorktree.ts
+++ b/source/utils/team/teamWorktree.ts
@@ -1,6 +1,6 @@
 import {execSync} from 'child_process';
 import {existsSync} from 'fs';
-import {join, resolve, relative, isAbsolute} from 'path';
+import {join, resolve, relative, isAbsolute, sep} from 'path';
 import {mkdirSync, rmSync} from 'fs';
 
 const WORKTREE_BASE = join(process.cwd(), '.snow', 'worktrees');
@@ -474,18 +474,24 @@ export function enforceWorktreePath(
 
 	const mainRoot = resolve(process.cwd());
 	const resolvedWorktree = resolve(worktreePath);
+	const isWithin = (root: string, candidate: string): boolean => {
+		const relativePath = relative(root, candidate);
+		return (
+			relativePath === '' ||
+			(relativePath !== '..' &&
+				!relativePath.startsWith(`..${sep}`) &&
+				!isAbsolute(relativePath))
+		);
+	};
 
 	if (isAbsolute(filePath)) {
 		const resolved = resolve(filePath);
 
-		if (
-			resolved === resolvedWorktree ||
-			resolved.startsWith(resolvedWorktree + '/')
-		) {
+		if (isWithin(resolvedWorktree, resolved)) {
 			return resolved;
 		}
 
-		if (resolved === mainRoot || resolved.startsWith(mainRoot + '/')) {
+		if (isWithin(mainRoot, resolved)) {
 			const rel = relative(mainRoot, resolved);
 			return resolve(resolvedWorktree, rel);
 		}
@@ -493,7 +499,8 @@ export function enforceWorktreePath(
 		return null;
 	}
 
-	return resolve(resolvedWorktree, filePath);
+	const resolved = resolve(resolvedWorktree, filePath);
+	return isWithin(resolvedWorktree, resolved) ? resolved : null;
 }
 
 /**


### PR DESCRIPTION
## 问题

工作树路径校验可能把同前缀的相邻目录误判为工作树内部路径，并允许相对路径穿越。TODO 扫描器也可能把 `builder`、`.github` 等合法路径错误过滤。

## 修改

* 精确判断路径是否位于工作树内，阻止路径穿越
* TODO 扫描改为按完整路径段和文件后缀过滤
* 移除容易误匹配的跨行 TODO 正则
* 补充相关边界测试
* 修正 `codebase-search` 描述中的空格

## 验证

新增 AVA 测试 5 项，全部通过。
